### PR TITLE
refactor(web_fetch): 优化抓取链路并解耦抓取组件

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,81 @@
+{
+  "name": "wisepen-fetcher",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wisepen-fetcher",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "dependencies": {
+        "rebrowser-playwright": "^1.52.0",
+        "turndown": "^7.2.4"
+      }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "name": "rebrowser-playwright-core",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/rebrowser-playwright-core/-/rebrowser-playwright-core-1.52.0.tgz",
+      "integrity": "sha512-gjrvLNh0RX6B/tg6pWaPNGf+9+z1Jl2EyAh5MXD5xMa2lputGRZ9V2MJ/uofcC5Np3vSOJ3SdVSRqwteC0FjfQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/rebrowser-playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/rebrowser-playwright/-/rebrowser-playwright-1.52.0.tgz",
+      "integrity": "sha512-UjpqfwmF9+XtOuCCxGQ2ZlLeuSaSv//4Z6ZQgYPsJovz3d7nWodCd2hSRQigAswAUnsPmVwnQUpSn+TLKaKV+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "npm:rebrowser-playwright-core@~1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "wisepen-fetcher",
+  "version": "1.0.0",
+  "description": "Web page fetcher using rebrowser-playwright",
+  "dependencies": {
+    "rebrowser-playwright": "^1.52.0",
+    "turndown": "^7.2.4"
+  },
+  "scripts": {
+    "postinstall": "npx playwright-core install chromium"
+  }
+}

--- a/scripts/local_web_fetcher.js
+++ b/scripts/local_web_fetcher.js
@@ -1,0 +1,375 @@
+const { chromium } = require('rebrowser-playwright');
+const TurndownService = require('turndown');
+
+// ---------------------------------------------------------------------------
+// 配置常量
+// ---------------------------------------------------------------------------
+const NAVIGATION_TIMEOUT_MS = 60000;
+const NETWORK_IDLE_TIMEOUT_MS = 8000;
+
+const MAX_SCROLL_STEPS = 8;
+const SCROLL_DELAY_MS = 700;
+const POST_SCROLL_IDLE_MS = 1200;
+
+const MIN_CONTENT_TEXT_LENGTH = 200;
+
+const BLOCKED_RESOURCE_TYPES = new Set([
+  'image',
+  'media',
+  'font',
+  'stylesheet',
+]);
+
+const BROWSER_ARGS = [
+  '--proxy-server=direct://',
+  '--disable-blink-features=AutomationControlled',
+  '--no-sandbox',
+  '--disable-dev-shm-usage',
+  '--disable-infobars',
+  '--disable-background-networking',
+  '--disable-component-extensions-with-background-pages',
+  '--disable-default-apps',
+  '--disable-extensions-http-throttling',
+  '--disable-sync',
+  '--disable-translate',
+  '--metrics-recording-only',
+  '--mute-audio',
+  '--no-first-run',
+  '--safebrowsing-disable-auto-update',
+  '--lang=zh-CN',
+];
+
+// ---------------------------------------------------------------------------
+// Markdown 转换器
+// ---------------------------------------------------------------------------
+const turndownService = new TurndownService({
+  headingStyle: 'atx',
+  codeBlockStyle: 'fenced',
+  bulletListMarker: '-',
+});
+
+turndownService.addRule('ignore-base64-images', {
+  filter: node =>
+    node.nodeName === 'IMG' &&
+    node.getAttribute('src')?.startsWith('data:image/'),
+  replacement: () => '',
+});
+
+// ---------------------------------------------------------------------------
+// 工具函数
+// ---------------------------------------------------------------------------
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function normalizeMarkdown(markdown) {
+  return markdown
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function writeStdout(content) {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(content, error => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function autoScroll(page) {
+  let previousHeight = 0;
+  let stableCount = 0;
+
+  for (let step = 0; step < MAX_SCROLL_STEPS; step++) {
+    const state = await page.evaluate(() => {
+      const documentElement = document.documentElement;
+      const body = document.body;
+
+      const scrollHeight = Math.max(
+        documentElement?.scrollHeight || 0,
+        body?.scrollHeight || 0
+      );
+
+      const viewportHeight = window.innerHeight || 768;
+      const currentY = window.scrollY || window.pageYOffset || 0;
+
+      const nearBottom =
+        currentY + viewportHeight >= scrollHeight - 16;
+
+      if (!nearBottom) {
+        const delta = Math.floor(viewportHeight * (0.85 + Math.random() * 0.25));
+        window.scrollBy({
+          top: delta,
+          behavior: 'auto',
+        });
+      }
+
+      return {
+        scrollHeight,
+        currentY,
+        nearBottom,
+      };
+    });
+
+    if (state.scrollHeight === previousHeight) {
+      stableCount += 1;
+    } else {
+      stableCount = 0;
+      previousHeight = state.scrollHeight;
+    }
+
+    if (state.nearBottom && stableCount >= 1) {
+      break;
+    }
+
+    await sleep(SCROLL_DELAY_MS + Math.floor(Math.random() * 300));
+  }
+
+  await sleep(POST_SCROLL_IDLE_MS);
+}
+
+async function extractPageData(page) {
+  return page.evaluate((minTextLength) => {
+    const removeSelectors = [
+      'script',
+      'style',
+      'noscript',
+      'iframe',
+      'template',
+      'canvas',
+      'svg',
+      'ad',
+      '.ad',
+      '.ads',
+      '#ad',
+      '#ads',
+      '[class*="advert"]',
+      '[id*="advert"]',
+      '[class*="banner"]',
+      '[id*="banner"]',
+      'img[src^="data:image/"]',
+    ];
+
+    document
+      .querySelectorAll(removeSelectors.join(','))
+      .forEach(element => element.remove());
+
+    const contentSelectors = [
+      'article',
+      'main',
+      '[role="main"]',
+      '.article',
+      '.post',
+      '.entry-content',
+      '.post-content',
+      '.article-content',
+      '.content',
+      '#content',
+      '#main',
+    ];
+
+    let bestElement = null;
+    let bestTextLength = 0;
+
+    for (const selector of contentSelectors) {
+      const elements = Array.from(document.querySelectorAll(selector));
+
+      for (const element of elements) {
+        const textLength = element.innerText
+          ? element.innerText.trim().length
+          : 0;
+
+        if (textLength > bestTextLength) {
+          bestElement = element;
+          bestTextLength = textLength;
+        }
+      }
+    }
+
+    const body = document.body;
+    const selectedElement =
+      bestElement && bestTextLength >= minTextLength
+        ? bestElement
+        : body;
+
+    return {
+      title: document.title || '',
+      html: selectedElement ? selectedElement.innerHTML : '',
+      usedBodyFallback: selectedElement === body,
+      selectedTextLength: selectedElement?.innerText?.trim().length || 0,
+    };
+  }, MIN_CONTENT_TEXT_LENGTH);
+}
+
+// ---------------------------------------------------------------------------
+// 主抓取逻辑
+// ---------------------------------------------------------------------------
+async function fetchUrl(url) {
+  process.stderr.write(`Fetching: ${url}\n`);
+
+  let browser;
+  let context;
+
+  try {
+    browser = await chromium.launch({
+      headless: true,
+      args: BROWSER_ARGS,
+    });
+
+    context = await browser.newContext({
+      locale: 'zh-CN',
+      timezoneId: 'Asia/Shanghai',
+      viewport: {
+        width: 1366 + Math.floor(Math.random() * 100),
+        height: 768 + Math.floor(Math.random() * 100),
+      },
+    });
+
+    await context.route('**/*', route => {
+      const resourceType = route.request().resourceType();
+
+      if (BLOCKED_RESOURCE_TYPES.has(resourceType)) {
+        return route.abort();
+      }
+
+      return route.continue();
+    });
+
+    await context.addInitScript(() => {
+      try {
+        Object.defineProperty(navigator, 'webdriver', {
+          get: () => undefined,
+          configurable: true,
+        });
+      } catch (_) {
+        // best-effort
+      }
+
+      try {
+        const permissions = window.navigator.permissions;
+        const originalQuery = permissions?.query;
+
+        if (originalQuery) {
+          permissions.query = function query(parameters) {
+            return parameters?.name === 'notifications'
+              ? Promise.resolve({ state: Notification.permission })
+              : originalQuery.call(this, parameters);
+          };
+        }
+      } catch (_) {
+        // best-effort
+      }
+
+      try {
+        if (!window.chrome) {
+          window.chrome = {
+            runtime: {},
+            loadTimes() { },
+            csi() { },
+            app: {},
+          };
+        }
+      } catch (_) {
+        // best-effort
+      }
+
+      try {
+        delete window.__pwInitScripts;
+        delete window.__playwright__binding__;
+      } catch (_) {
+        // best-effort
+      }
+    });
+
+    const page = await context.newPage();
+
+    page.setDefaultTimeout(NAVIGATION_TIMEOUT_MS);
+    page.setDefaultNavigationTimeout(NAVIGATION_TIMEOUT_MS);
+
+    await page.goto(url, {
+      waitUntil: 'domcontentloaded',
+      timeout: NAVIGATION_TIMEOUT_MS,
+    });
+
+    await page
+      .waitForLoadState('networkidle', {
+        timeout: NETWORK_IDLE_TIMEOUT_MS,
+      })
+      .catch(() => {
+        // 现代页面常有长连接、埋点、轮询。
+        // networkidle 超时不代表失败。
+      });
+
+    await autoScroll(page);
+
+    const pageData = await extractPageData(page);
+
+    process.stderr.write(
+      `Extracted text length: ${pageData.selectedTextLength}, fallbackToBody: ${pageData.usedBodyFallback}\n`
+    );
+
+    const markdown = normalizeMarkdown(
+      turndownService.turndown(pageData.html)
+    );
+
+    if (!markdown) {
+      throw new Error('No readable content');
+    }
+
+    await writeStdout(markdown);
+  } catch (error) {
+    process.stderr.write(`Error: ${error.message}\n`);
+
+    try {
+      const errorPage = context?.pages?.()[0];
+
+      if (errorPage) {
+        const screenshot = await errorPage.screenshot({
+          type: 'jpeg',
+          quality: 30,
+          fullPage: false,
+        });
+
+        process.stderr.write(
+          `[screenshot] ${screenshot.toString('base64').slice(0, 200)}...\n`
+        );
+      }
+    } catch (_) {
+      // best-effort
+    }
+
+    throw error;
+  } finally {
+    if (context) {
+      await context.close().catch(() => { });
+    }
+
+    if (browser) {
+      await browser.close().catch(() => { });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI 入口
+// ---------------------------------------------------------------------------
+async function main() {
+  const url = process.argv[2];
+
+  if (!url) {
+    process.stderr.write('Usage: node local_web_fetcher.js <url>\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    await fetchUrl(url);
+  } catch (_) {
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/services/wisepen-chat-service/pyproject.toml
+++ b/services/wisepen-chat-service/pyproject.toml
@@ -23,4 +23,17 @@ dependencies = [
     "jieba",
     "zeroentropy",
     "wisepen-common",
+    "tavily-python",
+    "httpx",
+    "steel-sdk",
+    "readability-lxml",
+    "markdownify",
+    "playwright",
+    "pdfplumber",
+    "python-docx",
+    "openpyxl",
+    "python-pptx"
 ]
+
+[tool.uv]
+index-url = "https://pypi.tuna.tsinghua.edu.cn/simple"

--- a/services/wisepen-chat-service/src/chat/application/tools/web_fetch_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/web_fetch_tool.py
@@ -6,61 +6,13 @@ from chat.domain.interfaces.tool import BaseTool
 from chat.application.web_fetch.fetch_coordinator import FetchCoordinator
 from common.logger import log_fail
 
+__all__ = [
+    "WebFetchTool",
+]
 
-_TRUNCATION_MARKER = "\n\n...(Content truncated due to length)"
+TRUNCATION_MARKER = "\n\n...(Content truncated due to length)"
 
-
-class WebFetchTool(BaseTool):
-    """网页浏览抓取工具"""
-
-    def __init__(self):
-        self._fetcher = FetchCoordinator(settings.STEEL_BASE_URL)
-
-    @property
-    def name(self) -> str:
-        return "web_fetch"
-
-    @property
-    def description(self) -> str:
-        return _TOOL_DESCRIPTION
-
-    @property
-    def parameters_schema(self) -> Dict[str, Any]:
-        return _TOOL_SCHEMA
-
-    async def execute(self, context: Dict[str, Any], **kwargs) -> str:
-        """执行网页浏览并返回 Markdown 内容或错误消息"""
-        session_id: Optional[str] = context.get("session_id")
-        if not session_id:
-            return "[Tool Error] Missing session_id in execution context."
-
-        url: str = kwargs.get("url", "")
-        force_browser: bool = kwargs.get("force_browser", False)
-
-        if not url:
-            return "[Tool Error] Missing required url parameter"
-
-        url = url.strip()
-        if not _is_valid_http_url(url):
-            return "[Tool Error] Invalid url parameter. URL must start with http:// or https://."
-
-        try:
-            md_result = await self._fetcher.fetch(url, force_browser=force_browser)
-        except Exception as e:
-            log_fail("网页抓取工具", e, session_id=session_id, url=url, force_browser=force_browser)
-            return "[Tool Error] Unexpected error while fetching web page content."
-
-        if md_result is None:
-            return "[Tool Result] Failed to fetch web page content (all fetch methods exhausted)"
-
-        md_result = _normalize_markdown_result(md_result)
-        if not md_result:
-            return "[Tool Result] Failed to fetch web page content (empty content returned)"
-
-        return md_result
-
-
-_TOOL_DESCRIPTION = (
+TOOL_DESCRIPTION = (
     "Fetches and extracts textual content from a given URL, returning clean Markdown. "
     "Supports both web pages and direct document links (PDF, DOCX, XLSX, PPTX) — "
     "content type is auto-detected, no need to specify format.\n\n"
@@ -78,8 +30,7 @@ _TOOL_DESCRIPTION = (
     "Focus on extracting the information relevant to the user's request."
 )
 
-
-_TOOL_SCHEMA = {
+TOOL_SCHEMA = {
     "type": "object",
     "properties": {
         "url": {
@@ -104,17 +55,74 @@ _TOOL_SCHEMA = {
 }
 
 
-def _is_valid_http_url(url: str) -> bool:
+class WebFetchTool(BaseTool):
+    def __init__(self):
+        self._fetcher = FetchCoordinator(settings.STEEL_BASE_URL)
+
+    @property
+    def name(self) -> str:
+        return "web_fetch"
+
+    @property
+    def description(self) -> str:
+        return TOOL_DESCRIPTION
+
+    @property
+    def parameters_schema(self) -> Dict[str, Any]:
+        return TOOL_SCHEMA
+
+    async def execute(self, context: Dict[str, Any], **kwargs) -> str:
+        session_id: Optional[str] = context.get("session_id")
+        if not session_id:
+            return "[Tool Error] Missing session_id in execution context."
+
+        url: str = kwargs.get("url", "")
+        force_browser: bool = kwargs.get("force_browser", False)
+
+        if not url:
+            return "[Tool Error] Missing required url parameter"
+
+        url = url.strip()
+        if not is_valid_http_url(url):
+            return "[Tool Error] Invalid url parameter. URL must start with http:// or https://."
+
+        try:
+            md_result = await self._fetcher.fetch(url, force_browser=force_browser)
+        except Exception as e:
+            log_fail("网页抓取工具", e, session_id=session_id, url=url, force_browser=force_browser)
+            return "[Tool Error] Unexpected error while fetching web page content."
+
+        if md_result is None:
+            return "[Tool Result] Failed to fetch web page content (all fetch methods exhausted)"
+
+        md_result = normalize_markdown_result(md_result)
+        if not md_result:
+            return "[Tool Result] Failed to fetch web page content (empty content returned)"
+
+        return md_result
+
+
+def is_valid_http_url(url: str) -> bool:
     parsed = urlparse(url)
     return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
 
 
-def _normalize_markdown_result(markdown: str) -> str:
+def normalize_markdown_result(markdown: str) -> str:
     markdown = markdown.strip()
 
-    if len(markdown) > settings.TOOL_RESULT_MAX_CHARS:
-        limit = settings.TOOL_RESULT_MAX_CHARS
-        keep_len = max(0, limit - len(_TRUNCATION_MARKER))
-        markdown = markdown[:keep_len].rstrip() + _TRUNCATION_MARKER
+    if len(markdown) <= settings.TOOL_RESULT_MAX_CHARS:
+        return markdown
 
-    return markdown
+    limit = settings.TOOL_RESULT_MAX_CHARS
+    keep_len = max(0, limit - len(TRUNCATION_MARKER))
+
+    if keep_len <= 0:
+        return markdown[:limit]
+
+    head = markdown[:keep_len]
+    paragraph_boundary = head.rfind("\n\n")
+
+    if paragraph_boundary >= int(keep_len * 0.6):
+        head = head[:paragraph_boundary]
+
+    return head.rstrip() + TRUNCATION_MARKER

--- a/services/wisepen-chat-service/src/chat/application/tools/web_fetch_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/web_fetch_tool.py
@@ -1,0 +1,120 @@
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+from chat.core.config.app_settings import settings
+from chat.domain.interfaces.tool import BaseTool
+from chat.application.web_fetch.fetch_coordinator import FetchCoordinator
+from common.logger import log_fail
+
+
+_TRUNCATION_MARKER = "\n\n...(Content truncated due to length)"
+
+
+class WebFetchTool(BaseTool):
+    """网页浏览抓取工具"""
+
+    def __init__(self):
+        self._fetcher = FetchCoordinator(settings.STEEL_BASE_URL)
+
+    @property
+    def name(self) -> str:
+        return "web_fetch"
+
+    @property
+    def description(self) -> str:
+        return _TOOL_DESCRIPTION
+
+    @property
+    def parameters_schema(self) -> Dict[str, Any]:
+        return _TOOL_SCHEMA
+
+    async def execute(self, context: Dict[str, Any], **kwargs) -> str:
+        """执行网页浏览并返回 Markdown 内容或错误消息"""
+        session_id: Optional[str] = context.get("session_id")
+        if not session_id:
+            return "[Tool Error] Missing session_id in execution context."
+
+        url: str = kwargs.get("url", "")
+        force_browser: bool = kwargs.get("force_browser", False)
+
+        if not url:
+            return "[Tool Error] Missing required url parameter"
+
+        url = url.strip()
+        if not _is_valid_http_url(url):
+            return "[Tool Error] Invalid url parameter. URL must start with http:// or https://."
+
+        try:
+            md_result = await self._fetcher.fetch(url, force_browser=force_browser)
+        except Exception as e:
+            log_fail("网页抓取工具", e, session_id=session_id, url=url, force_browser=force_browser)
+            return "[Tool Error] Unexpected error while fetching web page content."
+
+        if md_result is None:
+            return "[Tool Result] Failed to fetch web page content (all fetch methods exhausted)"
+
+        md_result = _normalize_markdown_result(md_result)
+        if not md_result:
+            return "[Tool Result] Failed to fetch web page content (empty content returned)"
+
+        return md_result
+
+
+_TOOL_DESCRIPTION = (
+    "Fetches and extracts textual content from a given URL, returning clean Markdown. "
+    "Supports both web pages and direct document links (PDF, DOCX, XLSX, PPTX) — "
+    "content type is auto-detected, no need to specify format.\n\n"
+    "**Fetch strategy:** Three-stage automatic fallback: "
+    "1) lightweight static HTTP request; 2) headless browser (Steel) for JS-heavy pages; "
+    "3) local headless browser as final fallback. "
+    "Document URLs are handled directly via static fetch — no browser stage needed.\n\n"
+    "**When to use:** Call this tool when a user provides a URL (web page or document) "
+    "and asks you to read, summarize, analyze, or answer questions about its content.\n\n"
+    "**force_browser:** Set to true ONLY when: "
+    "a) default mode returned incomplete content or a bot-check page; "
+    "b) the target is a known dynamic, JavaScript-heavy website. "
+    "Do NOT use force_browser for document URLs (PDF, DOCX, etc.) — it provides no benefit.\n\n"
+    "**Note:** Returned content may be very long and is automatically truncated. "
+    "Focus on extracting the information relevant to the user's request."
+)
+
+
+_TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "url": {
+            "type": "string",
+            "description": (
+                "The URL to fetch. Accepts web pages (HTML) and direct document links "
+                "(PDF, DOCX, XLSX, PPTX). Must start with http:// or https://."
+            ),
+        },
+        "force_browser": {
+            "type": "boolean",
+            "description": (
+                "Force browser mode. Defaults to false. "
+                "false: tries a fast static fetch first, then falls back to a headless browser. "
+                "true: skips the static fetch and uses a headless browser immediately. Useful for dynamic, "
+                "JavaScript-heavy pages or when a static fetch has already failed."
+            ),
+            "default": False,
+        },
+    },
+    "required": ["url"],
+}
+
+
+def _is_valid_http_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _normalize_markdown_result(markdown: str) -> str:
+    markdown = markdown.strip()
+
+    if len(markdown) > settings.TOOL_RESULT_MAX_CHARS:
+        limit = settings.TOOL_RESULT_MAX_CHARS
+        keep_len = max(0, limit - len(_TRUNCATION_MARKER))
+        markdown = markdown[:keep_len].rstrip() + _TRUNCATION_MARKER
+
+    return markdown

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/__init__.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/__init__.py
@@ -1,0 +1,7 @@
+from .content_processor import ContentProcessor
+from .fetch_coordinator import FetchCoordinator
+
+__all__ = [
+    "ContentProcessor",
+    "FetchCoordinator",
+]

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/content_processor.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/content_processor.py
@@ -1,0 +1,358 @@
+from io import BytesIO
+from typing import Callable, Dict, List, Optional
+from zipfile import BadZipFile, ZipFile
+
+import pdfplumber
+from docx import Document as DocxDocument
+from markdownify import markdownify
+from openpyxl import load_workbook
+from pptx import Presentation
+from readability import Document
+
+from common.logger import log_ok, log_fail
+
+
+_OLE_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+
+_MAX_ZIP_UNCOMPRESSED_SIZE = 200 * 1024 * 1024
+_ANTI_CRAWL_SCAN_CHARS = 20000
+
+_ANTI_CRAWL_KEYWORDS = (
+    "just a moment",
+    "please enable javascript",
+    "please enable js",
+    "captcha",
+    "access denied",
+    "cloudflare",
+    "are you a robot",
+    "are you human",
+    "verify you are human",
+)
+
+
+def _looks_like_anti_crawl(text: str) -> bool:
+    lower = text[:_ANTI_CRAWL_SCAN_CHARS].lower()
+    return any(kw in lower for kw in _ANTI_CRAWL_KEYWORDS)
+
+
+def _normalize_text(text: str) -> str:
+    lines = [
+        line.rstrip()
+        for line in text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    ]
+    result = "\n".join(lines).strip()
+
+    while "\n\n\n" in result:
+        result = result.replace("\n\n\n", "\n\n")
+
+    return result
+
+
+class DocumentParser:
+    """文档解析器：负责 bytes 文档识别、解析和基础质量过滤。"""
+
+    def __init__(
+        self,
+        min_content_length: int = 50,
+        max_document_size: int = 50 * 1024 * 1024,
+    ):
+        self._min_content_length = min_content_length
+        self._max_document_size = max_document_size
+        self._parsers: Dict[str, Callable[[bytes], Optional[str]]] = {
+            "pdf": self._parse_pdf,
+            "docx": self._parse_docx,
+            "xlsx": self._parse_xlsx,
+            "pptx": self._parse_pptx,
+        }
+
+    def parse(self, data: bytes) -> Optional[str]:
+        if len(data) > self._max_document_size:
+            log_fail("文档解析", f"文件过大({len(data)}字节)，上限{self._max_document_size}字节")
+            return None
+
+        doc_type = self._detect_doc_type(data)
+        if doc_type is None:
+            return None
+
+        parser = self._parsers.get(doc_type)
+        if parser is None:
+            log_fail("文档解析", f"暂不支持的文档类型: {doc_type}")
+            return None
+
+        text = parser(data)
+        if text is None:
+            log_fail("文档清洗", "文本提取返回空")
+            return None
+
+        cleaned = _normalize_text(text)
+
+        if _looks_like_anti_crawl(cleaned):
+            log_fail("文档清洗", "提取文本疑似反爬/错误页面，触发降级")
+            return None
+
+        if len(cleaned) < self._min_content_length:
+            log_fail(
+                "文档清洗",
+                f"提取文本过短({len(cleaned)}字符)，阈值{self._min_content_length}，触发降级",
+            )
+            return None
+
+        log_ok("文档清洗", length=len(cleaned), doc_type=doc_type)
+        return cleaned
+
+    def _detect_doc_type(self, data: bytes) -> Optional[str]:
+        if data[:5] == b"%PDF-":
+            return "pdf"
+
+        if data[:8] == _OLE_MAGIC:
+            log_fail("文档解析", "OLE 复合文档(旧版 .doc/.xls/.ppt)，暂不支持")
+            return None
+
+        try:
+            with ZipFile(BytesIO(data)) as zf:
+                infos = zf.infolist()
+                uncompressed_size = sum(info.file_size for info in infos)
+
+                if uncompressed_size > _MAX_ZIP_UNCOMPRESSED_SIZE:
+                    log_fail(
+                        "文档解析",
+                        f"ZIP 解压后体积过大({uncompressed_size}字节)，上限{_MAX_ZIP_UNCOMPRESSED_SIZE}字节",
+                    )
+                    return None
+
+                names = {info.filename for info in infos}
+
+                matches = [
+                    ("word/document.xml", "docx"),
+                    ("xl/workbook.xml", "xlsx"),
+                    ("ppt/presentation.xml", "pptx"),
+                ]
+
+                hits = [doc_type for sig, doc_type in matches if sig in names]
+
+                if len(hits) != 1:
+                    if hits:
+                        log_fail("文档解析", f"ZIP 内含多种 Office 特征文件({', '.join(hits)})，无法确定类型")
+                    return None
+
+                return hits[0]
+
+        except BadZipFile:
+            pass
+
+        log_fail("文档解析", "无法识别文档类型")
+        return None
+
+    def _parse_pdf(self, data: bytes) -> Optional[str]:
+        try:
+            text_parts: List[str] = []
+            page_count = 0
+
+            with pdfplumber.open(BytesIO(data)) as pdf:
+                page_count = len(pdf.pages)
+
+                for page in pdf.pages:
+                    page_text = page.extract_text()
+                    if page_text:
+                        text_parts.append(page_text)
+
+            result = "\n".join(text_parts).strip()
+
+            if result:
+                log_ok("PDF 文本提取", pages=page_count, length=len(result))
+                return result
+
+            return None
+
+        except Exception as e:
+            log_fail("PDF 文本提取", e)
+            return None
+
+    def _parse_docx(self, data: bytes) -> Optional[str]:
+        try:
+            doc = DocxDocument(BytesIO(data))
+            parts: List[str] = []
+
+            for para in doc.paragraphs:
+                text = para.text.strip()
+                if text:
+                    parts.append(text)
+
+            for table in doc.tables:
+                for row in table.rows:
+                    cells = [cell.text.strip() for cell in row.cells]
+                    if any(cells):
+                        parts.append("\t".join(cells))
+
+            result = "\n".join(parts).strip()
+
+            if result:
+                log_ok("DOCX 文本提取", length=len(result))
+                return result
+
+            return None
+
+        except Exception as e:
+            log_fail("DOCX 文本提取", e)
+            return None
+
+    def _parse_xlsx(self, data: bytes) -> Optional[str]:
+        wb = None
+
+        try:
+            wb = load_workbook(BytesIO(data), read_only=True, data_only=True)
+            parts: List[str] = []
+
+            for sheet in wb:
+                sheet_parts: List[str] = []
+
+                for row in sheet.iter_rows(values_only=True):
+                    cells = [str(cell) if cell is not None else "" for cell in row]
+                    line = "\t".join(cells).strip()
+
+                    if line:
+                        sheet_parts.append(line)
+
+                if sheet_parts:
+                    parts.append(f"Sheet: {sheet.title}")
+                    parts.extend(sheet_parts)
+
+            result = "\n".join(parts).strip()
+
+            if result:
+                log_ok("XLSX 文本提取", length=len(result))
+                return result
+
+            return None
+
+        except Exception as e:
+            log_fail("XLSX 文本提取", e)
+            return None
+
+        finally:
+            if wb is not None:
+                wb.close()
+
+    def _parse_pptx(self, data: bytes) -> Optional[str]:
+        try:
+            prs = Presentation(BytesIO(data))
+            parts: List[str] = []
+
+            for slide in prs.slides:
+                for shape in slide.shapes:
+                    if shape.has_text_frame:
+                        text = shape.text.strip()
+                        if text:
+                            parts.append(text)
+
+            result = "\n".join(parts).strip()
+
+            if result:
+                log_ok("PPTX 文本提取", length=len(result))
+                return result
+
+            return None
+
+        except Exception as e:
+            log_fail("PPTX 文本提取", e)
+            return None
+
+
+class ContentProcessor:
+    """内容处理器：负责 str/bytes 分流，以及 HTML/纯文本清洗。"""
+
+    def __init__(
+        self,
+        min_content_length: int = 400,
+        document_min_content_length: int = 50,
+        max_document_size: int = 50 * 1024 * 1024,
+    ):
+        self._min_content_length = min_content_length
+        self._document_parser = DocumentParser(
+            min_content_length=document_min_content_length,
+            max_document_size=max_document_size,
+        )
+
+    def process(self, content: str | bytes) -> Optional[str]:
+        if isinstance(content, bytes):
+            return self._document_parser.parse(content)
+
+        return self._process_text(content)
+
+    def _process_text(self, content: str) -> Optional[str]:
+        stripped = content.strip()
+        if not stripped:
+            return None
+
+        if _looks_like_anti_crawl(stripped):
+            log_fail("内容检测", "疑似反爬/错误页面，触发降级")
+            return None
+
+        lower_head = stripped[:1024].lower()
+        if "<html" in lower_head or "<!doctype html" in lower_head or "<body" in lower_head:
+            return self._process_html(stripped)
+
+        return self._process_plain_text(stripped)
+
+    def _process_html(self, html: str) -> Optional[str]:
+        try:
+            clean_content = self._extract_main_content(html)
+            markdown = self._convert_to_markdown(clean_content)
+            result = _normalize_text(markdown)
+
+            if _looks_like_anti_crawl(result):
+                log_fail("HTML 清洗", "清洗后疑似反爬/错误页面，触发降级")
+                return None
+
+            if len(result) < self._min_content_length:
+                log_fail(
+                    "HTML 清洗",
+                    f"清洗后文本过短({len(result)}字符)，阈值{self._min_content_length}，触发降级",
+                )
+                return None
+
+            return result
+
+        except Exception as e:
+            log_fail("HTML 清洗", e, fallback="返回未清洗原文，可能含 HTML 标签")
+            fallback = _normalize_text(html)
+
+            if len(fallback) < self._min_content_length:
+                return None
+
+            return fallback
+
+    def _process_plain_text(self, text: str) -> Optional[str]:
+        normalized = _normalize_text(text)
+
+        if len(normalized) < self._min_content_length:
+            log_fail(
+                "纯文本检测",
+                f"文本过短({len(normalized)}字符)，阈值{self._min_content_length}，触发降级",
+            )
+            return None
+
+        if _looks_like_anti_crawl(normalized):
+            log_fail("纯文本检测", "疑似反爬/错误页面，触发降级")
+            return None
+
+        return normalized
+
+    def _extract_main_content(self, html: str) -> str:
+        try:
+            return Document(html).summary()
+        except Exception as e:
+            log_fail("readability 提取主体内容", e)
+            return html
+
+    def _convert_to_markdown(self, html: str) -> str:
+        try:
+            return markdownify(
+                html,
+                heading_style="ATX",
+                strip=["script", "style", "img", "nav", "footer"],
+                autolinks=True,
+            ).strip()
+        except Exception as e:
+            log_fail("HTML 转 Markdown", e)
+            return html

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/content_processor.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/content_processor.py
@@ -11,13 +11,17 @@ from readability import Document
 
 from common.logger import log_ok, log_fail
 
+__all__ = [
+    "ContentProcessor",
+    "DocumentParser",
+]
 
-_OLE_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+OLE_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
 
-_MAX_ZIP_UNCOMPRESSED_SIZE = 200 * 1024 * 1024
-_ANTI_CRAWL_SCAN_CHARS = 20000
+MAX_ZIP_UNCOMPRESSED_SIZE = 200 * 1024 * 1024
+ANTI_CRAWL_SCAN_CHARS = 20000
 
-_ANTI_CRAWL_KEYWORDS = (
+ANTI_CRAWL_KEYWORDS = (
     "just a moment",
     "please enable javascript",
     "please enable js",
@@ -30,12 +34,12 @@ _ANTI_CRAWL_KEYWORDS = (
 )
 
 
-def _looks_like_anti_crawl(text: str) -> bool:
-    lower = text[:_ANTI_CRAWL_SCAN_CHARS].lower()
-    return any(kw in lower for kw in _ANTI_CRAWL_KEYWORDS)
+def looks_like_anti_crawl(text: str) -> bool:
+    lower = text[:ANTI_CRAWL_SCAN_CHARS].lower()
+    return any(kw in lower for kw in ANTI_CRAWL_KEYWORDS)
 
 
-def _normalize_text(text: str) -> str:
+def normalize_text(text: str) -> str:
     lines = [
         line.rstrip()
         for line in text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
@@ -84,9 +88,9 @@ class DocumentParser:
             log_fail("文档清洗", "文本提取返回空")
             return None
 
-        cleaned = _normalize_text(text)
+        cleaned = normalize_text(text)
 
-        if _looks_like_anti_crawl(cleaned):
+        if looks_like_anti_crawl(cleaned):
             log_fail("文档清洗", "提取文本疑似反爬/错误页面，触发降级")
             return None
 
@@ -104,7 +108,7 @@ class DocumentParser:
         if data[:5] == b"%PDF-":
             return "pdf"
 
-        if data[:8] == _OLE_MAGIC:
+        if data[:8] == OLE_MAGIC:
             log_fail("文档解析", "OLE 复合文档(旧版 .doc/.xls/.ppt)，暂不支持")
             return None
 
@@ -113,10 +117,10 @@ class DocumentParser:
                 infos = zf.infolist()
                 uncompressed_size = sum(info.file_size for info in infos)
 
-                if uncompressed_size > _MAX_ZIP_UNCOMPRESSED_SIZE:
+                if uncompressed_size > MAX_ZIP_UNCOMPRESSED_SIZE:
                     log_fail(
                         "文档解析",
-                        f"ZIP 解压后体积过大({uncompressed_size}字节)，上限{_MAX_ZIP_UNCOMPRESSED_SIZE}字节",
+                        f"ZIP 解压后体积过大({uncompressed_size}字节)，上限{MAX_ZIP_UNCOMPRESSED_SIZE}字节",
                     )
                     return None
 
@@ -204,18 +208,22 @@ class DocumentParser:
             parts: List[str] = []
 
             for sheet in wb:
-                sheet_parts: List[str] = []
+                sheet_rows: List[str] = []
 
                 for row in sheet.iter_rows(values_only=True):
                     cells = [str(cell) if cell is not None else "" for cell in row]
                     line = "\t".join(cells).strip()
 
                     if line:
-                        sheet_parts.append(line)
+                        sheet_rows.append(line)
 
-                if sheet_parts:
-                    parts.append(f"Sheet: {sheet.title}")
-                    parts.extend(sheet_parts)
+                if sheet_rows:
+                    parts.append(f"## Sheet: {sheet.title}")
+                    parts.append("")
+                    parts.append("```tsv")
+                    parts.extend(sheet_rows)
+                    parts.append("```")
+                    parts.append("")
 
             result = "\n".join(parts).strip()
 
@@ -238,12 +246,20 @@ class DocumentParser:
             prs = Presentation(BytesIO(data))
             parts: List[str] = []
 
-            for slide in prs.slides:
+            for index, slide in enumerate(prs.slides, 1):
+                slide_parts: List[str] = []
+
                 for shape in slide.shapes:
                     if shape.has_text_frame:
                         text = shape.text.strip()
                         if text:
-                            parts.append(text)
+                            slide_parts.append(text)
+
+                if slide_parts:
+                    parts.append(f"## Slide {index}")
+                    parts.append("")
+                    parts.extend(slide_parts)
+                    parts.append("")
 
             result = "\n".join(parts).strip()
 
@@ -284,7 +300,7 @@ class ContentProcessor:
         if not stripped:
             return None
 
-        if _looks_like_anti_crawl(stripped):
+        if looks_like_anti_crawl(stripped):
             log_fail("内容检测", "疑似反爬/错误页面，触发降级")
             return None
 
@@ -298,9 +314,9 @@ class ContentProcessor:
         try:
             clean_content = self._extract_main_content(html)
             markdown = self._convert_to_markdown(clean_content)
-            result = _normalize_text(markdown)
+            result = normalize_text(markdown)
 
-            if _looks_like_anti_crawl(result):
+            if looks_like_anti_crawl(result):
                 log_fail("HTML 清洗", "清洗后疑似反爬/错误页面，触发降级")
                 return None
 
@@ -315,7 +331,7 @@ class ContentProcessor:
 
         except Exception as e:
             log_fail("HTML 清洗", e, fallback="返回未清洗原文，可能含 HTML 标签")
-            fallback = _normalize_text(html)
+            fallback = normalize_text(html)
 
             if len(fallback) < self._min_content_length:
                 return None
@@ -323,7 +339,7 @@ class ContentProcessor:
             return fallback
 
     def _process_plain_text(self, text: str) -> Optional[str]:
-        normalized = _normalize_text(text)
+        normalized = normalize_text(text)
 
         if len(normalized) < self._min_content_length:
             log_fail(
@@ -332,7 +348,7 @@ class ContentProcessor:
             )
             return None
 
-        if _looks_like_anti_crawl(normalized):
+        if looks_like_anti_crawl(normalized):
             log_fail("纯文本检测", "疑似反爬/错误页面，触发降级")
             return None
 

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/fetch_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/fetch_coordinator.py
@@ -1,8 +1,28 @@
+import time
+from collections import OrderedDict
 from typing import Optional, List, Tuple
+from urllib.parse import urlparse
 
 from chat.application.web_fetch.fetcher import StaticFetcher, SteelFetcher, SteelFetcherConfig, LocalScriptFetcher
 from chat.application.web_fetch.content_processor import ContentProcessor
 from common.logger import log_ok, log_fail
+
+__all__ = [
+    "FetchCoordinator",
+]
+
+CACHE_TTL_SECONDS = 10 * 60
+CACHE_MAX_ITEMS = 128
+
+DOCUMENT_EXTENSIONS = (
+    ".pdf",
+    ".doc",
+    ".docx",
+    ".xls",
+    ".xlsx",
+    ".ppt",
+    ".pptx",
+)
 
 
 class FetchCoordinator:
@@ -24,9 +44,14 @@ class FetchCoordinator:
         last_resort_min_length: int = 50,
         static_timeout: float = 15.0,
         browser_timeout: float = 60.0,
+        cache_ttl_seconds: int = CACHE_TTL_SECONDS,
+        cache_max_items: int = CACHE_MAX_ITEMS,
     ):
         self._min_content_length = min_content_length
         self._last_resort_min_length = last_resort_min_length
+        self._cache_ttl_seconds = cache_ttl_seconds
+        self._cache_max_items = cache_max_items
+        self._cache: OrderedDict[tuple[str, bool], tuple[float, str]] = OrderedDict()
 
         self._static_fetcher = StaticFetcher(timeout=static_timeout)
         self._steel_fetcher = SteelFetcher(
@@ -60,7 +85,29 @@ class FetchCoordinator:
         Returns:
             转换后的 Markdown 内容；全部失败则返回 None
         """
-        chain = self._browser_chain if force_browser else self._lightweight_chain
+        url = url.strip()
+        effective_force_browser = force_browser
+
+        if force_browser and is_document_url(url):
+            log_ok(
+                "网页抓取文档 URL 忽略 force_browser，优先使用静态链路",
+                url=url,
+                force_browser=force_browser,
+            )
+            effective_force_browser = False
+
+        cached = self._get_cached(url, effective_force_browser)
+        if cached is not None:
+            log_ok(
+                "网页抓取缓存命中",
+                url=url,
+                force_browser=effective_force_browser,
+                length=len(cached),
+            )
+            return cached
+
+        chain = self._browser_chain if effective_force_browser else self._lightweight_chain
+        failure_reasons: list[str] = []
 
         for i, (fetcher, content_type) in enumerate(chain):
             fetcher_name = fetcher.__class__.__name__
@@ -70,17 +117,32 @@ class FetchCoordinator:
             try:
                 content = await fetcher.fetch(url)
             except Exception as e:
-                log_fail("网页抓取", e, url=url, fetcher=fetcher_name)
+                failure_reasons.append(f"{fetcher_name}: exception={e.__class__.__name__}")
+                log_fail(
+                    "网页抓取",
+                    e,
+                    url=url,
+                    fetcher=fetcher_name,
+                )
                 continue
 
             if not content:
-                log_fail("网页抓取", "抓取内容为空", url=url, fetcher=fetcher_name)
+                failure_reasons.append(f"{fetcher_name}: empty content")
+                log_fail(
+                    "网页抓取",
+                    "抓取内容为空",
+                    url=url,
+                    fetcher=fetcher_name,
+                )
                 continue
 
             if content_type == "markdown":
                 markdown = str(content).strip()
 
                 if len(markdown) < min_length:
+                    failure_reasons.append(
+                        f"{fetcher_name}: too short length={len(markdown)} min={min_length}"
+                    )
                     log_fail(
                         "网页抓取",
                         f"内容过短({len(markdown)}字符)，阈值{min_length}，触发降级",
@@ -89,16 +151,70 @@ class FetchCoordinator:
                     )
                     continue
 
-                log_ok("网页抓取", url=url, fetcher=fetcher_name, length=len(markdown))
+                log_ok(
+                    "网页抓取",
+                    url=url,
+                    fetcher=fetcher_name,
+                    length=len(markdown),
+                )
+                self._set_cached(url, effective_force_browser, markdown)
                 return markdown
 
             result = self._processor.process(content)
             if result is None:
-                log_fail("网页抓取", "内容处理失败，触发降级", url=url, fetcher=fetcher_name)
+                failure_reasons.append(f"{fetcher_name}: processor failed")
+                log_fail(
+                    "网页抓取",
+                    "内容处理失败，触发降级",
+                    url=url,
+                    fetcher=fetcher_name,
+                )
                 continue
 
-            log_ok("网页抓取", url=url, fetcher=fetcher_name, length=len(result))
+            log_ok(
+                "网页抓取",
+                url=url,
+                fetcher=fetcher_name,
+                length=len(result),
+            )
+            self._set_cached(url, effective_force_browser, result)
             return result
 
-        log_fail("网页抓取", "所有抓取器均失败", url=url)
+        log_fail(
+            "网页抓取",
+            "所有抓取器均失败",
+            url=url,
+            force_browser=effective_force_browser,
+            reasons=" | ".join(failure_reasons[-5:]),
+        )
         return None
+
+    def _get_cached(self, url: str, force_browser: bool) -> Optional[str]:
+        key = (url, force_browser)
+        item = self._cache.get(key)
+
+        if item is None:
+            return None
+
+        created_at, markdown = item
+        age = time.monotonic() - created_at
+
+        if age > self._cache_ttl_seconds:
+            self._cache.pop(key, None)
+            return None
+
+        self._cache.move_to_end(key)
+        return markdown
+
+    def _set_cached(self, url: str, force_browser: bool, markdown: str) -> None:
+        key = (url, force_browser)
+        self._cache[key] = (time.monotonic(), markdown)
+        self._cache.move_to_end(key)
+
+        while len(self._cache) > self._cache_max_items:
+            self._cache.popitem(last=False)
+
+
+def is_document_url(url: str) -> bool:
+    path = urlparse(url).path.lower()
+    return path.endswith(DOCUMENT_EXTENSIONS)

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/fetch_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/fetch_coordinator.py
@@ -1,0 +1,104 @@
+from typing import Optional, List, Tuple
+
+from chat.application.web_fetch.fetcher import StaticFetcher, SteelFetcher, SteelFetcherConfig, LocalScriptFetcher
+from chat.application.web_fetch.content_processor import ContentProcessor
+from common.logger import log_ok, log_fail
+
+
+class FetchCoordinator:
+    """网页抓取调度器：按优先级依次尝试多种抓取策略，自动降级
+
+    抓取链路:
+        普通模式 → StaticFetcher → SteelFetcher → LocalScriptFetcher
+        强制浏览器 → SteelFetcher → LocalScriptFetcher
+
+    每个抓取器返回的内容分为两类:
+        - raw (str | bytes): 需要经过 ContentProcessor 处理
+        - markdown (str): 已是干净的 Markdown，直接返回
+    """
+
+    def __init__(
+        self,
+        steel_base_url: str,
+        min_content_length: int = 400,
+        last_resort_min_length: int = 50,
+        static_timeout: float = 15.0,
+        browser_timeout: float = 60.0,
+    ):
+        self._min_content_length = min_content_length
+        self._last_resort_min_length = last_resort_min_length
+
+        self._static_fetcher = StaticFetcher(timeout=static_timeout)
+        self._steel_fetcher = SteelFetcher(
+            SteelFetcherConfig(base_url=steel_base_url, timeout=browser_timeout)
+        )
+        self._local_script_fetcher = LocalScriptFetcher(timeout=browser_timeout)
+
+        self._processor = ContentProcessor(
+            min_content_length=min_content_length,
+            document_min_content_length=last_resort_min_length,
+        )
+
+        self._lightweight_chain: List[Tuple] = [
+            (self._static_fetcher, "raw"),
+            (self._steel_fetcher, "markdown"),
+            (self._local_script_fetcher, "markdown"),
+        ]
+
+        self._browser_chain: List[Tuple] = [
+            (self._steel_fetcher, "markdown"),
+            (self._local_script_fetcher, "markdown"),
+        ]
+
+    async def fetch(self, url: str, *, force_browser: bool = False) -> Optional[str]:
+        """从指定 URL 获取内容并转换为 Markdown
+
+        Args:
+            url: 目标网页 URL
+            force_browser: 是否强制使用浏览器链路
+
+        Returns:
+            转换后的 Markdown 内容；全部失败则返回 None
+        """
+        chain = self._browser_chain if force_browser else self._lightweight_chain
+
+        for i, (fetcher, content_type) in enumerate(chain):
+            fetcher_name = fetcher.__class__.__name__
+            is_last = i == len(chain) - 1
+            min_length = self._last_resort_min_length if is_last else self._min_content_length
+
+            try:
+                content = await fetcher.fetch(url)
+            except Exception as e:
+                log_fail("网页抓取", e, url=url, fetcher=fetcher_name)
+                continue
+
+            if not content:
+                log_fail("网页抓取", "抓取内容为空", url=url, fetcher=fetcher_name)
+                continue
+
+            if content_type == "markdown":
+                markdown = str(content).strip()
+
+                if len(markdown) < min_length:
+                    log_fail(
+                        "网页抓取",
+                        f"内容过短({len(markdown)}字符)，阈值{min_length}，触发降级",
+                        url=url,
+                        fetcher=fetcher_name,
+                    )
+                    continue
+
+                log_ok("网页抓取", url=url, fetcher=fetcher_name, length=len(markdown))
+                return markdown
+
+            result = self._processor.process(content)
+            if result is None:
+                log_fail("网页抓取", "内容处理失败，触发降级", url=url, fetcher=fetcher_name)
+                continue
+
+            log_ok("网页抓取", url=url, fetcher=fetcher_name, length=len(result))
+            return result
+
+        log_fail("网页抓取", "所有抓取器均失败", url=url)
+        return None

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/__init__.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/__init__.py
@@ -1,0 +1,10 @@
+from .static_fetcher import StaticFetcher
+from .steel_fetcher import SteelFetcher, SteelFetcherConfig
+from .local_fetcher import LocalScriptFetcher
+
+__all__ = [
+    "StaticFetcher",
+    "SteelFetcher",
+    "SteelFetcherConfig",
+    "LocalScriptFetcher",
+]

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/local_fetcher.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/local_fetcher.py
@@ -1,0 +1,112 @@
+import asyncio
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from common.logger import log_ok, log_fail, log_error
+
+
+_MAX_DIR_TRAVERSAL = 10
+_MAX_SUBPROCESS_BUFFER = 10 * 1024 * 1024
+_MAX_ERROR_SNIPPET = 500
+
+
+def _find_root_dir() -> Path:
+    """向上查找包含 scripts/local_web_fetcher.js 的最近父目录"""
+    current = Path(__file__).resolve().parent
+
+    for _ in range(_MAX_DIR_TRAVERSAL):
+        if (current / "scripts" / "local_web_fetcher.js").exists():
+            return current
+
+        if current.parent == current:
+            break
+
+        current = current.parent
+
+    raise FileNotFoundError("找不到项目根目录（包含 scripts/local_web_fetcher.js）")
+
+
+ROOT_DIR = _find_root_dir()
+SCRIPT_PATH = ROOT_DIR / "scripts" / "local_web_fetcher.js"
+
+
+async def _kill_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+
+    process.kill()
+
+    try:
+        await asyncio.wait_for(process.communicate(), timeout=5)
+    except Exception:
+        await process.wait()
+
+
+class LocalScriptFetcher:
+    def __init__(self, timeout: float = 120.0):
+        if not SCRIPT_PATH.is_file():
+            log_error("本地脚本初始化", f"未找到 JS 脚本: {SCRIPT_PATH}")
+            raise FileNotFoundError(f"未找到 JS 脚本: {SCRIPT_PATH}")
+
+        node_path = shutil.which("node") or shutil.which("node.exe")
+
+        if not node_path or not Path(node_path).is_file():
+            log_error("本地脚本初始化", "未检测到 Node.js 运行环境，请确认 Node.js 已安装并加入 PATH")
+            raise FileNotFoundError("未检测到 Node.js 运行环境，请确认 Node.js 已安装并加入 PATH")
+
+        self._node_path = node_path
+        self._timeout = timeout
+
+        log_ok("本地脚本初始化", node_path=self._node_path, timeout=self._timeout)
+
+    async def fetch(self, url: str) -> Optional[str]:
+        process = None
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                self._node_path,
+                str(SCRIPT_PATH),
+                url,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                limit=_MAX_SUBPROCESS_BUFFER,
+            )
+
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=self._timeout,
+            )
+
+            if process.returncode != 0:
+                err_msg = (
+                    stderr.decode("utf-8", errors="replace").strip()[:_MAX_ERROR_SNIPPET]
+                    if stderr
+                    else ""
+                )
+                log_fail("本地脚本执行", f"退出码 {process.returncode}: {err_msg}", url=url)
+                return None
+
+            markdown = stdout.decode("utf-8", errors="replace").strip()
+
+            if not markdown:
+                log_fail("本地脚本执行", "抓取内容为空", url=url)
+                return None
+
+            return markdown
+
+        except asyncio.TimeoutError:
+            log_fail("本地脚本执行", f"超时 {self._timeout}s", url=url)
+
+            if process:
+                await _kill_process(process)
+
+            return None
+
+        except Exception as e:
+            log_error("本地脚本执行", e, url=url)
+
+            if process:
+                await _kill_process(process)
+
+            return None

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/local_fetcher.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/local_fetcher.py
@@ -5,36 +5,19 @@ from typing import Optional
 
 from common.logger import log_ok, log_fail, log_error
 
+__all__ = [
+    "LocalScriptFetcher",
+]
 
-_MAX_DIR_TRAVERSAL = 10
-_MAX_SUBPROCESS_BUFFER = 10 * 1024 * 1024
-_MAX_ERROR_SNIPPET = 500
+MAX_SUBPROCESS_BUFFER = 10 * 1024 * 1024
+MAX_ERROR_SNIPPET = 500
 
-
-def _find_root_dir() -> Path:
-    """向上查找包含 scripts/local_web_fetcher.js 的最近父目录"""
-    current = Path(__file__).resolve().parent
-
-    for _ in range(_MAX_DIR_TRAVERSAL):
-        if (current / "scripts" / "local_web_fetcher.js").exists():
-            return current
-
-        if current.parent == current:
-            break
-
-        current = current.parent
-
-    raise FileNotFoundError("找不到项目根目录（包含 scripts/local_web_fetcher.js）")
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "local_web_fetcher.js"
 
 
-ROOT_DIR = _find_root_dir()
-SCRIPT_PATH = ROOT_DIR / "scripts" / "local_web_fetcher.js"
-
-
-async def _kill_process(process: asyncio.subprocess.Process) -> None:
+async def kill_process(process: asyncio.subprocess.Process) -> None:
     if process.returncode is not None:
         return
-
     process.kill()
 
     try:
@@ -70,7 +53,7 @@ class LocalScriptFetcher:
                 url,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                limit=_MAX_SUBPROCESS_BUFFER,
+                limit=MAX_SUBPROCESS_BUFFER,
             )
 
             stdout, stderr = await asyncio.wait_for(
@@ -80,7 +63,7 @@ class LocalScriptFetcher:
 
             if process.returncode != 0:
                 err_msg = (
-                    stderr.decode("utf-8", errors="replace").strip()[:_MAX_ERROR_SNIPPET]
+                    stderr.decode("utf-8", errors="replace").strip()[:MAX_ERROR_SNIPPET]
                     if stderr
                     else ""
                 )
@@ -99,7 +82,7 @@ class LocalScriptFetcher:
             log_fail("本地脚本执行", f"超时 {self._timeout}s", url=url)
 
             if process:
-                await _kill_process(process)
+                await kill_process(process)
 
             return None
 
@@ -107,6 +90,6 @@ class LocalScriptFetcher:
             log_error("本地脚本执行", e, url=url)
 
             if process:
-                await _kill_process(process)
+                await kill_process(process)
 
             return None

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/static_fetcher.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/static_fetcher.py
@@ -1,0 +1,238 @@
+import httpx
+from typing import Optional, Set, Tuple
+from urllib.parse import urlparse
+
+from common.logger import log_ok, log_fail, log_error
+
+
+_SUPPORTED_DOC_MIME_TYPES: Set[str] = {
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+_TEXT_FRIENDLY_MIME_TYPES: Set[str] = {
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/x-javascript",
+}
+
+_SUPPORTED_DOC_EXTENSIONS: Tuple[str, ...] = (
+    ".pdf",
+    ".doc",
+    ".docx",
+    ".xls",
+    ".xlsx",
+    ".ppt",
+    ".pptx",
+)
+
+_TEXT_FRIENDLY_EXTENSIONS: Tuple[str, ...] = (
+    ".txt",
+    ".md",
+    ".json",
+    ".xml",
+    ".csv",
+)
+
+_MAX_RESPONSE_BYTES = 50 * 1024 * 1024
+_READ_CHUNK_SIZE = 64 * 1024
+
+
+class StaticFetcher:
+    """轻量级静态 HTTP 抓取器"""
+
+    def __init__(
+        self,
+        timeout: float = 10.0,
+        max_retries: int = 3,
+        max_response_bytes: int = _MAX_RESPONSE_BYTES,
+    ):
+        self._timeout = timeout
+        self._max_retries = max_retries
+        self._max_response_bytes = max_response_bytes
+        self._headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            ),
+            "Accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+        }
+
+    async def fetch(self, url: str) -> Optional[str | bytes]:
+        try:
+            transport = httpx.AsyncHTTPTransport(retries=self._max_retries)
+
+            async with httpx.AsyncClient(
+                timeout=self._timeout,
+                headers=self._headers,
+                transport=transport,
+                follow_redirects=True,
+            ) as client:
+                async with client.stream("GET", url) as response:
+                    response.raise_for_status()
+
+                    media_type = self._get_media_type(response)
+                    path = urlparse(url).path.lower()
+
+                    if not self._may_read_body(media_type, path):
+                        log_fail(
+                            "静态抓取",
+                            f"不支持的 Content-Type: {media_type or 'unknown'}",
+                            url=url,
+                        )
+                        return None
+
+                    content = await self._read_limited(response, url)
+                    if content is None:
+                        return None
+
+                    return self._route_response(
+                        media_type=media_type,
+                        path=path,
+                        url=url,
+                        content=content,
+                    )
+
+        except httpx.TimeoutException:
+            log_fail("静态抓取", f"请求超时 {self._timeout}s", url=url)
+            return None
+
+        except httpx.ConnectError:
+            log_fail("静态抓取", "连接失败", url=url)
+            return None
+
+        except httpx.HTTPStatusError as e:
+            log_fail("静态抓取", f"HTTP {e.response.status_code}", url=url)
+            return None
+
+        except httpx.TooManyRedirects:
+            log_fail("静态抓取", "重定向次数过多", url=url)
+            return None
+
+        except httpx.RequestError as e:
+            log_fail("静态抓取", f"请求异常: {e.__class__.__name__}", url=url)
+            return None
+
+        except Exception as e:
+            log_error("静态抓取", e, url=url)
+            return None
+
+    def _get_media_type(self, response: httpx.Response) -> str:
+        return response.headers.get("content-type", "").lower().split(";")[0].strip()
+
+    def _may_read_body(self, media_type: str, path: str) -> bool:
+        if not media_type:
+            return True
+
+        if media_type == "application/octet-stream":
+            return path.endswith(_SUPPORTED_DOC_EXTENSIONS) or path.endswith(_TEXT_FRIENDLY_EXTENSIONS)
+
+        if self._is_text_like(media_type, path):
+            return True
+
+        if self._is_document_like(media_type, path):
+            return True
+
+        return False
+
+    async def _read_limited(self, response: httpx.Response, url: str) -> Optional[bytes]:
+        content_length = response.headers.get("content-length")
+
+        if content_length:
+            try:
+                expected_size = int(content_length)
+            except ValueError:
+                expected_size = 0
+
+            if expected_size > self._max_response_bytes:
+                log_fail(
+                    "静态抓取",
+                    f"响应体过大({expected_size}字节)，上限{self._max_response_bytes}字节",
+                    url=url,
+                )
+                return None
+
+        chunks = []
+        total_size = 0
+
+        async for chunk in response.aiter_bytes(chunk_size=_READ_CHUNK_SIZE):
+            total_size += len(chunk)
+
+            if total_size > self._max_response_bytes:
+                log_fail(
+                    "静态抓取",
+                    f"响应体超过上限({total_size}字节)，上限{self._max_response_bytes}字节",
+                    url=url,
+                )
+                return None
+
+            chunks.append(chunk)
+
+        return b"".join(chunks)
+
+    def _route_response(
+        self,
+        *,
+        media_type: str,
+        path: str,
+        url: str,
+        content: bytes,
+    ) -> Optional[str | bytes]:
+        if self._is_text_response(media_type, path, content):
+            text = self._decode_text(response_content=content).strip()
+
+            if not text:
+                log_fail("静态抓取", "文本响应为空", url=url)
+                return None
+
+            log_ok("静态抓取", content_type=media_type or "unknown", size=len(content), url=url)
+            return text
+
+        if self._is_document_response(media_type, path):
+            log_ok("静态抓取", content_type=media_type or "unknown", size=len(content), url=url)
+            return content
+
+        log_fail("静态抓取", f"不支持的 Content-Type: {media_type or 'unknown'}", url=url)
+        return None
+
+    def _is_text_like(self, media_type: str, path: str) -> bool:
+        if media_type.startswith("text/"):
+            return True
+
+        if media_type in _TEXT_FRIENDLY_MIME_TYPES:
+            return True
+
+        if media_type.endswith("+json") or media_type.endswith("+xml"):
+            return True
+
+        if path.endswith(_TEXT_FRIENDLY_EXTENSIONS):
+            return True
+
+        return False
+
+    def _is_document_like(self, media_type: str, path: str) -> bool:
+        return media_type in _SUPPORTED_DOC_MIME_TYPES or path.endswith(_SUPPORTED_DOC_EXTENSIONS)
+
+    def _is_text_response(self, media_type: str, path: str, content: bytes) -> bool:
+        if self._is_text_like(media_type, path):
+            return True
+
+        head = content[:512].lstrip().lower()
+        if head.startswith(b"<!doctype html") or head.startswith(b"<html") or b"<html" in head[:128]:
+            return True
+
+        return False
+
+    def _is_document_response(self, media_type: str, path: str) -> bool:
+        return self._is_document_like(media_type, path)
+
+    def _decode_text(self, response_content: bytes) -> str:
+        return response_content.decode("utf-8", errors="replace")

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/static_fetcher.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/static_fetcher.py
@@ -4,8 +4,11 @@ from urllib.parse import urlparse
 
 from common.logger import log_ok, log_fail, log_error
 
+__all__ = [
+    "StaticFetcher",
+]
 
-_SUPPORTED_DOC_MIME_TYPES: Set[str] = {
+SUPPORTED_DOC_MIME_TYPES: Set[str] = {
     "application/pdf",
     "application/msword",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -15,14 +18,14 @@ _SUPPORTED_DOC_MIME_TYPES: Set[str] = {
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 }
 
-_TEXT_FRIENDLY_MIME_TYPES: Set[str] = {
+TEXT_FRIENDLY_MIME_TYPES: Set[str] = {
     "application/json",
     "application/xml",
     "application/javascript",
     "application/x-javascript",
 }
 
-_SUPPORTED_DOC_EXTENSIONS: Tuple[str, ...] = (
+SUPPORTED_DOC_EXTENSIONS: Tuple[str, ...] = (
     ".pdf",
     ".doc",
     ".docx",
@@ -32,7 +35,7 @@ _SUPPORTED_DOC_EXTENSIONS: Tuple[str, ...] = (
     ".pptx",
 )
 
-_TEXT_FRIENDLY_EXTENSIONS: Tuple[str, ...] = (
+TEXT_FRIENDLY_EXTENSIONS: Tuple[str, ...] = (
     ".txt",
     ".md",
     ".json",
@@ -40,8 +43,8 @@ _TEXT_FRIENDLY_EXTENSIONS: Tuple[str, ...] = (
     ".csv",
 )
 
-_MAX_RESPONSE_BYTES = 50 * 1024 * 1024
-_READ_CHUNK_SIZE = 64 * 1024
+MAX_RESPONSE_BYTES = 50 * 1024 * 1024
+READ_CHUNK_SIZE = 64 * 1024
 
 
 class StaticFetcher:
@@ -51,7 +54,7 @@ class StaticFetcher:
         self,
         timeout: float = 10.0,
         max_retries: int = 3,
-        max_response_bytes: int = _MAX_RESPONSE_BYTES,
+        max_response_bytes: int = MAX_RESPONSE_BYTES,
     ):
         self._timeout = timeout
         self._max_retries = max_retries
@@ -133,7 +136,7 @@ class StaticFetcher:
             return True
 
         if media_type == "application/octet-stream":
-            return path.endswith(_SUPPORTED_DOC_EXTENSIONS) or path.endswith(_TEXT_FRIENDLY_EXTENSIONS)
+            return path.endswith(SUPPORTED_DOC_EXTENSIONS) or path.endswith(TEXT_FRIENDLY_EXTENSIONS)
 
         if self._is_text_like(media_type, path):
             return True
@@ -163,7 +166,7 @@ class StaticFetcher:
         chunks = []
         total_size = 0
 
-        async for chunk in response.aiter_bytes(chunk_size=_READ_CHUNK_SIZE):
+        async for chunk in response.aiter_bytes(chunk_size=READ_CHUNK_SIZE):
             total_size += len(chunk)
 
             if total_size > self._max_response_bytes:
@@ -207,19 +210,19 @@ class StaticFetcher:
         if media_type.startswith("text/"):
             return True
 
-        if media_type in _TEXT_FRIENDLY_MIME_TYPES:
+        if media_type in TEXT_FRIENDLY_MIME_TYPES:
             return True
 
         if media_type.endswith("+json") or media_type.endswith("+xml"):
             return True
 
-        if path.endswith(_TEXT_FRIENDLY_EXTENSIONS):
+        if path.endswith(TEXT_FRIENDLY_EXTENSIONS):
             return True
 
         return False
 
     def _is_document_like(self, media_type: str, path: str) -> bool:
-        return media_type in _SUPPORTED_DOC_MIME_TYPES or path.endswith(_SUPPORTED_DOC_EXTENSIONS)
+        return media_type in SUPPORTED_DOC_MIME_TYPES or path.endswith(SUPPORTED_DOC_EXTENSIONS)
 
     def _is_text_response(self, media_type: str, path: str, content: bytes) -> bool:
         if self._is_text_like(media_type, path):

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/steel_fetcher.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/steel_fetcher.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import steel
+from steel import AsyncSteel
+
+from common.logger import log_fail, log_ok
+
+
+@dataclass(frozen=True)
+class SteelFetcherConfig:
+    base_url: str
+    timeout: float = 60.0
+    max_retries: int = 2
+    use_proxy: bool = False
+    delay_ms: float = 0.0
+    region: Optional[dict[str, Any]] = None
+    strip_output: bool = True
+
+
+class SteelFetcher:
+    """通过 Steel API 的 scrape 接口获取页面 Markdown 内容。
+
+    职责边界：
+    - 负责调用 Steel scrape；
+    - 负责 SDK client 生命周期；
+    - 负责 Steel 异常分类日志；
+    - 不做内容质量判断，不做反爬关键词过滤；
+    - 内容过滤交给 FetchCoordinator / ContentProcessor。
+    """
+
+    def __init__(self, config: SteelFetcherConfig):
+        self._config = config
+        self._client = AsyncSteel(
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_retries=config.max_retries,
+        )
+        log_ok(
+            "Steel 抓取器初始化",
+            base_url=config.base_url,
+            timeout=config.timeout,
+            max_retries=config.max_retries,
+            use_proxy=config.use_proxy,
+            delay_ms=config.delay_ms,
+        )
+
+    async def fetch(self, url: str) -> Optional[str]:
+        try:
+            kwargs: dict[str, Any] = {
+                "url": url,
+                "format": ["markdown"],
+                "use_proxy": self._config.use_proxy,
+            }
+
+            if self._config.delay_ms > 0:
+                kwargs["delay"] = self._config.delay_ms
+
+            if self._config.region is not None:
+                kwargs["region"] = self._config.region
+
+            response = await self._client.scrape(**kwargs)
+
+            markdown = response.content.markdown if response.content else None
+            if markdown is None:
+                log_fail("Steel 浏览器抓取", "响应中无 markdown 内容", url=url)
+                return None
+
+            if self._config.strip_output:
+                markdown = markdown.strip()
+                
+            if not markdown:
+                log_fail("Steel 浏览器抓取", "markdown 内容为空", url=url)
+                return None
+
+            return markdown
+
+        except steel.RateLimitError as e:
+            log_fail("Steel 浏览器抓取", f"触发限流: {e}", url=url)
+            return None
+
+        except steel.APITimeoutError as e:
+            log_fail("Steel 浏览器抓取", f"请求超时: {e}", url=url)
+            return None
+
+        except steel.APIConnectionError as e:
+            log_fail("Steel 浏览器抓取", f"连接失败: {e}", url=url)
+            return None
+
+        except steel.APIStatusError as e:
+            log_fail(
+                "Steel 浏览器抓取",
+                f"HTTP {e.status_code}: {e.response}",
+                url=url,
+            )
+            return None
+
+        except steel.APIError as e:
+            log_fail("Steel 浏览器抓取", f"Steel API 错误: {e}", url=url)
+            return None
+
+        except Exception as e:
+            log_fail("Steel 浏览器抓取", e, url=url)
+            return None
+

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/steel_fetcher.py
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/fetcher/steel_fetcher.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import steel
 from steel import AsyncSteel
 
 from common.logger import log_fail, log_ok
+
+__all__ = [
+    "SteelFetcher",
+    "SteelFetcherConfig",
+]
 
 
 @dataclass(frozen=True)
@@ -16,20 +21,12 @@ class SteelFetcherConfig:
     max_retries: int = 2
     use_proxy: bool = False
     delay_ms: float = 0.0
-    region: Optional[dict[str, Any]] = None
+    region: Optional[Dict[str, Any]] = None
     strip_output: bool = True
 
 
 class SteelFetcher:
-    """通过 Steel API 的 scrape 接口获取页面 Markdown 内容。
-
-    职责边界：
-    - 负责调用 Steel scrape；
-    - 负责 SDK client 生命周期；
-    - 负责 Steel 异常分类日志；
-    - 不做内容质量判断，不做反爬关键词过滤；
-    - 内容过滤交给 FetchCoordinator / ContentProcessor。
-    """
+    """通过 Steel API 的 scrape 接口获取页面 Markdown 内容"""
 
     def __init__(self, config: SteelFetcherConfig):
         self._config = config
@@ -49,7 +46,7 @@ class SteelFetcher:
 
     async def fetch(self, url: str) -> Optional[str]:
         try:
-            kwargs: dict[str, Any] = {
+            kwargs: Dict[str, Any] = {
                 "url": url,
                 "format": ["markdown"],
                 "use_proxy": self._config.use_proxy,
@@ -70,7 +67,7 @@ class SteelFetcher:
 
             if self._config.strip_output:
                 markdown = markdown.strip()
-                
+
             if not markdown:
                 log_fail("Steel 浏览器抓取", "markdown 内容为空", url=url)
                 return None

--- a/services/wisepen-chat-service/src/chat/application/web_fetch/local_web_fetcher.js
+++ b/services/wisepen-chat-service/src/chat/application/web_fetch/local_web_fetcher.js
@@ -1,0 +1,427 @@
+const { chromium } = require('rebrowser-playwright');
+const TurndownService = require('turndown');
+
+// ---------------------------------------------------------------------------
+// 配置常量
+// ---------------------------------------------------------------------------
+const NAVIGATION_TIMEOUT_MS = 60000;
+const NETWORK_IDLE_TIMEOUT_MS = 8000;
+
+const MAX_SCROLL_STEPS = 8;
+const SCROLL_DELAY_MS = 700;
+const POST_SCROLL_IDLE_MS = 1200;
+
+const MIN_CONTENT_TEXT_LENGTH = 200;
+
+const BLOCKED_RESOURCE_TYPES = new Set([
+  'image',
+  'media',
+  'font',
+  'stylesheet',
+]);
+
+const BROWSER_ARGS = [
+  '--disable-blink-features=AutomationControlled',
+  '--no-sandbox',
+  '--disable-dev-shm-usage',
+  '--disable-infobars',
+  '--disable-background-networking',
+  '--disable-component-extensions-with-background-pages',
+  '--disable-default-apps',
+  '--disable-extensions-http-throttling',
+  '--disable-sync',
+  '--disable-translate',
+  '--metrics-recording-only',
+  '--mute-audio',
+  '--no-first-run',
+  '--safebrowsing-disable-auto-update',
+  '--lang=zh-CN',
+];
+
+const PROXY_ENV_KEYS = [
+  'HTTPS_PROXY',
+  'https_proxy',
+  'HTTP_PROXY',
+  'http_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+];
+
+const NO_PROXY_ENV_KEYS = ['NO_PROXY', 'no_proxy'];
+
+// ---------------------------------------------------------------------------
+// Markdown 转换器
+// ---------------------------------------------------------------------------
+const turndownService = new TurndownService({
+  headingStyle: 'atx',
+  codeBlockStyle: 'fenced',
+  bulletListMarker: '-',
+});
+
+turndownService.addRule('ignore-base64-images', {
+  filter: node =>
+    node.nodeName === 'IMG' &&
+    node.getAttribute('src')?.startsWith('data:image/'),
+  replacement: () => '',
+});
+
+// ---------------------------------------------------------------------------
+// 工具函数
+// ---------------------------------------------------------------------------
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function normalizeMarkdown(markdown) {
+  return markdown
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function writeStdout(content) {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(content, error => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function envProxyConfig() {
+  const proxyValue = PROXY_ENV_KEYS
+    .map(key => process.env[key])
+    .find(value => value && value.trim());
+
+  if (!proxyValue) return undefined;
+
+  const raw = proxyValue.includes('://') ? proxyValue : `http://${proxyValue}`;
+  let parsed;
+
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return undefined;
+  }
+
+  if (!parsed.hostname) return undefined;
+
+  const proxy = {
+    server: `${parsed.protocol}//${parsed.hostname}${parsed.port ? `:${parsed.port}` : ''}`,
+  };
+
+  if (parsed.username) proxy.username = decodeURIComponent(parsed.username);
+  if (parsed.password) proxy.password = decodeURIComponent(parsed.password);
+
+  const bypass = NO_PROXY_ENV_KEYS
+    .map(key => process.env[key])
+    .filter(Boolean)
+    .join(',');
+
+  if (bypass) proxy.bypass = bypass;
+
+  return proxy;
+}
+
+async function autoScroll(page) {
+  let previousHeight = 0;
+  let stableCount = 0;
+
+  for (let step = 0; step < MAX_SCROLL_STEPS; step++) {
+    const state = await page.evaluate(() => {
+      const documentElement = document.documentElement;
+      const body = document.body;
+
+      const scrollHeight = Math.max(
+        documentElement?.scrollHeight || 0,
+        body?.scrollHeight || 0
+      );
+
+      const viewportHeight = window.innerHeight || 768;
+      const currentY = window.scrollY || window.pageYOffset || 0;
+
+      const nearBottom =
+        currentY + viewportHeight >= scrollHeight - 16;
+
+      if (!nearBottom) {
+        const delta = Math.floor(viewportHeight * (0.85 + Math.random() * 0.25));
+        window.scrollBy({
+          top: delta,
+          behavior: 'auto',
+        });
+      }
+
+      return {
+        scrollHeight,
+        currentY,
+        nearBottom,
+      };
+    });
+
+    if (state.scrollHeight === previousHeight) {
+      stableCount += 1;
+    } else {
+      stableCount = 0;
+      previousHeight = state.scrollHeight;
+    }
+
+    if (state.nearBottom && stableCount >= 1) {
+      break;
+    }
+
+    await sleep(SCROLL_DELAY_MS + Math.floor(Math.random() * 300));
+  }
+
+  await sleep(POST_SCROLL_IDLE_MS);
+}
+
+async function extractPageData(page) {
+  return page.evaluate((minTextLength) => {
+    const removeSelectors = [
+      'script',
+      'style',
+      'noscript',
+      'iframe',
+      'template',
+      'canvas',
+      'svg',
+      'ad',
+      '.ad',
+      '.ads',
+      '#ad',
+      '#ads',
+      '[class*="advert"]',
+      '[id*="advert"]',
+      '[class*="banner"]',
+      '[id*="banner"]',
+      'img[src^="data:image/"]',
+    ];
+
+    document
+      .querySelectorAll(removeSelectors.join(','))
+      .forEach(element => element.remove());
+
+    const contentSelectors = [
+      'article',
+      'main',
+      '[role="main"]',
+      '.article',
+      '.post',
+      '.entry-content',
+      '.post-content',
+      '.article-content',
+      '.content',
+      '#content',
+      '#main',
+    ];
+
+    let bestElement = null;
+    let bestTextLength = 0;
+
+    for (const selector of contentSelectors) {
+      const elements = Array.from(document.querySelectorAll(selector));
+
+      for (const element of elements) {
+        const textLength = element.innerText
+          ? element.innerText.trim().length
+          : 0;
+
+        if (textLength > bestTextLength) {
+          bestElement = element;
+          bestTextLength = textLength;
+        }
+      }
+    }
+
+    const body = document.body;
+    const selectedElement =
+      bestElement && bestTextLength >= minTextLength
+        ? bestElement
+        : body;
+
+    return {
+      title: document.title || '',
+      html: selectedElement ? selectedElement.innerHTML : '',
+      usedBodyFallback: selectedElement === body,
+      selectedTextLength: selectedElement?.innerText?.trim().length || 0,
+    };
+  }, MIN_CONTENT_TEXT_LENGTH);
+}
+
+// ---------------------------------------------------------------------------
+// 主抓取逻辑
+// ---------------------------------------------------------------------------
+async function fetchUrl(url) {
+  process.stderr.write(`Fetching: ${url}\n`);
+
+  let browser;
+  let context;
+
+  try {
+    const launchOptions = {
+      headless: true,
+      args: BROWSER_ARGS,
+    };
+
+    const proxy = envProxyConfig();
+    if (proxy) {
+      launchOptions.proxy = proxy;
+    }
+
+    browser = await chromium.launch(launchOptions);
+
+    context = await browser.newContext({
+      locale: 'zh-CN',
+      timezoneId: 'Asia/Shanghai',
+      viewport: {
+        width: 1366 + Math.floor(Math.random() * 100),
+        height: 768 + Math.floor(Math.random() * 100),
+      },
+    });
+
+    await context.route('**/*', route => {
+      const resourceType = route.request().resourceType();
+
+      if (BLOCKED_RESOURCE_TYPES.has(resourceType)) {
+        return route.abort();
+      }
+
+      return route.continue();
+    });
+
+    await context.addInitScript(() => {
+      try {
+        Object.defineProperty(navigator, 'webdriver', {
+          get: () => undefined,
+          configurable: true,
+        });
+      } catch (_) {
+        // best-effort
+      }
+
+      try {
+        const permissions = window.navigator.permissions;
+        const originalQuery = permissions?.query;
+
+        if (originalQuery) {
+          permissions.query = function query(parameters) {
+            return parameters?.name === 'notifications'
+              ? Promise.resolve({ state: Notification.permission })
+              : originalQuery.call(this, parameters);
+          };
+        }
+      } catch (_) {
+        // best-effort
+      }
+
+      try {
+        if (!window.chrome) {
+          window.chrome = {
+            runtime: {},
+            loadTimes() { },
+            csi() { },
+            app: {},
+          };
+        }
+      } catch (_) {
+        // best-effort
+      }
+
+      try {
+        delete window.__pwInitScripts;
+        delete window.__playwright__binding__;
+      } catch (_) {
+        // best-effort
+      }
+    });
+
+    const page = await context.newPage();
+
+    page.setDefaultTimeout(NAVIGATION_TIMEOUT_MS);
+    page.setDefaultNavigationTimeout(NAVIGATION_TIMEOUT_MS);
+
+    await page.goto(url, {
+      waitUntil: 'domcontentloaded',
+      timeout: NAVIGATION_TIMEOUT_MS,
+    });
+
+    await page
+      .waitForLoadState('networkidle', {
+        timeout: NETWORK_IDLE_TIMEOUT_MS,
+      })
+      .catch(() => {
+        // 现代页面常有长连接、埋点、轮询。
+        // networkidle 超时不代表失败。
+      });
+
+    await autoScroll(page);
+
+    const pageData = await extractPageData(page);
+
+    process.stderr.write(
+      `Extracted text length: ${pageData.selectedTextLength}, fallbackToBody: ${pageData.usedBodyFallback}\n`
+    );
+
+    const markdown = normalizeMarkdown(
+      turndownService.turndown(pageData.html)
+    );
+
+    if (!markdown) {
+      throw new Error('No readable content');
+    }
+
+    await writeStdout(markdown);
+  } catch (error) {
+    process.stderr.write(`Error: ${error.message}\n`);
+
+    try {
+      const errorPage = context?.pages?.()[0];
+
+      if (errorPage) {
+        const screenshot = await errorPage.screenshot({
+          type: 'jpeg',
+          quality: 30,
+          fullPage: false,
+        });
+
+        process.stderr.write(
+          `[screenshot] ${screenshot.toString('base64').slice(0, 200)}...\n`
+        );
+      }
+    } catch (_) {
+      // best-effort
+    }
+
+    throw error;
+  } finally {
+    if (context) {
+      await context.close().catch(() => { });
+    }
+
+    if (browser) {
+      await browser.close().catch(() => { });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI 入口
+// ---------------------------------------------------------------------------
+async function main() {
+  const url = process.argv[2];
+
+  if (!url) {
+    process.stderr.write('Usage: node local_web_fetcher.js <url>\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    await fetchUrl(url);
+  } catch (_) {
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/services/wisepen-chat-service/src/chat/container.py
+++ b/services/wisepen-chat-service/src/chat/container.py
@@ -28,6 +28,9 @@ from chat.application.tools import (
     SearchHistoricalMessagesTool,
     LoadSkillTool,
     LoadSkillAssetTool,
+    WebSearchTool,
+    WebFetchTool,
+    BrowseInteractTool,
 )
 from common.clients.file_storage import FileStorageClient
 from common.cloud.nacos_client import nacos_client_manager
@@ -86,16 +89,16 @@ class Container(containers.DeclarativeContainer):
     oss_skill_asset_loader = providers.Singleton(
         OssSkillAssetLoader,
         file_storage_client=file_storage_client,
-        cache_dir=settings.SKILL_OSS_CACHE_DIR,
+        cache_dir=settings.skill_oss_cache_path,
         cache_ttl_seconds=settings.SKILL_OSS_CACHE_TTL_SECONDS,
         gc_interval_seconds=settings.SKILL_OSS_CACHE_GC_INTERVAL_SECONDS,
     )
-    # 开发态（profile=dev）使用 LocalFSSkillAssetLoader
-    # 生产态（profile=prod）使用 OssSkillAssetLoader
-    if bootstrap_settings.IS_DEV:
+    # 开发态使用 LocalFSSkillAssetLoader
+    # 线上态使用 OssSkillAssetLoader
+    if settings.DEV:
         skill_asset_loader = providers.Singleton(
             LocalFSSkillAssetLoader,
-            root_dir=str(settings.SKILL_ASSETS_CACHE_PATH),
+            root_dir=str(settings.skill_assets_cache_path),
             oss_fallback=oss_skill_asset_loader,
         )
     else:
@@ -133,11 +136,27 @@ class Container(containers.DeclarativeContainer):
         skill_repo=skill_repo,
         skill_asset_loader=skill_asset_loader,
     )
+    # WebSearchTool
+    web_search_tool = providers.Singleton(
+        WebSearchTool,
+    )
+    # WebFetchTool
+    web_fetch_tool = providers.Singleton(
+        WebFetchTool,
+    )
+
+    # BrowserInteractTool
+    browse_interact_tool = providers.Singleton(
+        BrowseInteractTool,
+    )
 
     tool_providers = providers.List(
         search_history_tool,
         load_skill_tool,
         load_skill_asset_tool,
+        web_search_tool,
+        web_fetch_tool,
+        browse_interact_tool,
     )
 
     tool_registry = providers.Singleton(

--- a/services/wisepen-chat-service/src/chat/core/config/app_settings.py
+++ b/services/wisepen-chat-service/src/chat/core/config/app_settings.py
@@ -64,7 +64,7 @@ class AppSettings(BaseModel):
 
     # Token 动态滑动窗口 + 双水位压缩配置
     # 模型上下文窗口总大小（token 数），默认对齐 gpt-4o 的 128k 上下文 128000
-    CTX_TOKEN_LIMIT: int = 32000
+    CTX_TOKEN_LIMIT: int = 128000
     # 高水位线（触发阈值）：上下文累计 Token 达到此比例时触发摘要压缩
     CTX_HIGH_WATERMARK_RATIO: float = 0.8
     # 低水位线（安全退役线）：切分时按 Token 保留此比例以内的最新明细

--- a/services/wisepen-chat-service/src/chat/core/config/app_settings.py
+++ b/services/wisepen-chat-service/src/chat/core/config/app_settings.py
@@ -1,98 +1,119 @@
+import os
 import yaml
 import asyncio
 import threading
 from pathlib import Path
 from typing import Literal
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
+from chat.core.config.bootstrap_settings import bootstrap_settings
 from common.cloud.nacos_client import nacos_client_manager
 from common.logger import log_event, log_error
 
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ENV_FILE_PATH = os.path.join(BASE_DIR, ".env")
+
 SERVICE_ROOT = Path(__file__).resolve().parents[4]
 
-
+# 全量应用配置, 必须由Nacos提供，漏配启动报错
 class AppSettings(BaseModel):
-    """
-    由 Nacos 提供的全量业务配置
-    extra=forbid 校验, 预防字段错误
-    """
+    APP_NAME: str
+    SERVICE_NAME: str
+    SERVICE_HOST: str
+    SERVICE_PORT: int
+    DEV: bool
+    LOG_LEVEL: str
 
-    model_config = ConfigDict(extra="forbid")
-
-    # LLM 默认网关配置（作为 fallback，主对话链路从 Provider 表动态获取）
+    # LLM 默认网关配置（作为 fallback，主对话链路已从 Provider 表动态获取）
     LLM_BASE_URL: str
     LLM_API_KEY: str
+
     DEFAULT_MODEL_ID: int = 1
 
-    # 模型配置 (请求依赖 LLM 默认网关配置)
-    # Memory相关模型
-    MEMORY_LLM_MODEL: str
-    MEMORY_EMBEDDING_MODEL: str
-    MEMORY_RERANKER_ZE_MODEL: str
-    ZERO_ENTROPY_API_KEY: str
-
-    # 摘要模型
-    SUMMARY_MODEL: str
-
-    # 安全配置
-    # 与 APISIX 网关约定的请求来源 token
-    FROM_SOURCE_SECRET: str = "APISIX-wX0iR6tY"
-
     # Kafka 配置
-    KAFKA_BOOTSTRAP_SERVERS: str
+    KAFKA_BOOTSTRAP_SERVERS: str = "wisepen-dev-server:9094"
     KAFKA_TOKEN_CONSUMPTION_TOPIC: str = "wisepen-user-token-consumption-topic"
 
-    # Redis / MongoDB / Qdrant 配置
+    # Memory 使用的模型
+    MEMORY_LLM_MODEL: str = "gpt-4o"
+    MEMORY_EMBEDDING_MODEL: str = "text-embedding-3-large"
+    MEMORY_RERANKER_ZE_MODEL: str = "zerank-1"
+    ZERO_ENTROPY_API_KEY: str
+
+    # 摘要压缩使用的轻量级模型（调用成本低、速度快）
+    SUMMARY_MODEL: str = "openai/gemini-3-flash-preview"
+
+    # 安全配置：与 APISIX 网关约定的防绕过 Token
+    FROM_SOURCE_SECRET: str
+
+    # Redis
     REDIS_URL: str
+    # MongoDB
     MONGODB_URL: str
     MONGODB_DB_NAME: str
+    # Qdrant (Mem0 长期语义记忆向量存储)
     QDRANT_HOST: str
     QDRANT_PORT: int = 6333
     QDRANT_PASSWORD: str
 
-    # 参数配置
+    # Web Search 工具配置
+    TAVILY_API_KEY: str = "dummy_key"
 
-    # Token 动态滑动窗口 + 双水位压缩
-    # 模型上下文窗口总大小（token 数），默认对齐 gpt-4o 的 128k 上下文
-    CTX_TOKEN_LIMIT: int = 128000
+    # Browse URL 工具配置
+    STEEL_BASE_URL: str = "http://localhost:3000"
+
+    # Token 动态滑动窗口 + 双水位压缩配置
+    # 模型上下文窗口总大小（token 数），默认对齐 gpt-4o 的 128k 上下文 128000
+    CTX_TOKEN_LIMIT: int = 32000
     # 高水位线（触发阈值）：上下文累计 Token 达到此比例时触发摘要压缩
     CTX_HIGH_WATERMARK_RATIO: float = 0.8
-    # 低水位线（安全退役线）：切分时按 Token 保留此比例以内的最新明细。
+    # 低水位线（安全退役线）：切分时按 Token 保留此比例以内的最新明细
     # 最老的 (HIGH - LOW) 比例的 Token 对应的消息将被送去摘要
     CTX_LOW_WATERMARK_RATIO: float = 0.5
     # Redis 回填时从 MongoDB 拉取的历史消息条数上限
     CTX_FALLBACK_HISTORY_LIMIT: int = 20
 
-    # Agentic ReAct 循环
+    # Agentic ReAct 循环配置
     # ReAct 最大推理迭代次数，防止工具调用产生无限循环
-    AGENT_MAX_ITERATIONS: int = 5
+    AGENT_MAX_ITERATIONS: int = 15
     # 工具返回内容的字符截断上限（约 ~1000 token），防止超长结果撑爆后续迭代的上下文水位
     TOOL_RESULT_MAX_CHARS: int = 4000
 
-    # Skill 系统配置
-    # 开发期 fixture 根目录：bootstrap_settings.is_dev=True 时 LocalFS 加载器先在这里
-    # 找资产，找不到才回退 OSS。生产形态完全不读这个目录，直接走 OssSkillAssetLoader。
+    # Skill 子系统配置（chat-service 作为只读消费方）
+
+    # 开发期 fixture 根目录：DEV=True 时 LocalFS 加载器先在这里找资产，找不到才回退 OSS
+    # 生产形态（DEV=False）完全不读这个目录，直接走 OssSkillAssetLoader
     SKILL_ASSETS_CACHE_DIR: str = "dev_fixtures/skill_bundles"
     @property
-    def SKILL_ASSETS_CACHE_PATH(self) -> Path:
+    def skill_assets_cache_path(self) -> Path:
         path = Path(self.SKILL_ASSETS_CACHE_DIR)
         if path.is_absolute():
             return path
         return (SERVICE_ROOT / path).resolve()
+
     # OSS 资产本地磁盘缓存目录（运行期管理，GC 自动清理）
-    SKILL_OSS_CACHE_DIR: str = "/var/skill_oss_cache"
+    SKILL_OSS_CACHE_DIR: str = "dev_fixtures/skill_oss_cache"
+    @property
+    def skill_oss_cache_path(self) -> Path:
+        path = Path(self.SKILL_OSS_CACHE_DIR)
+        if path.is_absolute():
+            return path
+        return (SERVICE_ROOT / path).resolve()
+
     # 缓存文件 TTL：mtime 距今超过该秒数 → GC 清理（默认 6 小时）
     SKILL_OSS_CACHE_TTL_SECONDS: int = 6 * 3600
     # GC 扫描周期（秒）
     SKILL_OSS_CACHE_GC_INTERVAL_SECONDS: int = 30 * 60
+
     # Matcher 每轮给 LLM 暴露的 skill 候选上限（受控披露，防 LLM 误加载）
     SKILL_MATCH_TOP_K: int = 2
-    # Skill 元数据缓存 TTL（秒）。用户/Java 端发布的新 Skill 最坏需等 TTL 才被当前副本感知。
-    # 过小会增加 Mongo 读压力；过大会让新 Skill 生效滞后。
-    # 未来接 Kafka 事件驱动刷新后可放大此值作为兜底轮询。
+
+    # Skill 元数据缓存 TTL（秒）。用户/Java 端发布的新 Skill 最坏需等 TTL 才被当前副本感知
+    # 过小会增加 Mongo 读压力；过大会让新 Skill 生效滞后
+    # 未来接 Kafka 事件驱动刷新后可放大此值作为兜底轮询
     SKILL_CACHE_TTL_SECONDS: int = 30
 
-    # 内部 RPC / 服务发现 配置
+    # ---- 内部 RPC / 服务发现（wisepen-common 基建） ----
     # Nacos 服务发现客户端侧负载均衡策略：weighted_random | round_robin | random
     RPC_LB_STRATEGY: Literal["weighted_random", "round_robin", "random"] = "weighted_random"
     # 单次请求超时（秒）
@@ -101,7 +122,6 @@ class AppSettings(BaseModel):
     RPC_DEFAULT_RETRIES: int = 2
     # ServiceDiscovery 本地缓存兜底 TTL（秒），即便订阅通道断连也会周期性强制 list
     SERVICE_DISCOVERY_CACHE_TTL_SECONDS: float = 30.0
-
 
 def _run_async(coro):
     """在新线程的独立事件循环中执行协程，兼容 uvicorn 启动时已有运行中事件循环的场景。"""
@@ -127,10 +147,12 @@ def load_settings() -> AppSettings:
         log_event("从 Nacos 拉取核心业务配置")
         raw_yaml = _run_async(nacos_client_manager.pull_config())
         config_dict = yaml.safe_load(raw_yaml) if raw_yaml else {}
-        return AppSettings(**(config_dict or {}))
+        full_config = {**bootstrap_settings.model_dump(), **config_dict}
+        if "DEV" not in full_config:
+            full_config["DEV"] = bootstrap_settings.IS_DEV
+        return AppSettings(**full_config)
     except Exception as e:
         log_error("Nacos 配置拉取或解析", e)
         raise
-
 
 settings = load_settings()


### PR DESCRIPTION
- 将文档解析逻辑从 ContentProcessor 中拆出为 DocumentParser，并使用 parse() 作为统一入口
- 让 ContentProcessor 聚焦于 str/bytes 分流、HTML 清洗和纯文本过滤，职责边界更清晰
- 为文档内容单独引入较低长度阈值，避免短 XLSX/PPTX/DOCX 等有效文档被误判为无效
- 优化 StaticFetcher，增加流式读取、响应体大小限制和读取前 Content-Type/扩展名预判
- 补充文档和文本扩展名兜底，支持 application/*+json 与 application/*+xml 等常见文本类型
- 将 SteelFetcher 改为配置化初始化，通过 SteelFetcherConfig 管理 base_url、timeout、重试、代理、延迟等参数
- 让 SteelFetcher 聚焦 Steel API 适配、Markdown 提取和异常分类，避免配置散落在调用方
- 调整 FetchCoordinator 对 StaticFetcher、SteelFetcher、LocalScriptFetcher 的编排，使抓取链路职责更明确
- 精简 WebFetchTool 的结果处理逻辑，保持工具层只负责 URL 校验、调用协调器和 Markdown 截断
- 优化本地浏览器 JS 抓取脚本，拦截重资源、动态滚动、正文容器优先提取并规范 Markdown 输出
- 强化 Python 子进程调用稳定性，保持 stdout 只输出正文、stderr 输出诊断信息