### PR TITLE
refactor(web_search): 从单文件搜索工具演进为多引擎降级搜索模块

### DIFF
--- a/services/wisepen-chat-service/src/chat/application/tools/web_search_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/web_search_tool.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from chat.application.web_search import SearchResponse, create_search_coordinator
+from chat.application.web_search.search_coordinator import SearchCoordinator
+from chat.application.web_search.models import ImageResult
+from chat.application.web_search.utils import count_unique_domains, extract_domain
+from chat.application.web_fetch.fetch_coordinator import FetchCoordinator
+from chat.core.config.app_settings import settings
+from chat.domain.interfaces.tool import BaseTool
+from common.logger import log_fail
+
+__all__ = [
+    "WebSearchTool",
+]
+
+TRUNCATION_MARKER = "\n\n...(Search result truncated due to length)"
+
+TOOL_DESCRIPTION = (
+    "Searches the web using a staged fallback chain: "
+    "fresh cache, SearXNG, DuckDuckGo buffer, stale cache, then Tavily as paid fallback.\n\n"
+    "Use this tool when current information, external facts, source lookup, or web evidence is required.\n\n"
+    "Use freshness_required=true when the user asks for time-sensitive information, "
+    "such as latest news, current facts, recent releases, current office holders, prices, weather, scores, schedules, or events happening now.\n\n"
+    "Use with_images=true when the user asks for pictures, photos, visual references, "
+    "locations, people, animals, products, UI screenshots, or other visual information.\n\n"
+    "Use fetch_top_pages=true only when snippets are insufficient and the user needs a detailed source-backed answer."
+)
+
+TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": "The web search query string.",
+        },
+        "max_results": {
+            "type": "integer",
+            "description": "Maximum number of web results to return. Default is 5. Maximum is 10.",
+            "default": 5,
+            "minimum": 1,
+            "maximum": 10,
+        },
+        "with_images": {
+            "type": "boolean",
+            "description": (
+                "Whether to include relevant image results. "
+                "Use this when the user asks for pictures, photos, visual references, locations, "
+                "people, products, animals, screenshots, or other visual information."
+            ),
+            "default": False,
+        },
+        "freshness_required": {
+            "type": "boolean",
+            "description": (
+                "Whether the search must avoid stale cached results. "
+                "Set to true for time-sensitive queries such as latest news, current facts, prices, "
+                "weather, scores, schedules, recent releases, or current office holders."
+            ),
+            "default": False,
+        },
+        "fetch_top_pages": {
+            "type": "boolean",
+            "description": (
+                "Whether to fetch and extract content from the top 1-2 result pages. "
+                "Use this when the user asks for detailed summary, source-backed answer, "
+                "or when snippets are insufficient."
+            ),
+            "default": False,
+        },
+    },
+    "required": ["query"],
+}
+
+
+class WebSearchTool(BaseTool):
+    def __init__(self, coordinator: Optional[SearchCoordinator] = None):
+        self._coordinator = coordinator or create_search_coordinator()
+        self._fetcher = FetchCoordinator(settings.STEEL_BASE_URL)
+
+    @property
+    def name(self) -> str:
+        return "web_search"
+
+    @property
+    def description(self) -> str:
+        return TOOL_DESCRIPTION
+
+    @property
+    def parameters_schema(self) -> Dict[str, Any]:
+        return TOOL_SCHEMA
+
+    async def execute(self, context: Dict[str, Any], **kwargs: Any) -> str:
+        session_id: Optional[str] = context.get("session_id")
+        if not session_id:
+            return "[Tool Error] Missing session_id in execution context."
+
+        query = kwargs.get("query", "").strip()
+        if not query:
+            return "[Tool Error] Missing required query parameter."
+
+        max_results = kwargs.get("max_results", 5)
+        max_results = max(1, min(max_results, 10))
+
+        with_images = kwargs.get("with_images", False)
+        freshness_required = kwargs.get("freshness_required", False)
+        fetch_top_pages = kwargs.get("fetch_top_pages", False)
+
+        try:
+            response = await self._coordinator.search(
+                query=query,
+                max_results=max_results,
+                with_images=with_images,
+                freshness_required=freshness_required,
+            )
+        except Exception as e:
+            log_fail(
+                "联网搜索工具",
+                e,
+                session_id=session_id,
+                query=query,
+                max_results=max_results,
+                with_images=with_images,
+                freshness_required=freshness_required,
+            )
+            return "[Tool Error] Unexpected error while searching the web."
+
+        if response is None:
+            return "[Tool Result] Failed to search the web (all search methods exhausted)."
+
+        if not has_search_content(response):
+            return "[Tool Result] No results found for the query."
+
+        extra_contents: list[str] = []
+
+        if fetch_top_pages:
+            extra_contents = await self._fetch_top_pages(response, limit=2)
+
+        return format_response(response, extra_contents=extra_contents)
+
+    async def _fetch_top_pages(
+        self,
+        response: SearchResponse,
+        *,
+        limit: int = 2,
+    ) -> list[str]:
+        contents: list[str] = []
+
+        for result in response.results[:limit]:
+            url = result.url.strip()
+            if not url:
+                continue
+
+            try:
+                content = await self._fetcher.fetch(url)
+            except Exception:
+                continue
+
+            if not content:
+                continue
+
+            contents.append(
+                f"Fetched page: {url}\n"
+                f"{content[:3000]}"
+            )
+
+        return contents
+
+
+def has_search_content(response: SearchResponse) -> bool:
+    return bool(response.answer or response.results or response.images)
+
+
+def format_response(
+    response: SearchResponse,
+    *,
+    extra_contents: list[str] | None = None,
+) -> str:
+    unique_domains = count_unique_domains(tuple(response.results))
+
+    lines = [f"[Tool Result] Web search results for: {response.query}"]
+
+    if response.source:
+        lines.append(f"Source: {response.source}")
+
+    lines.append(
+        f"Summary: {len(response.results)} results, "
+        f"{len(response.images)} query-level images, "
+        f"{unique_domains} unique domains."
+    )
+
+    if response.source == "stale_cache":
+        lines.append(
+            "Note: These results came from stale cache and may be outdated."
+        )
+
+    if response.answer:
+        lines.append(f"\nAnswer:\n{response.answer}")
+
+    if response.results:
+        lines.append("\nResults:")
+
+    for index, result in enumerate(response.results, 1):
+        title = result.title.strip() or result.url or "(no title)"
+        url = result.url.strip()
+        snippet = result.snippet.strip()
+        domain = extract_domain(url)
+
+        lines.append(f"\n{index}. {title}")
+
+        if domain:
+            lines.append(f"   Domain: {domain}")
+
+        if url:
+            lines.append(f"   URL: {url}")
+
+        if snippet:
+            lines.append(f"   Snippet: {snippet}")
+
+        if result.images:
+            lines.append("   Images:")
+            for image in result.images[:2]:
+                lines.append(format_image_line(image, indent="      "))
+
+    if response.images:
+        lines.append("\nQuery-level images:")
+        for image in response.images[:5]:
+            lines.append(format_image_line(image, indent="   "))
+
+    if extra_contents:
+        lines.append("\nFetched top pages:")
+        for index, content in enumerate(extra_contents, 1):
+            lines.append(f"\n--- Page {index} ---")
+            lines.append(content)
+
+    return normalize_search_result("\n".join(lines))
+
+
+def format_image_line(image: ImageResult, *, indent: str) -> str:
+    url = image.url.strip()
+    desc = image.desc.strip() if image.desc else ""
+
+    line = f"{indent}- {url}"
+
+    details: list[str] = []
+
+    if desc:
+        details.append(desc)
+
+    if image.resolution:
+        details.append(f"resolution={image.resolution}")
+
+    if image.source_url:
+        details.append(f"source={image.source_url}")
+
+    if details:
+        line += f" ({'; '.join(details)})"
+
+    return line
+
+
+def normalize_search_result(result: str) -> str:
+    result = result.strip()
+
+    if len(result) > settings.TOOL_RESULT_MAX_CHARS:
+        limit = settings.TOOL_RESULT_MAX_CHARS
+        keep_len = max(0, limit - len(TRUNCATION_MARKER))
+        result = result[:keep_len].rstrip() + TRUNCATION_MARKER
+
+    return result

--- a/services/wisepen-chat-service/src/chat/application/web_search/__init__.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/__init__.py
@@ -1,0 +1,27 @@
+from chat.application.web_search.search_coordinator import (
+    SearchCoordinator,
+    SearchStage,
+    create_search_coordinator,
+)
+from chat.application.web_search.models import (
+    ImageResult,
+    SearchResponse,
+    SearchResult,
+)
+from chat.application.web_search.cache import (
+    SearchCache,
+    SearchCacheKey,
+    make_search_cache_key,
+)
+
+__all__ = [
+    "ImageResult",
+    "SearchResult",
+    "SearchResponse",
+    "SearchStage",
+    "SearchCoordinator",
+    "create_search_coordinator",
+    "SearchCache",
+    "SearchCacheKey",
+    "make_search_cache_key",
+]

--- a/services/wisepen-chat-service/src/chat/application/web_search/cache.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/cache.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Optional, Tuple
+
+from cachetools import TTLCache
+
+from chat.application.web_search.models import SearchResponse
+
+__all__ = [
+    "SearchCache",
+    "SearchCacheKey",
+    "make_search_cache_key",
+]
+
+SearchCacheKey = Tuple[str, int, bool]
+
+
+class SearchCache:
+    def __init__(
+        self,
+        *,
+        fresh_ttl: int = 3600,
+        stale_ttl: int = 86400,
+        maxsize: int = 1024,
+    ) -> None:
+        self._fresh_cache: TTLCache[SearchCacheKey, SearchResponse] = TTLCache(
+            maxsize=maxsize,
+            ttl=fresh_ttl,
+        )
+        self._stale_cache: TTLCache[SearchCacheKey, SearchResponse] = TTLCache(
+            maxsize=maxsize,
+            ttl=stale_ttl,
+        )
+        self._lock = asyncio.Lock()
+
+    async def get_fresh(
+        self,
+        key: SearchCacheKey,
+    ) -> Optional[SearchResponse]:
+        async with self._lock:
+            return self._fresh_cache.get(key)
+
+    async def get_stale(
+        self,
+        key: SearchCacheKey,
+    ) -> Optional[SearchResponse]:
+        async with self._lock:
+            return self._stale_cache.get(key)
+
+    async def set(
+        self,
+        key: SearchCacheKey,
+        response: SearchResponse,
+    ) -> None:
+        async with self._lock:
+            self._fresh_cache[key] = response
+            self._stale_cache[key] = response
+
+
+def make_search_cache_key(
+    *,
+    query: str,
+    max_results: int,
+    with_images: bool,
+) -> SearchCacheKey:
+    normalized_query = " ".join(query.strip().lower().split())
+    return normalized_query, max_results, with_images

--- a/services/wisepen-chat-service/src/chat/application/web_search/models/__init__.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/models/__init__.py
@@ -1,0 +1,14 @@
+from chat.application.web_search.models.common import ImageResult, SearchResult, SearchResponse
+from chat.application.web_search.models.tavily import TavilySearchRequest, map_tavily_response
+from chat.application.web_search.models.searxng import SearXNGSearchRequest, map_searxng_response, merge_search_responses
+
+__all__ = [
+    "ImageResult",
+    "SearchResult",
+    "SearchResponse",
+    "TavilySearchRequest",
+    "map_tavily_response",
+    "SearXNGSearchRequest",
+    "map_searxng_response",
+    "merge_search_responses",
+]

--- a/services/wisepen-chat-service/src/chat/application/web_search/models/common.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/models/common.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional, Tuple
+
+__all__ = [
+    "ImageResult",
+    "SearchResult",
+    "SearchResponse",
+    "is_valid_result",
+    "to_optional_str",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ImageResult:
+    """通用图片搜索结果"""
+
+    url: str
+    desc: Optional[str] = None
+    source_url: Optional[str] = None
+    thumbnail_url: Optional[str] = None
+    resolution: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "url", self.url.strip())
+        object.__setattr__(self, "desc", normalize_optional_str(self.desc))
+        object.__setattr__(self, "source_url", normalize_optional_str(self.source_url))
+        object.__setattr__(self, "thumbnail_url", normalize_optional_str(self.thumbnail_url))
+        object.__setattr__(self, "resolution", normalize_optional_str(self.resolution))
+
+
+@dataclass(frozen=True, slots=True)
+class SearchResult:
+    """通用网页搜索结果"""
+
+    title: str
+    url: str
+    snippet: str
+    images: Tuple[ImageResult, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "title", self.title.strip())
+        object.__setattr__(self, "url", self.url.strip())
+        object.__setattr__(self, "snippet", self.snippet.strip())
+        object.__setattr__(self, "images", tuple(self.images))
+
+
+def is_valid_result(result: SearchResult) -> bool:
+    """只过滤明显无内容的结果，不判断与 query 的语义相关性。"""
+
+    title = result.title.strip()
+    url = result.url.strip()
+    snippet = result.snippet.strip()
+
+    if not url:
+        return False
+
+    if not title and not snippet:
+        return False
+
+    if len(title) + len(snippet) < 12:
+        return False
+
+    return True
+
+
+@dataclass(frozen=True, slots=True)
+class SearchResponse:
+    """通用搜索响应"""
+
+    query: str
+    results: Tuple[SearchResult, ...] = field(default_factory=tuple)
+    answer: Optional[str] = None
+    images: Tuple[ImageResult, ...] = field(default_factory=tuple)
+
+    # fresh_cache / searxng / duckduckgo / stale_cache / tavily
+    source: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "query", self.query.strip())
+        object.__setattr__(self, "results", tuple(self.results))
+        object.__setattr__(self, "answer", normalize_optional_str(self.answer))
+        object.__setattr__(self, "images", tuple(self.images))
+        object.__setattr__(self, "source", normalize_optional_str(self.source))
+
+
+def normalize_optional_str(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+
+    value = value.strip()
+    return value or None
+
+
+def to_optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+
+    return str(value)

--- a/services/wisepen-chat-service/src/chat/application/web_search/models/searxng.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/models/searxng.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from chat.application.web_search.models.common import (
+    ImageResult,
+    SearchResponse,
+    SearchResult,
+    is_valid_result,
+    to_optional_str,
+)
+from chat.application.web_search.utils import deduplicate_results_by_domain, deduplicate_images
+from common.logger import log_fail
+
+__all__ = [
+    "SearXNGSearchRequest",
+    "map_searxng_response",
+    "merge_search_responses",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SearXNGSearchRequest:
+    query: str
+    category: Optional[str] = None
+    language: Optional[str] = None
+    safesearch: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if not self.query.strip():
+            raise ValueError("query 不能为空")
+
+    def to_params(self) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "q": self.query,
+            "format": "json",
+        }
+
+        if self.category:
+            params["categories"] = self.category
+
+        if self.language:
+            params["language"] = self.language
+
+        if self.safesearch is not None:
+            params["safesearch"] = self.safesearch
+
+        return params
+
+
+def map_searxng_response(
+    data: Mapping[str, Any],
+    *,
+    query: str,
+    max_results: int,
+    images_only: bool = False,
+) -> SearchResponse:
+    raw_results = data.get("results") or ()
+
+    if not isinstance(raw_results, Sequence) or isinstance(raw_results, str):
+        raw_results = ()
+
+    raw_count = len(raw_results)
+
+    if images_only:
+        images = tuple(
+            image
+            for item in raw_results
+            if isinstance(item, Mapping)
+            for image in map_result_images(item)
+            if image.url
+        )
+        images = deduplicate_images(images)
+
+        return SearchResponse(
+            query=query,
+            results=(),
+            answer=to_optional_str(data.get("answer")),
+            images=images[:max_results],
+        )
+
+    mapped_results: List[SearchResult] = []
+
+    for item in raw_results:
+        if not isinstance(item, Mapping):
+            continue
+
+        result = map_searxng_result(item)
+        if not is_valid_result(result):
+            continue
+
+        mapped_results.append(result)
+
+    if raw_count > 0 and not mapped_results:
+        log_fail(
+            "SearXNG结果过滤",
+            "原始结果全部被过滤",
+            query=query,
+            raw_count=raw_count,
+        )
+
+    results = deduplicate_results_by_domain(
+        tuple(mapped_results),
+        max_per_domain=2,
+    )
+
+    return SearchResponse(
+        query=query,
+        results=results[:max_results],
+        answer=to_optional_str(data.get("answer")),
+    )
+
+
+def merge_search_responses(
+    web_response: SearchResponse,
+    image_response: SearchResponse,
+) -> SearchResponse:
+    return SearchResponse(
+        query=web_response.query,
+        results=web_response.results,
+        answer=web_response.answer or image_response.answer,
+        images=image_response.images,
+        source=web_response.source or image_response.source,
+    )
+
+
+def map_searxng_result(item: Mapping[str, Any]) -> SearchResult:
+    return SearchResult(
+        title=str(item.get("title") or ""),
+        url=str(item.get("url") or ""),
+        snippet=str(item.get("content") or item.get("snippet") or ""),
+        images=map_result_images(item),
+    )
+
+
+def map_result_images(item: Mapping[str, Any]) -> Tuple[ImageResult, ...]:
+    img_url = item.get("img_src")
+    thumbnail_url = item.get("thumbnail_src") or item.get("thumbnail")
+    source_url = item.get("url")
+
+    if not img_url and not thumbnail_url:
+        return ()
+
+    return (
+        ImageResult(
+            url=str(img_url or thumbnail_url),
+            desc=to_optional_str(item.get("title")),
+            source_url=str(source_url) if source_url else None,
+            thumbnail_url=str(thumbnail_url) if thumbnail_url else None,
+            resolution=to_optional_str(item.get("resolution")),
+        ),
+    )

--- a/services/wisepen-chat-service/src/chat/application/web_search/models/tavily.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/models/tavily.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from chat.application.web_search.models.common import (
+    ImageResult,
+    SearchResponse,
+    SearchResult,
+    is_valid_result,
+    to_optional_str,
+)
+from chat.application.web_search.utils import (
+    deduplicate_results_by_domain,
+    deduplicate_images,
+)
+__all__ = [
+    "TavilySearchRequest",
+    "map_tavily_response",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class TavilySearchRequest:
+    """Tavily Search API 请求体。
+
+    只接收公共搜索语义，然后在 to_payload() 中映射为 Tavily 参数。
+    """
+
+    query: str
+    max_results: int = 5
+    with_images: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.query.strip():
+            raise ValueError("query 不能为空")
+
+        if not 1 <= self.max_results <= 20:
+            raise ValueError("max_results 必须在 1 到 20 之间")
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "query": self.query,
+            "max_results": self.max_results,
+            "include_answer": False,
+            "include_raw_content": False,
+            "include_images": self.with_images,
+            "search_depth": "basic",
+        }
+
+
+def map_tavily_response(data: Mapping[str, Any]) -> SearchResponse:
+    """将 Tavily 原始响应映射为通用 SearchResponse"""
+
+    raw_results = data.get("results") or ()
+
+    if not isinstance(raw_results, Sequence) or isinstance(raw_results, str):
+        raw_results = ()
+
+    results = tuple(
+        result
+        for item in raw_results
+        if isinstance(item, Mapping)
+        for result in (map_tavily_result(item),)
+        if is_valid_result(result)
+    )
+    results = deduplicate_results_by_domain(results, max_per_domain=2)
+
+    return SearchResponse(
+        query=str(data.get("query") or ""),
+        results=results,
+        answer=to_optional_str(data.get("answer")),
+        images=map_images(data.get("images"))[:5],
+    )
+
+
+def map_tavily_result(item: Mapping[str, Any]) -> SearchResult:
+    return SearchResult(
+        title=str(item.get("title") or ""),
+        url=str(item.get("url") or ""),
+        snippet=str(item.get("content") or item.get("snippet") or ""),
+        images=map_images(item.get("images")),
+    )
+
+
+def map_images(items: Any) -> Tuple[ImageResult, ...]:
+    if not isinstance(items, Sequence) or isinstance(items, str):
+        return ()
+
+    images: List[ImageResult] = []
+
+    for item in items:
+        image = map_image(item)
+        if image is not None:
+            images.append(image)
+
+    return deduplicate_images(images)
+
+
+def map_image(item: Any) -> Optional[ImageResult]:
+    if isinstance(item, str):
+        return ImageResult(url=item)
+
+    if not isinstance(item, Mapping):
+        return None
+
+    url = item.get("url")
+    if not url:
+        return None
+
+    desc = item.get("description") or item.get("desc") or item.get("alt")
+    source_url = item.get("source_url") or item.get("source") or item.get("page_url")
+    thumbnail_url = (
+        item.get("thumbnail_url")
+        or item.get("thumbnail")
+        or item.get("thumbnail_src")
+    )
+
+    return ImageResult(
+        url=str(url),
+        desc=str(desc) if desc is not None else None,
+        source_url=str(source_url) if source_url else None,
+        thumbnail_url=str(thumbnail_url) if thumbnail_url else None,
+    )

--- a/services/wisepen-chat-service/src/chat/application/web_search/search_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/search_coordinator.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Awaitable, Callable, List, Optional, Set, Tuple
+
+from chat.application.web_search.cache import (
+    SearchCache,
+    make_search_cache_key,
+)
+from chat.application.web_search.models import SearchResponse
+from chat.application.web_search.searcher.duckduckgo_searcher import (
+    DuckDuckGoBufferSearcher,
+)
+from chat.application.web_search.searcher.searxng_searcher import SearXNGSearcher
+from chat.application.web_search.searcher.tavily_searcher import TavilySearcher
+from chat.core.config.app_settings import settings
+from common.logger import log_fail, log_ok
+
+__all__ = [
+    "SearchStage",
+    "SearchCoordinator",
+    "create_search_coordinator",
+]
+
+SearchStageFunc = Callable[..., Awaitable[Optional[SearchResponse]]]
+
+
+@dataclass(frozen=True, slots=True)
+class SearchStage:
+    name: str
+    handler: SearchStageFunc
+    cacheable: bool = True
+
+
+class SearchCoordinator:
+    """联网搜索调度器：Fresh Cache + 显式降级链"""
+
+    def __init__(
+        self,
+        *,
+        cache: SearchCache,
+        searxng_searcher: SearXNGSearcher,
+        duckduckgo_searcher: DuckDuckGoBufferSearcher,
+        tavily_searcher: TavilySearcher,
+        continue_on_empty: bool = True,
+        disabled_stages: Optional[Set[str]] = None,
+    ) -> None:
+        self._cache = cache
+        self._searxng = searxng_searcher
+        self._duckduckgo = duckduckgo_searcher
+        self._tavily = tavily_searcher
+        self._continue_on_empty = continue_on_empty
+        self._disabled_stages = disabled_stages or set()
+
+        self._chain: Tuple[SearchStage, ...] = (
+            SearchStage("searxng", self._search_searxng, cacheable=True),
+            SearchStage("duckduckgo", self._search_duckduckgo, cacheable=True),
+            SearchStage("stale_cache", self._search_stale_cache, cacheable=False),
+            SearchStage("tavily", self._search_tavily, cacheable=True),
+        )
+
+    async def search(
+        self,
+        query: str,
+        *,
+        max_results: int = 5,
+        with_images: bool = False,
+        freshness_required: bool = False,
+    ) -> Optional[SearchResponse]:
+        key = make_search_cache_key(
+            query=query,
+            max_results=max_results,
+            with_images=with_images,
+        )
+
+        fresh = await self._cache.get_fresh(key)
+        if fresh is not None:
+            log_ok(
+                "联网搜索",
+                stage="fresh_cache",
+                query=query,
+                max_results=max_results,
+                with_images=with_images,
+                results=len(fresh.results),
+                images=len(fresh.images),
+            )
+            return with_source(fresh, "fresh_cache")
+
+        last_empty: Optional[SearchResponse] = None
+        failures: List[str] = []
+
+        for stage in self._chain:
+            if stage.name in self._disabled_stages:
+                failures.append(f"{stage.name}: disabled_by_test")
+
+                log_fail(
+                    "联网搜索跳过",
+                    "测试注入：stage 被禁用，触发降级",
+                    stage=stage.name,
+                    query=query,
+                    max_results=max_results,
+                    with_images=with_images,
+                )
+                continue
+
+            if stage.name == "stale_cache" and freshness_required:
+                failures.append("stale_cache: skipped_for_freshness_required")
+
+                log_fail(
+                    "联网搜索跳过",
+                    "freshness_required=True，跳过 stale cache",
+                    stage=stage.name,
+                    query=query,
+                    max_results=max_results,
+                    with_images=with_images,
+                )
+                continue
+
+            try:
+                response = await stage.handler(
+                    query=query,
+                    max_results=max_results,
+                    with_images=with_images,
+                )
+
+            except Exception as e:
+                failures.append(f"{stage.name}: {type(e).__name__}: {e}")
+
+                log_fail(
+                    "联网搜索",
+                    e,
+                    stage=stage.name,
+                    query=query,
+                    max_results=max_results,
+                    with_images=with_images,
+                )
+                continue
+
+            if response is None:
+                failures.append(f"{stage.name}: returned_none")
+
+                log_fail(
+                    "联网搜索",
+                    "stage 返回 None，触发降级",
+                    stage=stage.name,
+                    query=query,
+                    max_results=max_results,
+                    with_images=with_images,
+                )
+                continue
+
+            if not has_content(response):
+                last_empty = response
+                failures.append(f"{stage.name}: empty_result")
+
+                log_fail(
+                    "联网搜索",
+                    "搜索结果为空，触发降级",
+                    stage=stage.name,
+                    query=query,
+                    max_results=max_results,
+                    with_images=with_images,
+                    results=len(response.results),
+                    images=len(response.images),
+                    has_answer=bool(response.answer),
+                    source=response.source,
+                )
+
+                if self._continue_on_empty:
+                    continue
+
+                return with_source(response, stage.name)
+
+            response = with_source(response, stage.name)
+
+            if stage.cacheable:
+                await self._cache.set(key, response)
+
+            log_ok(
+                "联网搜索",
+                stage=stage.name,
+                query=query,
+                max_results=max_results,
+                with_images=with_images,
+                results=len(response.results),
+                images=len(response.images),
+            )
+
+            return response
+
+        log_fail(
+            "联网搜索",
+            "所有搜索阶段均失败",
+            query=query,
+            max_results=max_results,
+            with_images=with_images,
+            freshness_required=freshness_required,
+            failures=failures,
+        )
+
+        return last_empty
+
+    async def _search_searxng(
+        self,
+        *,
+        query: str,
+        max_results: int,
+        with_images: bool,
+    ) -> Optional[SearchResponse]:
+        return await self._searxng.search(
+            query=query,
+            max_results=max_results,
+            with_images=with_images,
+        )
+
+    async def _search_duckduckgo(
+        self,
+        *,
+        query: str,
+        max_results: int,
+        with_images: bool,
+    ) -> Optional[SearchResponse]:
+        return await self._duckduckgo.search(
+            query=query,
+            max_results=max_results,
+            with_images=with_images,
+        )
+
+    async def _search_stale_cache(
+        self,
+        *,
+        query: str,
+        max_results: int,
+        with_images: bool,
+    ) -> Optional[SearchResponse]:
+        key = make_search_cache_key(
+            query=query,
+            max_results=max_results,
+            with_images=with_images,
+        )
+
+        return await self._cache.get_stale(key)
+
+    async def _search_tavily(
+        self,
+        *,
+        query: str,
+        max_results: int,
+        with_images: bool,
+    ) -> Optional[SearchResponse]:
+        return await self._tavily.search(
+            query=query,
+            max_results=max_results,
+            with_images=with_images,
+        )
+
+
+def has_content(response: SearchResponse) -> bool:
+    return bool(response.answer or response.results or response.images)
+
+
+def with_source(response: SearchResponse, source: str) -> SearchResponse:
+    return SearchResponse(
+        query=response.query,
+        results=response.results,
+        answer=response.answer,
+        images=response.images,
+        source=source,
+    )
+
+
+def create_search_coordinator() -> SearchCoordinator:
+    cache = SearchCache(
+        fresh_ttl=settings.WEB_SEARCH_FRESH_CACHE_TTL,
+        stale_ttl=settings.WEB_SEARCH_STALE_CACHE_TTL,
+        maxsize=settings.WEB_SEARCH_CACHE_MAXSIZE,
+    )
+
+    return SearchCoordinator(
+        cache=cache,
+        searxng_searcher=SearXNGSearcher(
+            base_url=settings.SEARXNG_BASE_URL,
+            timeout=settings.SEARXNG_TIMEOUT,
+            language=settings.SEARXNG_LANGUAGE or None,
+            safesearch=settings.SEARXNG_SAFESEARCH,
+        ),
+        duckduckgo_searcher=DuckDuckGoBufferSearcher(
+            timeout=settings.DUCKDUCKGO_TIMEOUT,
+            region=settings.DUCKDUCKGO_REGION,
+            safesearch=settings.DUCKDUCKGO_SAFESEARCH,
+        ),
+        tavily_searcher=TavilySearcher(
+            api_key=settings.TAVILY_API_KEY,
+            timeout=settings.TAVILY_TIMEOUT,
+        ),
+    )

--- a/services/wisepen-chat-service/src/chat/application/web_search/searcher/__init__.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/searcher/__init__.py
@@ -1,0 +1,11 @@
+from chat.application.web_search.searcher.duckduckgo_searcher import (
+    DuckDuckGoBufferSearcher,
+)
+from chat.application.web_search.searcher.searxng_searcher import SearXNGSearcher
+from chat.application.web_search.searcher.tavily_searcher import TavilySearcher
+
+__all__ = [
+    "DuckDuckGoBufferSearcher",
+    "SearXNGSearcher",
+    "TavilySearcher",
+]

--- a/services/wisepen-chat-service/src/chat/application/web_search/searcher/duckduckgo_searcher.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/searcher/duckduckgo_searcher.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Mapping, Tuple
+
+from ddgs import DDGS
+
+from chat.application.web_search.models import ImageResult, SearchResponse, SearchResult
+from chat.application.web_search.models.common import is_valid_result
+from chat.application.web_search.utils import deduplicate_results_by_domain, deduplicate_images
+
+__all__ = [
+    "DuckDuckGoBufferSearcher",
+]
+
+
+class DuckDuckGoBufferSearcher:
+    name = "duckduckgo"
+
+    def __init__(
+        self,
+        *,
+        timeout: float = 8.0,
+        region: str = "wt-wt",
+        safesearch: str = "moderate",
+    ) -> None:
+        if timeout <= 0:
+            raise ValueError("timeout 必须大于 0")
+
+        if not region.strip():
+            raise ValueError("region 不能为空")
+
+        if not safesearch.strip():
+            raise ValueError("safesearch 不能为空")
+
+        self._timeout = timeout
+        self._region = region
+        self._safesearch = safesearch
+
+    async def search(
+        self,
+        query: str,
+        *,
+        max_results: int = 5,
+        with_images: bool = False,
+    ) -> SearchResponse:
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(
+                    self._search_sync,
+                    query,
+                    max_results,
+                    with_images,
+                ),
+                timeout=self._timeout,
+            )
+
+        except asyncio.TimeoutError as e:
+            raise RuntimeError(
+                "DuckDuckGo timeout: "
+                f"query={query!r}, max_results={max_results}, "
+                f"with_images={with_images}, timeout={self._timeout}"
+            ) from e
+
+        except Exception as e:
+            raise RuntimeError(
+                "DuckDuckGo buffer search failed: "
+                f"query={query!r}, max_results={max_results}, "
+                f"with_images={with_images}, error={type(e).__name__}: {e}"
+            ) from e
+
+    def _search_sync(
+        self,
+        query: str,
+        max_results: int,
+        with_images: bool,
+    ) -> SearchResponse:
+        ddgs_timeout = max(1, int(self._timeout))
+
+        with DDGS(timeout=ddgs_timeout) as ddgs:
+            text_items = list(
+                ddgs.text(
+                    query,
+                    region=self._region,
+                    safesearch=self._safesearch,
+                    max_results=max_results,
+                )
+            )
+
+            results = tuple(
+                result
+                for item in text_items
+                if isinstance(item, Mapping)
+                for result in (map_text_result(item),)
+                if is_valid_result(result)
+            )
+            results = deduplicate_results_by_domain(results, max_per_domain=2)
+
+            images: Tuple[ImageResult, ...] = ()
+
+            if with_images:
+                image_items = list(
+                    ddgs.images(
+                        query,
+                        region=self._region,
+                        safesearch=self._safesearch,
+                        max_results=max_results,
+                    )
+                )
+
+                images = tuple(
+                    image
+                    for item in image_items
+                    if isinstance(item, Mapping)
+                    for image in (map_image_result(item),)
+                    if image.url
+                )
+                images = deduplicate_images(images)
+
+            return SearchResponse(
+                query=query,
+                results=results[:max_results],
+                images=images[:max_results],
+            )
+
+
+def map_text_result(item: Mapping[str, Any]) -> SearchResult:
+    return SearchResult(
+        title=str(item.get("title") or ""),
+        url=str(item.get("href") or item.get("url") or ""),
+        snippet=str(item.get("body") or item.get("snippet") or ""),
+    )
+
+
+def map_image_result(item: Mapping[str, Any]) -> ImageResult:
+    image_url = item.get("image") or item.get("img_src") or item.get("thumbnail")
+    source_url = item.get("url") or item.get("source") or item.get("source_url")
+    thumbnail_url = item.get("thumbnail") or item.get("thumbnail_url")
+
+    return ImageResult(
+        url=str(image_url or ""),
+        desc=str(item.get("title") or "") or None,
+        source_url=str(source_url) if source_url else None,
+        thumbnail_url=str(thumbnail_url) if thumbnail_url else None,
+    )

--- a/services/wisepen-chat-service/src/chat/application/web_search/searcher/searxng_searcher.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/searcher/searxng_searcher.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+import httpx
+
+from chat.application.web_search.models import SearchResponse
+from chat.application.web_search.models.searxng import (
+    SearXNGSearchRequest,
+    map_searxng_response,
+    merge_search_responses,
+)
+from common.logger import log_fail
+
+__all__ = [
+    "SearXNGSearcher",
+]
+
+
+class SearXNGSearcher:
+    name = "searxng"
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 5.0,
+        language: Optional[str] = None,
+        safesearch: Optional[int] = None,
+        web_category: str = "general",
+        image_category: str = "images",
+    ) -> None:
+        base_url = base_url.rstrip("/")
+
+        if not base_url:
+            raise ValueError("base_url 不能为空")
+
+        if not web_category.strip():
+            raise ValueError("web_category 不能为空")
+
+        if not image_category.strip():
+            raise ValueError("image_category 不能为空")
+
+        self._base_url = base_url
+        self._timeout = timeout
+        self._language = language.strip() or None if language else None
+        self._safesearch = safesearch
+        self._web_category = web_category
+        self._image_category = image_category
+
+    async def search(
+        self,
+        query: str,
+        *,
+        max_results: int = 5,
+        with_images: bool = False,
+    ) -> SearchResponse:
+        if not with_images:
+            return await self._search_web(
+                query=query,
+                max_results=max_results,
+            )
+
+        web_result, image_result = await asyncio.gather(
+            self._search_web(query=query, max_results=max_results),
+            self._search_images(query=query, max_results=max_results),
+            return_exceptions=True,
+        )
+
+        if isinstance(web_result, Exception):
+            raise web_result
+
+        if isinstance(image_result, Exception):
+            log_fail(
+                "SearXNG图片搜索失败",
+                image_result,
+                query=query,
+                max_results=max_results,
+            )
+            return web_result
+
+        return merge_search_responses(web_result, image_result)
+
+    async def _search_web(
+        self,
+        *,
+        query: str,
+        max_results: int,
+    ) -> SearchResponse:
+        request = SearXNGSearchRequest(
+            query=query,
+            category=self._web_category,
+            language=self._language,
+            safesearch=self._safesearch,
+        )
+
+        data = await self._get_json(request.to_params())
+
+        return map_searxng_response(
+            data,
+            query=query,
+            max_results=max_results,
+            images_only=False,
+        )
+
+    async def _search_images(
+        self,
+        *,
+        query: str,
+        max_results: int,
+    ) -> SearchResponse:
+        request = SearXNGSearchRequest(
+            query=query,
+            category=self._image_category,
+            language=self._language,
+            safesearch=self._safesearch,
+        )
+
+        data = await self._get_json(request.to_params())
+
+        return map_searxng_response(
+            data,
+            query=query,
+            max_results=max_results,
+            images_only=True,
+        )
+
+    async def _get_json(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self._base_url}/search"
+        response: Optional[httpx.Response] = None
+
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                response = await client.get(url, params=params)
+                response.raise_for_status()
+                data = response.json()
+
+        except httpx.HTTPStatusError as e:
+            body = e.response.text[:500]
+            raise RuntimeError(
+                "SearXNG HTTP error: "
+                f"status={e.response.status_code}, "
+                f"url={e.request.url}, "
+                f"params={params}, "
+                f"body={body!r}"
+            ) from e
+
+        except httpx.TimeoutException as e:
+            raise RuntimeError(
+                "SearXNG timeout: "
+                f"url={url}, params={params}, timeout={self._timeout}"
+            ) from e
+
+        except httpx.RequestError as e:
+            raise RuntimeError(
+                "SearXNG request error: "
+                f"url={url}, params={params}"
+            ) from e
+
+        except ValueError as e:
+            raw = response.text[:500] if response is not None else ""
+            raise RuntimeError(
+                "SearXNG invalid JSON: "
+                f"url={url}, params={params}, body={raw!r}"
+            ) from e
+
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                f"SearXNG invalid response type: type={type(data).__name__}, params={params}"
+            )
+
+        return data

--- a/services/wisepen-chat-service/src/chat/application/web_search/searcher/tavily_searcher.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/searcher/tavily_searcher.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from tavily import AsyncTavilyClient
+
+from chat.application.web_search.models import (
+    SearchResponse,
+    TavilySearchRequest,
+    map_tavily_response,
+)
+
+__all__ = [
+    "TavilySearcher",
+]
+
+
+class TavilySearcher:
+    name = "tavily"
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        timeout: float = 15.0,
+    ) -> None:
+        api_key = api_key.strip()
+
+        if not api_key:
+            raise ValueError("api_key 不能为空")
+
+        self._client = AsyncTavilyClient(api_key=api_key)
+        self._timeout = timeout
+
+    async def search(
+        self,
+        query: str,
+        *,
+        max_results: int = 5,
+        with_images: bool = False,
+    ) -> SearchResponse:
+        request = TavilySearchRequest(
+            query=query,
+            max_results=max_results,
+            with_images=with_images,
+        )
+
+        payload = request.to_payload()
+        payload["timeout"] = self._timeout
+
+        safe_payload = {
+            key: value
+            for key, value in payload.items()
+            if key not in {"api_key"}
+        }
+
+        try:
+            raw_response = await self._client.search(**payload)
+        except Exception as e:
+            raise RuntimeError(
+                "Tavily search failed: "
+                f"payload={safe_payload}, "
+                f"error={type(e).__name__}: {e}"
+            ) from e
+
+        return map_tavily_response(raw_response)

--- a/services/wisepen-chat-service/src/chat/application/web_search/utils/__init__.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/utils/__init__.py
@@ -1,0 +1,15 @@
+from chat.application.web_search.utils.domains import (
+    count_unique_domains,
+    deduplicate_results_by_domain,
+    extract_domain,
+)
+from chat.application.web_search.utils.images import (
+    deduplicate_images,
+)
+
+__all__ = [
+    "extract_domain",
+    "count_unique_domains",
+    "deduplicate_results_by_domain",
+    "deduplicate_images",
+]

--- a/services/wisepen-chat-service/src/chat/application/web_search/utils/domains.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/utils/domains.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+from urllib.parse import urlparse
+
+from chat.application.web_search.models.common import SearchResult
+
+__all__ = [
+    "extract_domain",
+    "count_unique_domains",
+    "deduplicate_results_by_domain",
+]
+
+
+def extract_domain(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return ""
+
+    domain = parsed.hostname
+    if not domain:
+        return ""
+
+    return domain.lower().removeprefix("www.")
+
+
+def count_unique_domains(results: Tuple[SearchResult, ...]) -> int:
+    domains = {extract_domain(result.url) for result in results}
+    domains.discard("")
+    return len(domains)
+
+
+def deduplicate_results_by_domain(
+    results: Tuple[SearchResult, ...],
+    *,
+    max_per_domain: int = 2,
+) -> Tuple[SearchResult, ...]:
+    domain_counts: Dict[str, int] = {}
+    deduped: List[SearchResult] = []
+
+    for result in results:
+        domain = extract_domain(result.url)
+
+        if not domain:
+            deduped.append(result)
+            continue
+
+        count = domain_counts.get(domain, 0)
+        if count >= max_per_domain:
+            continue
+
+        domain_counts[domain] = count + 1
+        deduped.append(result)
+
+    return tuple(deduped)

--- a/services/wisepen-chat-service/src/chat/application/web_search/utils/images.py
+++ b/services/wisepen-chat-service/src/chat/application/web_search/utils/images.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+from chat.application.web_search.models.common import ImageResult
+
+__all__ = [
+    "deduplicate_images",
+]
+
+
+def deduplicate_images(
+    images: Sequence[ImageResult],
+) -> Tuple[ImageResult, ...]:
+    seen: set[str] = set()
+    deduped: List[ImageResult] = []
+
+    for image in images:
+        key = image.url.strip()
+        if not key or key in seen:
+            continue
+
+        seen.add(key)
+        deduped.append(image)
+
+    return tuple(deduped)


### PR DESCRIPTION
拆分通用模型、搜索器、缓存与调度器，形成清晰的 web_search 模块边界。

接入 SearXNG、DuckDuckGo Buffer 与 Tavily，保留显式降级链和 Fresh/Stale Cache 成本保护策略。

增强图片搜索、强时效查询 freshness_required、错误日志上下文与确定性失败测试。