### PR TITLE
feat(chat): 优化 Skill 加载与消息生命周期管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ ENV/
 # 操作系统
 .DS_Store
 Thumbs.db
+
+# json
+origin_text.txt
+json_text.txt
+to_json.py

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,4 @@ ENV/
 Thumbs.db
 
 # json
-origin_text.txt
-json_text.txt
-to_json.py
+/zyq

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/check-academic-format-basics/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/check-academic-format-basics/1.0/SKILL.md
@@ -1,0 +1,194 @@
+---
+skill_id: check-academic-format-basics
+display_name: Check Academic Format Basics
+name: check-academic-format-basics
+description: Pre-checks student academic papers for only the basic format, grammar, pronoun clarity, academic tone, rhetorical-question opening, and visible formatting issues listed in this skill before section-specific diagnosis. Use when Codex needs to identify only revision-needed items involving academic heading capitalization, obvious grammar errors, unclear pronoun reference, overclaiming or promotional academic tone, rhetorical questions at paragraph or section openings, and visible basic academic formatting problems; do not use it to check citation quality, reference-list accuracy, source relevance, or reference-use problems.
+version: 1.0
+enabled: true
+triggers:
+  - 学术格式检查
+  - academic format check
+  - academic formatting
+  - grammar and tone check
+  - 论文基础格式检查
+  - 检查论文格式
+  - 检查语法和学术语气
+---
+
+
+
+# Check Academic Format Basics
+
+Use this skill as a preliminary check before more specific Introduction, Methods, Discussion, Conclusion, or reference-use diagnosis.
+
+Produce only items that need revision. Do not provide an overall evaluation, score, praise, summary, or full rewrite.
+
+## Scope
+
+Check for:
+
+1. basic academic heading format;
+2. obvious grammar problems;
+3. unclear pronoun reference;
+4. overclaiming, exaggerated, or promotional academic tone;
+5. rhetorical questions at paragraph or section openings;
+6. visible basic academic formatting problems.
+
+Only flag the issue types explicitly listed in this skill. If a problem is outside these categories, do not include it.
+
+Do not replace section-specific discourse diagnosis, citation checking, reference-use review, or detailed proofreading. Only flag issues that are visible from the submitted text and fall within this skill's scope.
+
+Do not flag citation or reference-use problems, including missing citations, inaccurate citation style, reference-list completeness, in-text/reference mismatch, source relevance, DOI/URL format, or bibliography-entry formatting. The word `References` may be checked only as a section heading capitalization or heading-style issue.
+
+## Severity Labels
+
+Use only these labels to decide which output part an item belongs to:
+
+- `必须修改`: the issue is clearly incorrect, violates the user's stated format rule, or seriously damages sentence correctness.
+- `建议修改`: the issue is understandable but weakens academic clarity, formality, restraint, or consistency.
+
+Do not repeat `必须修改` or `建议修改` in the `问题` column because the two output parts already show the severity level.
+
+## Required Checks
+
+### Heading Format
+
+Mark as `必须修改` when standard academic section headings are not capitalized correctly.
+
+Examples:
+
+- `introduction` -> `Introduction`
+- `method` -> `Method` or `Methods`
+- `results` -> `Results`
+- `references` -> `References`
+
+Check common headings such as `Abstract`, `Introduction`, `Literature Review`, `Method`, `Methods`, `Methodology`, `Results`, `Discussion`, `Conclusion`, `References`, and `Appendix`.
+
+Mark as `建议修改` when heading capitalization or style is visibly inconsistent but not clearly wrong.
+
+### Obvious Grammar Problems
+
+Mark as `必须修改` when a sentence contains a clear grammar problem, including:
+
+- subject-verb agreement errors;
+- sentence fragments;
+- run-on sentences that damage readability;
+- incorrect tense that changes meaning;
+- obvious article, singular/plural, or preposition errors;
+- malformed sentence structure.
+
+Only flag clear sentence-level errors. Do not treat every stylistic preference as a grammar problem.
+
+### Unclear Pronoun Reference
+
+Mark as `建议修改` when a pronoun has no clear referent or may refer to more than one previous noun or idea.
+
+Common pronouns and demonstratives to check:
+
+- `it`
+- `this`
+- `that`
+- `they`
+- `these`
+- `those`
+- `which`
+
+In the `问题` column, identify the unclear pronoun itself. In the `修改方向` column, ask for the referent to be named explicitly or for the sentence to be restructured.
+
+### Overclaiming
+
+Mark as `建议修改` when a sentence or phrase makes an overly absolute, exaggerated, promotional, or unsupported claim.
+
+Common signals include:
+
+- `transformative`
+- `groundbreaking`
+- `revolutionary`
+- `unprecedented`
+- `paving the way`
+- `poised to drive`
+- broad claims about solving major field-level problems;
+- strings of broad evaluative adjectives such as `interpretable, robust, and generalizable` when not supported by specific evidence.
+
+Do not diagnose by keywords alone. Consider whether the sentence replaces concrete academic judgment with promotional rhetoric.
+
+The revision direction should ask for a more specific, evidence-bounded academic claim. Prefer concrete scope, task type, condition, limitation, or future research direction.
+
+Example revision direction:
+
+`改为更具体、可验证的 final claim，说明该方法在哪些任务、条件或问题上具有潜力，或指出当前距离实用化还存在什么限制。`
+
+### Rhetorical Questions at Paragraph or Section Openings
+
+Mark as `建议修改` when a paragraph or section begins with a rhetorical question or question-answer style opening.
+
+Examples:
+
+- `So, why...?`
+- `Why does this happen?`
+- `What explains this phenomenon?`
+
+Academic prose should normally use declarative topic sentences instead of rhetorical questions at the start of paragraphs or sections.
+
+Do not flag formal research questions such as `RQ1:` or explicitly labeled research questions when they are part of the study design.
+
+### Basic Academic Formatting and Formality
+
+Mark as `建议修改` when visible academic convention problems appear, such as:
+
+- figure/table labels not capitalized, such as `figure 1` instead of `Figure 1`;
+- contractions in formal writing, such as `don't` or `can't`;
+- clearly informal expressions, such as `a lot of`, `things`, or `get`, when a more academic alternative is needed;
+- inconsistent formatting of repeated labels, headings, or section names.
+
+Use `必须修改` only if the format problem is clearly required by academic convention or the user's stated rules.
+
+## Output Format
+
+Output only the modification items, split into two parts.
+
+Use these two parts in this exact order:
+
+### 必须修改
+
+| 原句 | 问题 | 修改方向 |
+| ---- | ---- | -------- |
+
+### 建议修改
+
+| 原句 | 问题 | 修改方向 |
+| ---- | ---- | -------- |
+
+Each row must include:
+
+- `原句`: the exact sentence, heading, phrase, or visible text segment that needs revision.
+- `问题`: provide only a concise diagnosis. Do not begin with `必须修改：`, `建议修改：`, `必须修改`, or `建议修改`.
+- `修改方向`: provide a brief direction for revision. A sample rewrite may be included only when it is short and directly useful.
+
+If one part has no items, write exactly `无。` under that part's heading instead of a table.
+
+If there are no problems in either part, output:
+
+### 必须修改
+
+无。
+
+### 建议修改
+
+无。
+
+## Constraints
+
+Do not output unchanged content.
+
+Do not add sections before, between, or after the two required parts.
+
+Do not provide a general summary, score, or praise.
+
+Do not rewrite the whole paper or paragraph unless the user explicitly requests rewriting after diagnosis.
+
+Do not invent missing evidence, findings, sources, methods, or claims.
+
+Do not diagnose Introduction, Methods, Discussion, Conclusion, or References move-step quality in depth. This skill is only for basic pre-checking.
+
+Do not diagnose citation style, reference-list content, bibliography quality, or source relevance.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/check-academic-format-basics/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/check-academic-format-basics/1.0/SKILL.md
@@ -151,31 +151,39 @@ Use these two parts in this exact order:
 
 ### 必须修改
 
-| 原句 | 问题 | 修改方向 |
-| ---- | ---- | -------- |
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [exact sentence, heading, phrase, or visible text segment]
+   - 问题: [concise diagnosis in English]
+   - 具体改进方向: [brief revision direction in English]
 
 ### 建议修改
 
-| 原句 | 问题 | 修改方向 |
-| ---- | ---- | -------- |
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [exact sentence, heading, phrase, or visible text segment]
+   - 问题: [concise diagnosis in English]
+   - 具体改进方向: [brief revision direction in English]
 
-Each row must include:
+Each issue must include:
 
-- `原句`: the exact sentence, heading, phrase, or visible text segment that needs revision.
-- `问题`: provide only a concise diagnosis. Do not begin with `必须修改：`, `建议修改：`, `必须修改`, or `建议修改`.
-- `修改方向`: provide a brief direction for revision. A sample rewrite may be included only when it is short and directly useful.
+- `原文句子`: the exact sentence, heading, phrase, or visible text segment that needs revision.
+- `问题`: provide only a concise diagnosis in English. Do not begin with `必须修改：`, `建议修改：`, `必须修改`, or `建议修改`.
+- `具体改进方向`: provide a brief direction for revision in English. A sample rewrite may be included only when it is short and directly useful.
 
-If one part has no items, write exactly `无。` under that part's heading instead of a table.
+Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+
+Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.
+
+If one part has no items, write exactly `No items.` under that part's heading.
 
 If there are no problems in either part, output:
 
 ### 必须修改
 
-无。
+No items.
 
 ### 建议修改
 
-无。
+No items.
 
 ## Constraints
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/SKILL.md
@@ -25,29 +25,53 @@ For review papers, interpret `M1S3` as a synthesized pattern across the reviewed
 
 ## Required Workflow
 
-When performing a real diagnosis, first read `references/workflow.md` and follow its sequence:
+When performing a real diagnosis, first call `load_skill_asset` on `references/workflow.md` and follow its sequence.
+
+For every workflow step below, you MUST call `load_skill_asset` for each listed file before completing that step. If the same file has already been loaded earlier in the current turn, reuse the already loaded content instead of calling `load_skill_asset` again.
 
 1. verify that the input is a Conclusion-related section or passage;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/failure-strategies.md`
 2. identify discipline, article type, research tradition, evidence type, topic, and intended contribution;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/discipline-expectedness-profiles.md`
 3. segment the text into sentence-level units;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
 4. annotate each sentence with one primary move-step label and any secondary labels;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/move-step-definitions.md`
 5. select a discipline-sensitive expectedness profile, then adjust by article type;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/discipline-expectedness-profiles.md`
 6. judge expected move-step coverage using stable status labels;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
 7. diagnose Conclusion-specific logic chains;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/logic-chain-rubric.md`
 8. identify key missing or weak functions;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/move-step-definitions.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
 9. generate teaching-oriented feedback and revision priorities.
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/output-templates.md`
 
 ## Reference Files
 
-Load only the files needed for the current task:
+For a real Conclusion diagnosis, the following files are required by the workflow above and must be loaded through `load_skill_asset` when their workflow step is reached:
 
-- `references/move-step-definitions.md`: read when assigning or explaining Conclusion move-step labels.
-- `references/discipline-expectedness-profiles.md`: read when deciding which steps are Core, Conventional, Conditional, Optional / Enriching, Rare / Not Expected, or Not Applicable for a discipline and article type.
-- `references/diagnostic-rubric.md`: read when judging Expectedness, Present, Weak, Missing, Not Applicable, Unclear, and revision priority.
-- `references/logic-chain-rubric.md`: read when diagnosing looking-back to looking-forward coherence, including finding-significance-implication and limitation-improvement-future chains.
-- `references/output-templates.md`: read when formatting the final revision-priority-only answer.
-- `references/failure-strategies.md`: read when the input may not be a Conclusion, is too short, lacks discipline metadata, or asks only for rewriting.
-- `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses this framework.
+- `references/workflow.md`: required for every real Conclusion diagnosis.
+- `references/failure-strategies.md`: required during input-gate and failure-mode handling.
+- `references/discipline-expectedness-profiles.md`: required when identifying article profile and deciding which steps are Core, Conventional, Conditional, Optional / Enriching, Rare / Not Expected, or Not Applicable for a discipline and article type.
+- `references/move-step-definitions.md`: required when assigning or explaining Conclusion move-step labels.
+- `references/diagnostic-rubric.md`: required when judging Expectedness, Present, Weak, Missing, Not Applicable, Unclear, and revision priority.
+- `references/logic-chain-rubric.md`: required when diagnosing looking-back to looking-forward coherence, including finding-significance-implication and limitation-improvement-future chains.
+- `references/output-templates.md`: required when formatting the final revision-priority-only answer.
+
+Conditional reference:
+
+- `references/source-notes.md`: MUST load via `load_skill_asset` when the user asks about the theoretical basis, citations, source basis, or why the skill uses this framework.
 
 ## Default Output
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/SKILL.md
@@ -64,12 +64,21 @@ Do not output:
 - Key Missing or Weak Functions;
 - scores, summaries, introductions, closing remarks, or follow-up questions.
 
-The final response must contain only two tables, in this order:
+The final response must contain only two blocks, in this order:
 
 - 必须修改
 - 建议修改
 
-Each table should use `原文句子 | 问题 | 为什么影响 Conclusion | 具体改进方向`.
+Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+
+Each issue must follow this structure:
+
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens the Conclusion when relevant]
+   - 具体改进方向: [specific revision direction in English]
+
+Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.
 
 ## Constraints
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: diagnose-conclusion-skill
+description: Diagnoses the rhetorical move-step structure and coherence of academic Conclusion, Conclusions, Concluding Remarks, or final Discussion-and-Conclusion passages using a three-move Conclusion framework. Use when Codex needs to check, evaluate, diagnose, or give pedagogical feedback on Conclusion discourse, including missing or weak key-finding synthesis, contribution or significance, implications, limitations, improvements, future research, closing claim, discipline-sensitive expectations, or weak looking-back to looking-forward logic in academic English writing.
+---
+
+# Diagnose Conclusion Skill
+
+Use this skill to diagnose whether a student's academic Conclusion section consolidates the study, evaluates its contribution and boundaries, and projects credible future directions.
+
+This skill is for academic English writing pedagogy. Produce diagnostic feedback, not grammar correction, style polishing, or a full rewrite unless the user explicitly asks for revision after diagnosis.
+
+## Core Framework
+
+Use the Conclusion framework adapted from Yang and Allison's three-move model, later Conclusion(s) studies, the user's local teaching materials, and the WisePen discourse-diagnostic workflow:
+
+- Move 1: Consolidating the Study
+- Move 2: Evaluating the Study
+- Move 3: Projecting Forward
+
+A move is a broad rhetorical function in the Conclusion. A step is a more specific rhetorical action. Use the unified `M1S1`, `M1S2`, `M2S1` format.
+
+For research articles, use `M1S3 Synthesizing key findings` as the first-pass anchor step. Then check whether the Conclusion explains why the findings matter through `M2S1` and/or `M2S2`, and whether any limitation, improvement, future direction, or closing claim is expected for the discipline and article type.
+
+For review papers, interpret `M1S3` as a synthesized pattern across the reviewed literature, `M2S3` as a limitation of the literature or review, and `M3S2` as a grounded future research agenda.
+
+## Required Workflow
+
+When performing a real diagnosis, first read `references/workflow.md` and follow its sequence:
+
+1. verify that the input is a Conclusion-related section or passage;
+2. identify discipline, article type, research tradition, evidence type, topic, and intended contribution;
+3. segment the text into sentence-level units;
+4. annotate each sentence with one primary move-step label and any secondary labels;
+5. select a discipline-sensitive expectedness profile, then adjust by article type;
+6. judge expected move-step coverage using stable status labels;
+7. diagnose Conclusion-specific logic chains;
+8. identify key missing or weak functions;
+9. generate teaching-oriented feedback and revision priorities.
+
+## Reference Files
+
+Load only the files needed for the current task:
+
+- `references/move-step-definitions.md`: read when assigning or explaining Conclusion move-step labels.
+- `references/discipline-expectedness-profiles.md`: read when deciding which steps are Core, Conventional, Conditional, Optional / Enriching, Rare / Not Expected, or Not Applicable for a discipline and article type.
+- `references/diagnostic-rubric.md`: read when judging Expectedness, Present, Weak, Missing, Not Applicable, Unclear, and revision priority.
+- `references/logic-chain-rubric.md`: read when diagnosing looking-back to looking-forward coherence, including finding-significance-implication and limitation-improvement-future chains.
+- `references/output-templates.md`: read when formatting the final revision-priority-only answer.
+- `references/failure-strategies.md`: read when the input may not be a Conclusion, is too short, lacks discipline metadata, or asks only for rewriting.
+- `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses this framework.
+
+## Default Output
+
+Always perform the full diagnostic workflow internally, but the final response must output only the content of `Revision Priorities`.
+
+Do not output:
+
+- `## 7. Revision Priorities` or any `Revision Priorities` heading;
+- Overall Diagnosis;
+- Article Profile;
+- Sentence-Level Move-Step Annotation;
+- Expected Move / Step Coverage;
+- Conclusion Logic Diagnosis;
+- Key Missing or Weak Functions;
+- scores, summaries, introductions, closing remarks, or follow-up questions.
+
+The final response must contain only two tables, in this order:
+
+- 必须修改
+- 建议修改
+
+Each table should use `原文句子 | 问题 | 为什么影响 Conclusion | 具体改进方向`.
+
+## Constraints
+
+Do not:
+
+- require all Conclusion steps in every text;
+- treat Optional / Enriching or Rare / Not Expected steps as missing problems;
+- diagnose by keyword matching alone;
+- replace rhetorical diagnosis with grammar correction;
+- rewrite the whole Conclusion unless requested;
+- invent missing findings, literature, limitations, implications, applications, improvements, future directions, or contributions;
+- mark a function as Missing when an equivalent discipline-specific function is present;
+- force dissertation-style requirements onto research-article Conclusions;
+- use the term "optional" in final feedback to criticize the student's text.
+
+Do:
+
+- focus on rhetorical function;
+- preserve and quote original wording;
+- use sentence-level units by default;
+- allow one sentence to carry one primary label and multiple secondary labels;
+- separate Expectedness, Status, and Confidence;
+- distinguish Missing from Weak;
+- judge move-step coverage and logic-chain coherence separately;
+- explain why each issue matters for Conclusion synthesis, significance, credibility, impact, or closure;
+- separate must-fix and suggested-fix items;
+- provide concrete revision directions without inventing content for the student.
+

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/diagnostic-rubric.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/diagnostic-rubric.md
@@ -1,0 +1,150 @@
+# Conclusion Diagnostic Rubric
+
+Use this rubric to judge Conclusion move-step coverage and decide revision priorities.
+
+## Expectedness
+
+Expectedness describes whether a function should be checked for this discipline, article type, and passage.
+
+| Expectedness | Meaning | Can absence be criticized? |
+|---|---|---|
+| Core | A central function for this Conclusion type or discipline | Yes |
+| Conventional | Normally expected in this discipline or article type | Yes |
+| Strongly Expected | Highly expected; absence usually creates a serious weakness | Yes |
+| Conditional | Expected only when triggered by the study, article type, local context, or prior section design | Yes, if triggered |
+| Optional / Enriching | Useful but not required | No |
+| Rare / Not Expected | Normally not expected | No |
+| Not Applicable | Does not fit the study design, discipline, or article type | No |
+
+Use `references/discipline-expectedness-profiles.md` as the default guide for discipline-sensitive expectedness. If no close profile fits, fall back to the nearest broad family and infer cautiously from article type and visible rhetorical needs.
+
+## Fast First Pass
+
+Before doing a full coverage diagnosis, use this simplified check:
+
+1. Is there a clear `M1S3 Synthesizing key findings`?
+2. Is there a credible `M2S1` or `M2S2` that says why the finding matters?
+3. If the text makes broad claims, does it set boundaries through `M2S3` or `M2S4`?
+4. If future work is present, does `M3S2` follow from findings, implications, or limitations?
+5. Does the final sentence provide closure through `M3S3` or an equivalent final judgment?
+
+For many research-paper Conclusions, the absence of a clear `M1S3 -> M2S1/M2S2` backbone is the quickest sign that the Conclusion is underdeveloped.
+
+## Coverage Status
+
+Use only these five status labels:
+
+| Status | Definition |
+|---|---|
+| Present | The rhetorical function is clearly realized |
+| Weak | The function is attempted but underdeveloped, vague, unsupported, poorly connected, or lacking necessary detail |
+| Missing | A Core, Conventional, Strongly Expected, or triggered Conditional function is absent |
+| Not Applicable | The function does not fit the study design, discipline, article type, or local context |
+| Unclear | The available text is insufficient to decide whether the function is relevant or realized |
+
+## Status Rules by Step
+
+### M1S1 Restating purpose / scope
+
+Present when the sentence efficiently restates the study aim, research question, problem, object, or scope.
+
+Weak when it repeats the Introduction too broadly, lacks a clear object, or does not help readers understand what is being concluded.
+
+Missing only when readers need orientation because the Conclusion begins with findings or claims that are otherwise hard to interpret.
+
+### M1S2 Recalling method / evidence base
+
+Present when the sentence briefly reminds readers of method, data, corpus, sample, model, experiment, or review scope in a way that supports the conclusion.
+
+Weak when it becomes a full Methods recap, lists technical details without function, or fails to connect the evidence base to the conclusion.
+
+Missing only when the evidence base is necessary for judging the findings or contribution and is not recoverable from context.
+
+### M1S3 Synthesizing key findings
+
+Present when the sentence or set of sentences clearly consolidates the study's most important findings, outcomes, arguments, or review patterns.
+
+Weak when findings are vague, listed mechanically, too detailed, too broad, or not clearly distinguished from background.
+
+Missing when the Conclusion evaluates, recommends, or closes without first making the central finding or synthesis clear.
+
+### M1S4 Positioning findings against prior knowledge
+
+Present when the Conclusion explains how findings respond to a gap, extend, refine, confirm, challenge, or reorganize existing knowledge.
+
+Weak when prior knowledge is mentioned without explaining the relation between the current study and the field.
+
+Missing when the discipline or article type expects literature positioning and the Conclusion's contribution remains isolated.
+
+### M2S1 Indicating significance / contribution
+
+Present when the Conclusion states the importance, contribution, novelty, value, or advancement of the findings, method, model, framework, or argument.
+
+Weak when contribution is asserted with generic wording such as "this study is important" without specifying what is advanced.
+
+Missing when findings are summarized but their field-level or article-level value is never made clear.
+
+### M2S2 Drawing implications / applications
+
+Present when the Conclusion draws a concrete theoretical, practical, pedagogical, policy, clinical, technical, managerial, or methodological implication.
+
+Weak when implications are generic, too broad for the evidence, or disconnected from the findings.
+
+Missing when applied, clinical, educational, policy, technical, or business fields expect implications and the Conclusion does not provide them.
+
+### M2S3 Indicating limitations / boundaries
+
+Present when the Conclusion identifies a meaningful boundary, limitation, unresolved problem, scope condition, or generalizability constraint.
+
+Weak when the limitation is formulaic, vague, not tied to findings, or used only as a ritual phrase.
+
+Missing when the article's claims, evidence base, discipline, or article type requires explicit caution and no boundary is supplied.
+
+### M2S4 Evaluating methodology / evidence quality
+
+Present when the Conclusion evaluates method, dataset, model, validation, measurement, evidence strength, or analytical reliability.
+
+Weak when it vaguely praises or criticizes the method without specifying what is reliable, limited, validated, or untested.
+
+Missing when technical, computational, clinical, or method-focused claims require evidence-quality boundaries or validation commentary.
+
+### M3S1 Suggesting improvements
+
+Present when the Conclusion proposes specific improvements to methods, tools, data, intervention design, implementation, theory, or research design.
+
+Weak when improvements are generic, not grounded in identified limitations, or too vague to guide action.
+
+Missing when limitations or evidence-quality problems are identified but no improvement path is suggested and the discipline expects one.
+
+### M3S2 Recommending future research
+
+Present when the Conclusion recommends concrete future research directions, contexts, populations, datasets, variables, comparisons, validation settings, or research questions.
+
+Weak when it only says "more research is needed" without specifying what, why, or how it follows from the study.
+
+Missing when the study's limitations, unresolved findings, review synthesis, or field convention clearly calls for future work.
+
+### M3S3 Making an overall closing claim
+
+Present when the Conclusion ends with a final judgment, take-home message, or broad but supported closing claim.
+
+Weak when the ending is abrupt, repetitive, overgeneralized, or not supported by the preceding synthesis.
+
+Missing when the Conclusion ends with details, limitations, or future work but lacks rhetorical closure and leaves the article's final meaning unclear.
+
+## Revision Priority
+
+Use `必须修改` for:
+
+- Missing Core, Conventional, Strongly Expected, or triggered Conditional steps;
+- Weak steps that damage the core logic of the Conclusion;
+- Unclear functions when ambiguity prevents readers from understanding the Conclusion's finding, contribution, implication, boundary, or final meaning;
+- logic-chain breaks that prevent the Conclusion from being persuasive, credible, coherent, or complete.
+
+Use `建议修改` for:
+
+- Weak functions that mainly need more specificity, evidence, connection, scope, or clearer wording;
+- local improvements that would strengthen reader trust but do not break the Conclusion's central logic;
+- enriching moves that would improve closure but are not required.
+
+Do not duplicate the same issue in both priority blocks.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/discipline-expectedness-profiles.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/discipline-expectedness-profiles.md
@@ -1,0 +1,121 @@
+# Discipline-Sensitive Conclusion Profiles
+
+Use this file to decide which Conclusion steps are easiest to judge and most pedagogically important for a given discipline and article type.
+
+These profiles simplify diagnosis by starting from a shared Conclusion backbone and then narrowing the judgment by discipline.
+
+## Shared Starting Point for Research Articles
+
+Do not require all eleven steps.
+
+For research-article Conclusions, begin with this shared backbone:
+
+- `M1S3 Synthesizing key findings` is normally Core.
+- `M2S1 Indicating significance / contribution` is normally Conventional.
+- `M2S2 Drawing implications / applications` is Conventional in applied, clinical, policy, education, business, and technical fields, but may be lighter in some basic science articles.
+- `M2S3 Indicating limitations / boundaries` is Conditional when the Discussion already handled limitations, but Conventional or Strongly Expected when claims are broad, evidence is narrow, or the field expects explicit caution.
+- `M3S2 Recommending future research` is common but should not be required mechanically.
+- `M3S3 Making an overall closing claim` is Conventional when the Conclusion otherwise ends abruptly.
+
+Use the remaining steps selectively:
+
+- `M1S1` and `M1S2` are often brief orientation moves, not required in every short Conclusion.
+- `M1S4` is stronger in literature-dialogue and social-science fields.
+- `M2S4` is especially important in technical, AI, computational, engineering, clinical, and methodological papers.
+- `M3S1` is expected when clear limitations, technical constraints, or implementation weaknesses have been identified.
+
+## Research Paper Profiles
+
+### Natural Sciences / Physics / Materials / Environmental Science
+
+- Core: `M1S3`, `M2S1`
+- Conventional: `M3S3`
+- Conditional: `M1S1`, `M1S2`, `M1S4`, `M2S2`, `M2S3`, `M2S4`, `M3S1`, `M3S2`
+- Easy diagnostic focus: check whether the Conclusion distills the main result and states its contribution without over-expanding into a second Discussion.
+- Common chains: `M1S3 -> M2S1 -> M3S3`; `M1S3 -> M2S1 -> M3S2`
+- Avoid over-diagnosis: do not force heavy literature dialogue or long limitation sections when the article convention favors concise closure.
+
+### Engineering / Applied Technology
+
+- Core: `M1S3`, `M2S1`
+- Conventional: `M2S2`, `M2S4`, `M3S1`, `M3S2`
+- Conditional: `M1S1`, `M1S2`, `M1S4`, `M2S3`, `M3S3`
+- Easy diagnostic focus: check whether technical performance, application value, validation boundary, and future improvement are specific.
+- Common chains: `M1S3 -> M2S4 -> M3S1`; `M1S3 -> M2S2 -> M3S2`
+
+### Computer Science / AI / Data-Driven Research
+
+- Core: `M1S3`, `M2S1`, `M2S4`
+- Conventional: `M2S3`, `M3S1`, `M3S2`
+- Conditional: `M1S1`, `M1S2`, `M1S4`, `M2S2`, `M3S3`
+- Easy diagnostic focus: check dataset/model/task specificity, validation boundaries, reliability limits, and concrete next research directions.
+- Common chains: `M1S3 -> M2S4 -> M2S3 -> M3S1`; `M1S3 -> M2S1 -> M3S2`
+- Treat missing boundaries seriously when the Conclusion makes broad claims about model capability, deployment, safety, or generalization.
+
+### Medical / Health / Life Sciences
+
+- Core: `M1S3`, `M2S2`, `M2S3`
+- Strongly Expected: `M3S2` when evidence is preliminary, sample-bound, clinical, or translational
+- Conventional: `M2S1`, `M2S4`, `M3S3`
+- Conditional: `M1S1`, `M1S2`, `M1S4`, `M3S1`
+- Easy diagnostic focus: check whether the Conclusion states clinical, biological, or practical meaning while setting appropriate evidence boundaries.
+- Common chains: `M1S3 -> M2S2 -> M2S3 -> M3S2`; `M1S3 -> M2S4 -> M2S2`
+
+### Social Sciences / Education / Applied Linguistics
+
+- Core: `M1S3`, `M2S1`, `M2S2`
+- Conventional: `M1S4`, `M2S3`, `M3S2`, `M3S3`
+- Conditional: `M1S1`, `M1S2`, `M2S4`, `M3S1`
+- Easy diagnostic focus: check whether findings are connected to literature, theory, pedagogy, policy, or social practice rather than summarized in isolation.
+- Common chains: `M1S3 -> M1S4 -> M2S1/M2S2 -> M3S2`; `M2S3 -> M3S2`
+
+### Business / Management / Economics / Public Administration
+
+- Core: `M1S3`, `M2S1`, `M2S2`
+- Conventional: `M3S2`, `M3S3`
+- Conditional: `M1S1`, `M1S2`, `M1S4`, `M2S3`, `M2S4`, `M3S1`
+- Easy diagnostic focus: check whether managerial, policy, market, or organizational implications follow from the findings.
+- Common chains: `M1S3 -> M2S2 -> M3S3`; `M1S3 -> M2S3 -> M3S2`
+
+### Humanities / Law / Theoretical Fields
+
+- Core: `M1S3`, `M2S1`, `M3S3`
+- Conventional: `M1S4`, `M2S2`
+- Conditional: `M1S1`, `M1S2`, `M2S3`, `M2S4`, `M3S1`, `M3S2`
+- Easy diagnostic focus: treat findings as arguments, interpretations, propositions, framework claims, or legal conclusions rather than experimental results.
+- Common chains: `argument / synthesis -> contribution -> closing claim`; `interpretation -> implication -> future inquiry / action`
+- Avoid over-diagnosis: do not force empirical limitation language if the article is conceptual or doctrinal, but check whether scope and applicability are clear.
+
+## Review Paper Defaults
+
+Review papers use the same moves, but the object of conclusion is the literature rather than one new dataset or experiment.
+
+- Core: `M1S3 Synthesizing key findings`, `M2S1 Field-level significance / contribution`
+- Conventional: `M1S4 Positioning against prior knowledge`, `M2S3 Literature or review limitations`, `M3S2 Future research agenda`, `M3S3 Closing claim`
+- Conditional: `M1S1`, `M1S2`, `M2S2`, `M2S4`, `M3S1`
+- Easy diagnostic focus: the Conclusion should synthesize patterns, evaluate the field's limits, position the review's contribution, and propose concrete future directions.
+- Common chain: `M1S3 -> M2S1 -> M2S3 -> M3S2 -> M3S3`
+
+Do not accept a review Conclusion that merely repeats section topics or citation lists without synthesis.
+
+## Combined Discussion and Conclusion
+
+When the passage is a combined Discussion and Conclusion:
+
+- allow more explanation, literature comparison, and result interpretation than in a stand-alone Conclusion;
+- still require a final looking-back and looking-forward closure if the passage is the article's final section;
+- use `M1S3`, `M2S1/M2S2`, and `M3S2/M3S3` as the quickest final-section checks;
+- do not penalize the Conclusion for lacking limitation or future research if those functions are clearly present earlier in the combined section.
+
+## Dissertation-Like Conclusions
+
+This skill's v1 default is research articles. If the user provides a dissertation or thesis Conclusion, state that the diagnosis is adapted.
+
+For dissertations, treat these as more strongly expected:
+
+- explicit research aim or question recap (`M1S1`);
+- structured synthesis of findings (`M1S3`);
+- contribution and implications (`M2S1`, `M2S2`);
+- limitations (`M2S3`);
+- future research (`M3S2`);
+- final closing claim (`M3S3`).

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/failure-strategies.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/failure-strategies.md
@@ -1,0 +1,93 @@
+# Conclusion Failure Strategies
+
+Use this file when the submitted input does not cleanly fit the Conclusion diagnostic workflow.
+
+## Wrong Section
+
+If the passage is clearly Introduction, Methods, Results, Literature Review, or a non-final Discussion passage:
+
+- state that the passage is not suitable for a Conclusion diagnosis;
+- briefly identify the likely section type and why;
+- if another WisePen skill fits, suggest the appropriate diagnostic direction;
+- do not force Conclusion labels onto the passage.
+
+Example response:
+
+```text
+This passage reads as a Discussion rather than a Conclusion because it interprets individual findings and compares them with previous studies, but it does not yet perform final synthesis or closure. A Conclusion diagnosis would be unreliable unless you provide the final section.
+```
+
+## Combined Discussion and Conclusion
+
+If the passage is headed `Discussion and Conclusion`, `Results and Discussion`, or otherwise blends interpretation and closure:
+
+- continue if the passage includes final synthesis, implications, limitations, future work, or closing claim;
+- state that the diagnosis treats the passage as a combined final section;
+- allow Discussion-like explanation and literature comparison;
+- still diagnose whether the final part performs Conclusion closure.
+
+Do not criticize the passage for being longer or more interpretive than a stand-alone Conclusion when the heading signals a combined section.
+
+## Full Paper Provided
+
+If the user provides a full paper:
+
+- extract only the section headed `Conclusion`, `Conclusions`, `Concluding Remarks`, `Conclusion and Implications`, or a close equivalent;
+- if no heading exists, identify the final section or final paragraphs that perform Conclusion functions;
+- state the extraction decision;
+- do not diagnose the whole paper as if every final paragraph were a Conclusion if the boundary is unclear.
+
+If the Conclusion cannot be identified, ask for the Conclusion section.
+
+## Too Short or Insufficient Text
+
+If the input is a title, abstract, outline, bullet list, single sentence, or fragment:
+
+- do not produce a full diagnosis;
+- explain that there is too little rhetorical content for move-step coverage;
+- offer a limited comment only if at least one Conclusion function is visible.
+
+If the passage is short but diagnosable, continue and mark the diagnosis as limited.
+
+## Missing Discipline Metadata
+
+If the discipline is not provided:
+
+- infer the broad discipline from topic, terminology, method, and article type;
+- choose the nearest broad expectedness profile;
+- mark discipline-sensitive judgments as provisional;
+- avoid strong criticism for steps whose expectedness depends heavily on discipline.
+
+Do not ask for metadata when the text itself gives enough context for a cautious diagnosis.
+
+## Ambiguous Article Type
+
+If it is unclear whether the text is a research paper, review paper, theoretical paper, or dissertation-like Conclusion:
+
+- infer from cues such as `this study`, `review`, `literature`, `participants`, `dataset`, `model`, `experiment`, or `framework`;
+- state the inference in the Article Profile;
+- apply the closest profile cautiously;
+- mark uncertain coverage judgments as `Unclear` rather than `Missing` when expectedness depends on article type.
+
+## Rewrite-Only Requests
+
+If the user only asks to rewrite a Conclusion:
+
+- ask whether they want diagnosis first only when the request is ambiguous and a diagnosis would materially change the rewrite;
+- otherwise, if this skill is already triggered, provide a brief rhetorical diagnosis before any suggested revision;
+- do not invent findings, limitations, contributions, or future work;
+- if rewriting is requested, keep added content in placeholders or ask for missing study details when necessary.
+
+## New Content Risk
+
+Never invent:
+
+- findings or results;
+- literature claims;
+- methodological details;
+- limitations;
+- future research directions;
+- practical applications;
+- contribution claims.
+
+When a needed function is missing, tell the student what kind of information to add and where it should connect, but do not fabricate the content.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/logic-chain-rubric.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/logic-chain-rubric.md
@@ -1,0 +1,130 @@
+# Conclusion Logic-Chain Rubric
+
+Use this file to diagnose coherence among Conclusion functions. Logic-chain diagnosis is separate from move-step coverage: a text can include many steps but still connect them poorly.
+
+## Core Principle
+
+A strong Conclusion usually moves from looking back to looking forward:
+
+```text
+study purpose / problem -> key finding or synthesis -> significance / implication -> boundary / improvement / future direction -> final closing claim
+```
+
+Do not force every chain onto every text. Select the chain(s) that fit the discipline, article type, and visible rhetorical purpose.
+
+## Chain 1: Purpose / Problem -> Key Finding -> Field Advancement
+
+Use when the Conclusion restates the study's purpose or problem and then summarizes findings.
+
+| Element | What to check |
+|---|---|
+| Purpose / problem | Does the text identify what the study set out to answer, solve, examine, or review? |
+| Key finding / synthesis | Does the finding answer that purpose or problem? |
+| Field advancement | Does the text explain what has been advanced, refined, challenged, or clarified? |
+
+Common weak links:
+
+- purpose is restated but findings do not clearly answer it;
+- findings are listed but not synthesized;
+- contribution is asserted without explaining what knowledge changed.
+
+Revision direction: connect the central finding directly to the research problem and specify the field-level advancement.
+
+## Chain 2: Key Finding -> Significance -> Implication / Application
+
+Use when the Conclusion claims theoretical, practical, pedagogical, policy, clinical, technical, managerial, or methodological value.
+
+| Element | What to check |
+|---|---|
+| Key finding | Is the finding specific enough to support an implication? |
+| Significance | Does the text say why the finding matters? |
+| Implication / application | Does the implication follow from the finding rather than from broad background? |
+
+Common weak links:
+
+- implication is generic and could fit any study;
+- practical application exceeds the evidence;
+- significance repeats the finding without evaluating it.
+
+Revision direction: specify the audience or use context, then show how the finding supports that implication.
+
+## Chain 3: Limitation -> Improvement -> Future Research
+
+Use when the Conclusion mentions limitations, constraints, unresolved problems, or weaknesses.
+
+| Element | What to check |
+|---|---|
+| Limitation / boundary | Is the limitation specific and relevant to interpretation? |
+| Improvement | Does the text suggest how the limitation could be addressed? |
+| Future research | Does the future direction follow from the limitation or improvement path? |
+
+Common weak links:
+
+- limitation is formulaic and not linked to findings;
+- future work is generic rather than limitation-driven;
+- improvement is absent after a serious limitation.
+
+Revision direction: state the limitation's effect on interpretation, then recommend a concrete next study, dataset, method, population, site, comparison, or validation setting.
+
+## Chain 4: Review Synthesis -> Literature Limitation -> Future Agenda
+
+Use for review papers and literature-based articles.
+
+| Element | What to check |
+|---|---|
+| Review synthesis | Does the Conclusion integrate literature patterns rather than repeat section headings? |
+| Literature limitation | Does it identify what the field still lacks, not only what the review did not cover? |
+| Future agenda | Does it propose grounded future research based on the synthesis and limitations? |
+
+Common weak links:
+
+- the review concludes with a list of topics instead of a field-level synthesis;
+- limitations concern only the author's search process and not the state of knowledge;
+- the future agenda is a broad call for "more research" without direction.
+
+Revision direction: name the strongest pattern, the most important evidence gap, and the next research agenda that follows.
+
+## Chain 5: Technical / Clinical Finding -> Validation Boundary -> Practical Implication
+
+Use for engineering, AI, data-driven, clinical, health, and implementation-oriented studies.
+
+| Element | What to check |
+|---|---|
+| Technical / clinical finding | Is the main performance, mechanism, intervention result, or clinical finding clear? |
+| Validation boundary | Does the text state where the evidence has and has not been validated? |
+| Practical implication | Does the application claim stay within the validation boundary? |
+
+Common weak links:
+
+- the Conclusion claims deployment or clinical value without validation evidence;
+- model, dataset, sample, or context boundaries are missing;
+- practical implications are broader than the tested setting.
+
+Revision direction: state what was demonstrated, where it was demonstrated, what remains untested, and what use is therefore justified.
+
+## Chain 6: Finding / Synthesis -> Final Closing Claim
+
+Use for any Conclusion that ends with a take-home message.
+
+| Element | What to check |
+|---|---|
+| Finding / synthesis | Does the final claim build on the section's main synthesis? |
+| Closing claim | Does the ending give a meaningful final judgment without overclaiming? |
+
+Common weak links:
+
+- final sentence simply repeats the title or topic;
+- final claim is too broad for the evidence;
+- Conclusion ends with a limitation or future work item and lacks closure.
+
+Revision direction: convert the final sentence into a supported take-home message that names the article's main contribution or significance.
+
+## Reporting Logic Problems
+
+Use this table in full reports:
+
+| Logic chain | Evidence | Break / weak link | Why it weakens Conclusion | Revision direction |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+Quote the affected sentence(s) when diagnosing a broken or weak chain. Do not diagnose a missing chain that is not expected for the text.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/move-step-definitions.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/move-step-definitions.md
@@ -1,0 +1,85 @@
+# Conclusion Move-Step Definitions
+
+Use these labels when diagnosing Conclusion, Conclusions, Concluding Remarks, Conclusion and Implications, or clearly final Discussion-and-Conclusion passages.
+
+This skill uses the unified `M1S1` format. Step numbering restarts inside each move. A sentence may receive one primary label and multiple secondary labels when it performs more than one real rhetorical function.
+
+## Easy First-Pass Version
+
+For research-paper Conclusions, start with three anchor questions:
+
+1. Does the Conclusion synthesize the most important finding(s), not merely repeat the topic?
+2. Does it explain why those findings matter for the field, practice, theory, policy, method, or application?
+3. Does it close forward by setting boundaries, suggesting improvement, recommending future work, or making a final overall judgment when those functions are expected?
+
+For review papers, reinterpret the key steps:
+
+- `M1S3 Synthesizing key findings` = synthesized patterns across reviewed studies
+- `M1S4 Positioning findings against prior knowledge` = how the review updates, reorganizes, or challenges prior literature or prior reviews
+- `M2S3 Indicating limitations / boundaries` = limitations in the literature, evidence base, or review scope
+- `M3S2 Recommending future research` = a future research agenda grounded in the synthesis and limitations
+
+## Move 1: Consolidating the Study
+
+Move 1 looks back. It reminds readers what the study set out to do and consolidates the most important knowledge produced by the article.
+
+| Label | Step | Definition | Example |
+|---|---|---|---|
+| M1S1 | Restating purpose / scope | Restates the study aim, research question, problem, object, or scope of inquiry. It orients the Conclusion without reopening the Introduction. | "This study examined how peer feedback shapes revision decisions among undergraduate writers." |
+| M1S2 | Recalling method / evidence base | Briefly reminds readers of the method, data, corpus, sample, model, experiment, review scope, or evidence base when that reminder helps interpret the conclusion. | "Drawing on interviews and classroom observations, the study traced students' experiences across one semester." |
+| M1S3 | Synthesizing key findings | Brings together the most important empirical findings, review patterns, conceptual results, or argument outcomes. It should synthesize rather than list every result. | "Overall, the findings show that feedback uptake depended less on comment quantity than on students' trust in the reviewer." |
+| M1S4 | Positioning findings against prior knowledge | Explains how the findings respond to a research gap, extend, refine, confirm, challenge, or reorganize existing knowledge. | "These results extend previous genre-based writing research by showing that move awareness also affects peer-review decisions." |
+
+## Move 2: Evaluating the Study
+
+Move 2 judges what the study means. It evaluates the value, significance, implications, quality, and boundaries of the work.
+
+| Label | Step | Definition | Example |
+|---|---|---|---|
+| M2S1 | Indicating significance / contribution | States the importance, contribution, novelty, value, or field advancement of the findings or argument. | "The study contributes a classroom-level account of how affect mediates feedback engagement." |
+| M2S2 | Drawing implications / applications | Explains theoretical, practical, pedagogical, policy, clinical, technical, managerial, or methodological implications and possible applications. | "For writing teachers, the findings suggest that peer-review training should include trust-building and response strategies." |
+| M2S3 | Indicating limitations / boundaries | Identifies study limitations, evidence boundaries, unresolved problems, scope restrictions, generalizability limits, or limitations of the reviewed literature. | "Because the sample was drawn from one institution, the findings should be interpreted cautiously." |
+| M2S4 | Evaluating methodology / evidence quality | Evaluates the method, dataset, model, validation, measurement, analytical scope, or evidence quality, especially in technical, clinical, or computational studies. | "Although the model performed well on benchmark images, its robustness in active construction sites remains untested." |
+
+## Move 3: Projecting Forward
+
+Move 3 looks forward and gives closure. It turns findings and evaluation into improvement, future research, action, or a final take-home judgment.
+
+| Label | Step | Definition | Example |
+|---|---|---|---|
+| M3S1 | Suggesting improvements | Suggests concrete improvements to methods, data, intervention design, implementation, theory, tools, or study design, often in response to limitations. | "Future systems should integrate temporal site data rather than relying only on static images." |
+| M3S2 | Recommending future research | Recommends future research directions, questions, populations, contexts, variables, datasets, validation settings, or comparative work. | "Further studies should test whether these patterns hold across disciplines and proficiency levels." |
+| M3S3 | Making an overall closing claim | Gives a final judgment, take-home message, concluding claim, or broad closing statement that leaves readers with the article's main meaning. | "Taken together, the study shows that feedback literacy is not only a cognitive skill but also a relational practice." |
+
+## Labeling Guidance
+
+Assign the primary label to the sentence's dominant rhetorical function. Assign secondary labels when the sentence also performs another clear function.
+
+Do not assign a label only because of a cue word:
+
+- `This study` may signal `M1S1`, but only if the sentence restates the aim or scope.
+- `found` may signal `M1S3`, but only if the sentence synthesizes a key finding rather than repeating a method or background point.
+- `contribute` may signal `M2S1`, but only if the sentence explains value or advancement.
+- `should` may signal `M3S1` or `M3S2`, but only if it proposes improvement, action, or future research.
+- `limited` may signal `M2S3`, but only if it identifies a boundary or limitation of the study, evidence, field, or review.
+
+## Common Multi-Label Patterns
+
+| Pattern | Typical labels | Diagnostic note |
+|---|---|---|
+| Purpose plus finding | M1S1 + M1S3 | Common in short opening conclusion sentences. |
+| Finding plus significance | M1S3 + M2S1 | Strong conclusion move when a result is immediately evaluated. |
+| Finding plus implication | M1S3 + M2S2 | Common in applied fields, education, medicine, policy, engineering, and business. |
+| Limitation plus future research | M2S3 + M3S2 | A strong forward-looking chain when future work follows from a boundary. |
+| Evidence quality plus improvement | M2S4 + M3S1 | Common in computational, AI, engineering, and clinical validation studies. |
+| Future research plus closing claim | M3S2 + M3S3 | Common in final sentences that combine agenda and take-home message. |
+
+## Research Paper vs Review Paper
+
+When diagnosing a research paper, interpret `M1S3` as the author's own empirical, computational, conceptual, or evidence-based findings.
+
+When diagnosing a review paper, interpret `M1S3` as synthesized patterns across sources rather than a new experimental result. In review papers, `M2S3` often evaluates weaknesses in the field's evidence base, and `M3S2` should be grounded in the synthesis rather than a generic call for more studies.
+
+## Conclusion vs Discussion
+
+Conclusion is usually more compressed than Discussion. It should not re-run the full interpretation of every result. When a text is a combined Discussion and Conclusion, allow fuller explanation and literature dialogue, but still check whether the final passage performs looking-back synthesis and looking-forward closure.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/output-templates.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/output-templates.md
@@ -8,24 +8,32 @@ The diagnosis workflow may produce internal annotations, coverage judgments, and
 
 Output only the content that would normally appear under `Revision Priorities`. Do not include a `Revision Priorities` heading, section number, diagnosis summary, profile table, sentence-level annotation, coverage table, logic diagnosis, or closing note.
 
+Use this exact structure:
+
 ```markdown
 ### 必须修改
 
-| 原文句子 | 问题 | 为什么影响 Conclusion | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens the Conclusion when relevant]
+   - 具体改进方向: [specific revision direction in English]
 
 ### 建议修改
 
-| 原文句子 | 问题 | 为什么影响 Conclusion | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens the Conclusion when relevant]
+   - 具体改进方向: [specific revision direction in English]
 ```
+
+If one block has no items, keep the heading and write `No items.` under it.
 
 ## Item Rules
 
 - Put missing expected steps and weak items that materially affect Conclusion synthesis, significance, credibility, implication, future direction, or closure under `必须修改`.
 - Put weak items that would improve specificity, evidence, connection, implication, or flow but do not break the core Conclusion logic under `建议修改`.
+- Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+- Start each item with `Issue N:` followed by a concise English issue summary.
 - Anchor each item in original wording.
 - Do not invent findings, limitations, implications, applications, future directions, or contributions for the student.
-- If one block has no items, still keep the block and write `暂无` in the table cells.
+- Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/output-templates.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/output-templates.md
@@ -1,0 +1,31 @@
+# Conclusion Output Templates
+
+Use this template to keep Conclusion diagnoses focused on revision advice only.
+
+The diagnosis workflow may produce internal annotations, coverage judgments, and logic-chain checks. Do not include those internal diagnostic sections in the final response.
+
+## Final Output
+
+Output only the content that would normally appear under `Revision Priorities`. Do not include a `Revision Priorities` heading, section number, diagnosis summary, profile table, sentence-level annotation, coverage table, logic diagnosis, or closing note.
+
+```markdown
+### 必须修改
+
+| 原文句子 | 问题 | 为什么影响 Conclusion | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+### 建议修改
+
+| 原文句子 | 问题 | 为什么影响 Conclusion | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+```
+
+## Item Rules
+
+- Put missing expected steps and weak items that materially affect Conclusion synthesis, significance, credibility, implication, future direction, or closure under `必须修改`.
+- Put weak items that would improve specificity, evidence, connection, implication, or flow but do not break the core Conclusion logic under `建议修改`.
+- Anchor each item in original wording.
+- Do not invent findings, limitations, implications, applications, future directions, or contributions for the student.
+- If one block has no items, still keep the block and write `暂无` in the table cells.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/source-notes.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/source-notes.md
@@ -1,0 +1,58 @@
+# Source Notes
+
+The Conclusion framework in this skill is based on the user's local WisePen teaching materials and academic move-analysis literature.
+
+## Local WisePen Sources
+
+The original local teaching materials have been distilled into this skill's `references/workflow.md`, `references/move-step-definitions.md`, and related rubric files. They included:
+
+- a generic discourse-diagnostic workflow;
+- a locally annotated published-paper sample;
+- local Conclusion teaching notes;
+- a Week 13 teaching deck on Discussion and Conclusion language moves;
+- a local copy of Peacock's Discussion-move article.
+
+The local teaching materials frame Conclusion as serving two broad functions:
+
+- looking back: summarize and bring together the main areas or findings;
+- looking forward: give a final comment or judgment, including significance, improvement, and future directions.
+
+The user's specified teaching sequence is:
+
+1. revisit the most important findings and show how they advance the field;
+2. make a final judgment on importance and significance, implications, impact, and possible applications;
+3. indicate limitations when appropriate;
+4. suggest improvements;
+5. recommend future work.
+
+## Core Academic Basis
+
+Use Yang and Allison's model as the main research-article Conclusion basis:
+
+- Move 1: Summarizing the study
+- Move 2: Evaluating the study
+- Move 3: Deductions from the research
+
+This skill adapts those moves into the WisePen local numbering system:
+
+- `M1 Consolidating the Study`
+- `M2 Evaluating the Study`
+- `M3 Projecting Forward`
+
+The framework also draws on later research on Conclusion(s) sections and stand-alone Conclusions, including:
+
+- Yang, R., & Allison, D. (2003). Research articles in applied linguistics: Moving from results to conclusions. English for Specific Purposes, 22, 365-385. https://doi.org/10.1016/S0889-4906(02)00026-1
+- Farneste, M. (2017). Rhetorical structure of the Conclusions sections of applied linguistics research articles. Baltic Journal of English Language, Literature and Culture, 7, 25-42. https://doi.org/10.22364/BJELLC.07.2017.04
+- Kanoksilapatham, B. (2023). Structural organization of research article stand-alone conclusion sections. Journal of Language and Education, 9(3), 128-146. https://doi.org/10.17323/jle.2023.16907
+- Deng, F., & He, Q. (2023). Authorial stance in conclusion sections of research articles: A contrastive study of hard and soft sciences. Frontiers in Psychology, 14, 1175144. https://doi.org/10.3389/fpsyg.2023.1175144
+- Peacock, M. (2002). Communicative moves in the discussion section of research articles. System, 30, 479-497. https://doi.org/10.1016/S0346-251X(02)00050-7
+
+The skill uses Peacock mainly for discipline-sensitive caution about final-section moves, especially the idea that move expectations vary across fields and that recommendations, limitations, and claims should not be treated as equally obligatory in all disciplines.
+
+## Design Assumptions
+
+- V1 focuses on research-article Conclusions.
+- Dissertation and thesis Conclusions can be diagnosed adaptively, but they are not the default expectedness model.
+- Stand-alone Conclusions and combined Discussion-and-Conclusion sections are both accepted when the passage performs final-section functions.
+- The skill diagnoses rhetorical function, not grammar or phrase quality.
+- The framework should not require every possible step in every field.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/workflow.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/workflow.md
@@ -1,0 +1,257 @@
+# Conclusion Discourse Diagnostic Workflow
+
+This workflow diagnoses a submitted Conclusion-related section through a three-move Conclusion framework. It should produce teaching-oriented feedback, not grammar correction or full rewriting.
+
+## 0. Input Gate
+
+Confirm that the submitted text can reasonably be diagnosed as a Conclusion-related passage.
+
+Continue when:
+
+- the text is explicitly headed `Conclusion`, `Conclusions`, `Concluding Remarks`, `Conclusion and Implications`, `Discussion and Conclusion`, or a close equivalent;
+- the heading is absent but the passage clearly summarizes the study's main findings, evaluates significance, states implications, acknowledges limitations, recommends future work, or gives a final closing claim;
+- the user provides a full paper and the Conclusion-related section can be cleanly extracted;
+- the passage is short but still diagnosable, in which case state that the diagnosis is limited to the visible text.
+
+Stop or ask for more input when:
+
+- the text clearly belongs to another section and does not perform Conclusion functions;
+- the user asks for a full Conclusion diagnosis but provides only a title, abstract, outline, table, figure caption, or isolated sentence;
+- a full paper is provided but no Conclusion-related passage can be identified;
+- the text has too little rhetorical content to support move-step diagnosis.
+
+If the section type is uncertain, state the inference and mark later discipline- or section-specific judgments as provisional.
+
+## 1. Identify Article Profile
+
+Infer or read the profile from user metadata and the submitted text.
+
+Use this profile only to select appropriate expectations. It is not a checklist.
+
+| Profile dimension | What to identify |
+|---|---|
+| Discipline / subdiscipline | Broad field and, when possible, local field |
+| Article type | Research paper, review paper, theoretical paper, technical paper, mixed paper, dissertation-like study, or unclear |
+| Research tradition | Quantitative, qualitative, mixed, computational, laboratory, applied, conceptual, review-based, or unclear |
+| Data / evidence type | Participants, corpus, experiment, dataset, model, texts, sources, cases, materials, or unclear |
+| Topic / research object | The phenomenon, object, population, site, mechanism, method, model, or problem being concluded |
+| Intended contribution | Finding, claim, intervention, implication, method, model, framework, synthesis, recommendation, or unclear |
+| Confidence | High, Medium, or Low |
+
+Identify discipline first. Use the closest profile in `references/discipline-expectedness-profiles.md` as the first filter for expectedness. Then adjust by article type.
+
+If the exact discipline is unclear, map the text to the nearest broad family:
+
+- Natural sciences / engineering
+- Medical / life sciences
+- Computer science / AI / applied technology
+- Social sciences / education / applied linguistics / business
+- Humanities / law / theoretical fields
+
+If the fit is still weak, use cautious default expectations and mark discipline-sensitive judgments as provisional.
+
+## 2. Segment the Conclusion into Sentence-Level Units
+
+Segment the submitted text into sentence-level units before assigning move-step labels.
+
+Rules:
+
+- Use one sentence as one unit by default.
+- Use `U1`, `U2`, `U3` numbering for sentence units.
+- Do not split a sentence into clause units merely because it performs more than one step.
+- Preserve original wording for every unit.
+- Use the unit only as evidence; do not rewrite it during diagnosis.
+- Split only when the user explicitly asks for clause-level analysis or when numbered/listed subparts function like independent sentences.
+
+One sentence can count toward more than one step if the secondary function is rhetorically real, not merely implied by a keyword.
+
+## 3. Annotate Moves and Steps
+
+Use `references/move-step-definitions.md`.
+
+For each sentence unit, assign:
+
+- one primary move-step label for the dominant rhetorical function;
+- secondary label(s), if the sentence also performs additional rhetorical functions;
+- confidence;
+- a short reason grounded in rhetorical function.
+
+Use this table:
+
+| Unit | Sentence | Primary label | Secondary label(s) | Confidence | Reason |
+|---|---|---|---|---|---|
+| U1 | ... | M1S3 | M2S1 | High | ... |
+
+Confidence labels:
+
+| Confidence | Meaning |
+|---|---|
+| High | The rhetorical function is explicit |
+| Medium | The function is likely but partly implicit |
+| Low | The function is ambiguous or underdeveloped |
+
+Judge rhetorical function in context, not by keyword matching alone.
+
+## 4. Build the Expectedness Model
+
+Build expectedness primarily by discipline, then adjust by article type.
+
+Use `references/discipline-expectedness-profiles.md`.
+
+Use only these expectedness labels:
+
+| Expectedness | Meaning | Can absence be criticized? |
+|---|---|---|
+| Core | A central function for this Conclusion type or discipline | Yes |
+| Conventional | Normally expected in this discipline or article type | Yes |
+| Strongly Expected | Highly expected; absence usually creates a serious weakness | Yes |
+| Conditional | Expected only when triggered by the study, article type, local context, or prior section design | Yes, if triggered |
+| Optional / Enriching | Useful but not required | No |
+| Rare / Not Expected | Normally not expected | No |
+| Not Applicable | Does not fit the study design, discipline, or article type | No |
+
+Do not ask whether all steps appear. Ask which steps are pedagogically important for this text's discipline, article type, and research tradition.
+
+For research-paper Conclusions, begin with this fast backbone check:
+
+1. Is there a clear `M1S3 Synthesizing key findings`?
+2. Does the Conclusion explain why the findings matter through `M2S1` and/or `M2S2`?
+3. If the study has visible limitations or strong claims, does it set appropriate boundaries through `M2S3` or `M2S4`?
+4. If future work is expected, does `M3S2` follow from the findings, limitations, or implications?
+5. Does the final sentence give a meaningful close through `M3S3` or a clearly equivalent field-specific final judgment?
+
+Article-type adjustments:
+
+- Empirical research papers usually need finding synthesis and contribution or implication; limitations and future work depend on discipline and whether Discussion already handled them.
+- Review papers need synthesis of literature patterns, field-level significance, literature limitations, and a grounded future agenda.
+- Technical or computational papers need contribution, evidence quality, validation boundary, and concrete future improvement more than broad rhetorical flourish.
+- Theoretical or conceptual papers may realize findings as arguments, propositions, interpretations, or framework claims rather than empirical results.
+- Dissertation-like Conclusions are usually more complex and may require explicit limitations, recommendations, and future work, but this skill's v1 default is research articles.
+
+Use `Optional / Enriching` and `Rare / Not Expected` internally, but do not criticize students for missing them in final feedback.
+
+## 5. Evaluate Expected Move-Step Coverage
+
+Use only these five status labels:
+
+| Status | Definition |
+|---|---|
+| Present | The rhetorical function is clearly realized |
+| Weak | The function is attempted but underdeveloped, vague, unsupported, poorly connected, or lacking necessary detail |
+| Missing | A Core, Conventional, Strongly Expected, or triggered Conditional function is absent |
+| Not Applicable | The function does not fit the study design, discipline, article type, or local context |
+| Unclear | The available text is insufficient to decide whether the function is relevant or realized |
+
+Keep three layers separate:
+
+- Expectedness: whether a function should be checked.
+- Status: how well the submitted text realizes that function.
+- Confidence: how certain the annotator is about a sentence-level label.
+
+Use this coverage table:
+
+| Move / Step / Function | Expectedness | Status | Evidence | Problem | Why it matters |
+|---|---|---|---|---|---|
+| M1S3 Synthesizing key findings | Core | Present / Weak / Missing / Not Applicable / Unclear | ... | ... | ... |
+
+Mark Present only when the rhetorical function is achieved, not merely when a keyword appears. Mark Missing only when the function is expected for this specific text.
+
+## 6. Diagnose Conclusion Logic Chains
+
+Read `references/logic-chain-rubric.md`.
+
+Diagnose whether the Conclusion's rhetorical functions connect to each other. This is separate from move-step coverage.
+
+Check logic chains that fit the text, such as:
+
+- research purpose / problem -> key finding -> field advancement
+- key finding -> significance -> implication / application
+- limitation -> improvement -> future research
+- review synthesis -> literature limitation -> future agenda
+- technical / clinical finding -> validation boundary -> practical implication
+- finding / synthesis -> final closing claim
+
+Use this table:
+
+| Logic chain | Evidence | Break / weak link | Why it weakens Conclusion | Revision direction |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+Do not force a chain that does not fit the article type or local passage.
+
+## 7. Identify Key Missing or Weak Functions
+
+Summarize the most important Missing, Weak, or Unclear functions.
+
+Use this table:
+
+| Function | Status | Evidence | Why it matters | Revision direction |
+|---|---|---|---|---|
+| M2S1 Significance / contribution | Weak | ... | ... | ... |
+
+Prioritize issues that weaken Conclusion persuasiveness:
+
+- the section repeats background but does not synthesize key findings;
+- findings are summarized but not evaluated for significance or contribution;
+- implications are generic or disconnected from findings;
+- limitations are missing when the study's scope, evidence, or claims require boundaries;
+- future research is generic and does not follow from findings or limitations;
+- the final sentence ends abruptly without a closing judgment;
+- the Conclusion introduces new findings or literature that should have been handled earlier.
+
+Use the discipline profile to avoid over-diagnosing light steps. For example:
+
+- in short hard-science Conclusions, do not force long literature dialogue or extensive limitation discussion when the findings and contribution are clear;
+- in applied social sciences, education, and business, treat weak implications and weak future directions more seriously;
+- in technical AI or engineering papers, treat missing validation boundaries or vague future improvements more seriously;
+- in review papers, treat simple summary without synthesis as a serious weakness.
+
+## 8. Convert Diagnosis into Teaching Feedback
+
+Generate feedback in a teaching style:
+
+- begin from what the Conclusion already does;
+- identify missing, weak, or unclear rhetorical functions;
+- explain why each issue affects synthesis, significance, credibility, impact, or closure;
+- before writing a feedback item, return to the original sentence and confirm that the problem is real;
+- separate the closing feedback into two blocks: 必须修改 and 建议修改;
+- tell the student what kind of content to add or clarify next;
+- avoid replacing diagnosis with polished rewritten prose.
+
+Useful feedback pattern:
+
+```text
+Your Conclusion already does X. However, it does not yet do Y. This matters because Z. To revise, add or clarify A, B, and C.
+```
+
+Use this pattern only to decide the table content. Do not output a paragraph-style diagnosis unless the user explicitly asks for a separate explanation outside the skill's final format.
+
+## 9. Output Structure
+
+Steps 1-8 are internal diagnostic work. They support the priority judgment, but they must not appear in the final response.
+
+Final output must contain only the content of `Revision Priorities`.
+
+Do not output:
+
+- `## 7. Revision Priorities` or any `Revision Priorities` heading;
+- Overall Diagnosis;
+- Article Profile;
+- Sentence-Level Move-Step Annotation;
+- Expected Move / Step Coverage;
+- Conclusion Logic Diagnosis;
+- Key Missing or Weak Functions;
+- paragraph summaries, scores, introductions, closing notes, or follow-up questions.
+
+Output two blocks in this order:
+
+- 必须修改: missing expected steps and weak items that materially affect Conclusion synthesis, significance, credibility, implication, future direction, or closure.
+- 建议修改: weak items that would improve specificity, evidence, connection, implication, or flow but do not break the core Conclusion logic.
+
+Each block must use this table:
+
+| 原文句子 | 问题 | 为什么影响 Conclusion | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+Each item must be anchored in original wording and should not invent content for the student. If one block has no items, still keep the block and write `暂无` in the table cells.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/workflow.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-conclusion-skill/1.0/references/workflow.md
@@ -248,10 +248,15 @@ Output two blocks in this order:
 - 必须修改: missing expected steps and weak items that materially affect Conclusion synthesis, significance, credibility, implication, future direction, or closure.
 - 建议修改: weak items that would improve specificity, evidence, connection, implication, or flow but do not break the core Conclusion logic.
 
-Each block must use this table:
+Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
 
-| 原文句子 | 问题 | 为什么影响 Conclusion | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
+Each item must follow this structure:
 
-Each item must be anchored in original wording and should not invent content for the student. If one block has no items, still keep the block and write `暂无` in the table cells.
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens the Conclusion when relevant]
+   - 具体改进方向: [specific revision direction in English]
+
+Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.
+
+Each item must be anchored in original wording and should not invent content for the student. If one block has no items, keep the block and write `No items.` under it.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/SKILL.md
@@ -28,29 +28,53 @@ For research papers, use `M2S1 Finding`, `M4S1 Reference to Previous Research`, 
 
 ## Required Workflow
 
-When performing a real diagnosis, first read `references/workflow.md` and follow its sequence:
+When performing a real diagnosis, first call `load_skill_asset` on `references/workflow.md` and follow its sequence.
+
+For every workflow step below, you MUST call `load_skill_asset` for each listed file before completing that step. If the same file has already been loaded earlier in the current turn, reuse the already loaded content instead of calling `load_skill_asset` again.
 
 1. verify that the input is a Discussion-related section or passage;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/failure-strategies.md`
 2. identify discipline, article type, research tradition, evidence type, topic, and intended contribution;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/discipline-sensitive-profiles.md`
 3. segment the text by sentence-level functional units;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
 4. annotate each sentence with one primary move-step label and any secondary labels;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/discussion-move-definitions.md`
 5. build a Peacock-informed discipline-sensitive expectation model, then adjust by article type;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/discipline-sensitive-profiles.md`
 6. judge expected move coverage using stable status labels;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
 7. diagnose Discussion-specific logic chains;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/logic-chain-rubric.md`
 8. identify key missing or weak functions;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/discussion-move-definitions.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
 9. generate teaching-oriented feedback and revision priorities.
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/output-templates.md`
 
 ## Reference Files
 
-Load only the files needed for the current task:
+For a real Discussion diagnosis, the following files are required by the workflow above and must be loaded through `load_skill_asset` when their workflow step is reached:
 
-- `references/discussion-move-definitions.md`: read when assigning or explaining Discussion move labels.
-- `references/discipline-sensitive-profiles.md`: read when deciding which moves are Core, Conventional, Conditional, or Not Applicable for a discipline, and when using the simplified Peacock-style profiles for research papers and review papers.
-- `references/diagnostic-rubric.md`: read when judging Expectedness, Present, Weak, Missing, Not Applicable, Unclear, and revision priority.
-- `references/logic-chain-rubric.md`: read when diagnosing Discussion coherence, including finding-explanation-claim and finding-limitation-recommendation chains.
-- `references/output-templates.md`: read when formatting the final revision-priority-only answer.
-- `references/failure-strategies.md`: read when the input may not be a Discussion, is too short, lacks discipline metadata, or asks only for rewriting.
-- `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses this framework.
+- `references/workflow.md`: required for every real Discussion diagnosis.
+- `references/failure-strategies.md`: required during input-gate and failure-mode handling.
+- `references/discipline-sensitive-profiles.md`: required when identifying article profile and deciding which moves are Core, Conventional, Conditional, or Not Applicable for a discipline and article type.
+- `references/discussion-move-definitions.md`: required when assigning or explaining Discussion move labels.
+- `references/diagnostic-rubric.md`: required when judging Expectedness, Present, Weak, Missing, Not Applicable, Unclear, and revision priority.
+- `references/logic-chain-rubric.md`: required when diagnosing Discussion coherence, including finding-explanation-claim and finding-limitation-recommendation chains.
+- `references/output-templates.md`: required when formatting the final revision-priority-only answer.
+
+Conditional reference:
+
+- `references/source-notes.md`: MUST load via `load_skill_asset` when the user asks about the theoretical basis, citations, source basis, or why the skill uses this framework.
 
 ## Default Output
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/SKILL.md
@@ -48,28 +48,29 @@ Load only the files needed for the current task:
 - `references/discipline-sensitive-profiles.md`: read when deciding which moves are Core, Conventional, Conditional, or Not Applicable for a discipline, and when using the simplified Peacock-style profiles for research papers and review papers.
 - `references/diagnostic-rubric.md`: read when judging Expectedness, Present, Weak, Missing, Not Applicable, Unclear, and revision priority.
 - `references/logic-chain-rubric.md`: read when diagnosing Discussion coherence, including finding-explanation-claim and finding-limitation-recommendation chains.
-- `references/output-templates.md`: read when formatting a full diagnostic report, short classroom feedback, sentence-level feedback, or coverage-only answer.
+- `references/output-templates.md`: read when formatting the final revision-priority-only answer.
 - `references/failure-strategies.md`: read when the input may not be a Discussion, is too short, lacks discipline metadata, or asks only for rewriting.
 - `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses this framework.
 
 ## Default Output
 
-Unless the user asks for a shorter format, return seven sections:
+Unless the user explicitly asks for a different format, return only the final concrete revision priorities.
 
-1. Overall Diagnosis
-2. Article Profile
-3. Functional-Unit Move-Step Annotation
-4. Expected Move Coverage
-5. Discussion Logic Diagnosis
-6. Key Missing or Weak Functions
-7. Revision Priorities
-
-In section 7, split the closing feedback into two tables, in this order:
+Do not include overall diagnosis, article profile, move-step annotation, coverage tables, logic diagnosis, missing/weak-function tables, diagnostic summaries, or closing notes in the final response. Use those analyses internally, then output only two blocks in this order:
 
 - 必须修改
 - 建议修改
 
-Each table should use `原文句子 | 问题 | 为什么影响 Discussion | 具体改进方向`.
+Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+
+Each issue must follow this structure:
+
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens Discussion when relevant]
+   - 具体改进方向: [specific revision direction in English]
+
+Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.
 
 ## Constraints
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: diagnose-discussion-skill
+description: Diagnoses the rhetorical move structure and coherence of academic Discussion sections using an 8-move Discussion framework based on research article discussion move studies. Use when Codex needs to check, evaluate, diagnose, or give pedagogical feedback on Discussion, Results and Discussion, Discussion and Conclusion, or review-article discussion passages, including missing or weak discussion moves, weak finding-explanation-claim logic, lack of connection to previous research, unsupported claims, missing limitations, or underdeveloped recommendations.
+---
+
+# Diagnose Discussion Skill
+
+Use this skill to diagnose whether a student's academic Discussion section interprets findings or synthesized evidence, connects them to previous research, explains their meaning, and develops credible claims, limitations, and recommendations.
+
+This skill is for academic English writing pedagogy. Produce diagnostic feedback, not grammar correction, style polishing, or a full rewrite unless the user explicitly asks for revision after diagnosis.
+
+## Core Framework
+
+Use the 8-move Discussion framework adapted from the user's source notes and `references/discussion-move-definitions.md`:
+
+- Move 1: Information Move
+- Move 2: Finding
+- Move 3: Expected or Unexpected Outcome
+- Move 4: Reference to Previous Research
+- Move 5: Explanation
+- Move 6: Claim
+- Move 7: Limitation
+- Move 8: Recommendation
+
+A move is a broad rhetorical function in the Discussion. This skill currently treats each move as one primary step using the unified `M1S1`, `M2S1` format so it remains compatible with the shared discourse-diagnostic workflow.
+
+For research papers, use `M2S1 Finding`, `M4S1 Reference to Previous Research`, and `M6S1 Claim` as the first-pass anchor moves. For review papers, interpret `M2S1` as a synthesized finding across studies and `M6S1` as a field-level claim.
+
+## Required Workflow
+
+When performing a real diagnosis, first read `references/workflow.md` and follow its sequence:
+
+1. verify that the input is a Discussion-related section or passage;
+2. identify discipline, article type, research tradition, evidence type, topic, and intended contribution;
+3. segment the text by sentence-level functional units;
+4. annotate each sentence with one primary move-step label and any secondary labels;
+5. build a Peacock-informed discipline-sensitive expectation model, then adjust by article type;
+6. judge expected move coverage using stable status labels;
+7. diagnose Discussion-specific logic chains;
+8. identify key missing or weak functions;
+9. generate teaching-oriented feedback and revision priorities.
+
+## Reference Files
+
+Load only the files needed for the current task:
+
+- `references/discussion-move-definitions.md`: read when assigning or explaining Discussion move labels.
+- `references/discipline-sensitive-profiles.md`: read when deciding which moves are Core, Conventional, Conditional, or Not Applicable for a discipline, and when using the simplified Peacock-style profiles for research papers and review papers.
+- `references/diagnostic-rubric.md`: read when judging Expectedness, Present, Weak, Missing, Not Applicable, Unclear, and revision priority.
+- `references/logic-chain-rubric.md`: read when diagnosing Discussion coherence, including finding-explanation-claim and finding-limitation-recommendation chains.
+- `references/output-templates.md`: read when formatting a full diagnostic report, short classroom feedback, sentence-level feedback, or coverage-only answer.
+- `references/failure-strategies.md`: read when the input may not be a Discussion, is too short, lacks discipline metadata, or asks only for rewriting.
+- `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses this framework.
+
+## Default Output
+
+Unless the user asks for a shorter format, return seven sections:
+
+1. Overall Diagnosis
+2. Article Profile
+3. Functional-Unit Move-Step Annotation
+4. Expected Move Coverage
+5. Discussion Logic Diagnosis
+6. Key Missing or Weak Functions
+7. Revision Priorities
+
+In section 7, split the closing feedback into two tables, in this order:
+
+- 必须修改
+- 建议修改
+
+Each table should use `原文句子 | 问题 | 为什么影响 Discussion | 具体改进方向`.
+
+## Constraints
+
+Do not:
+
+- require all 8 moves in every Discussion;
+- treat Optional / Enriching or Rare / Not Expected moves as missing problems;
+- diagnose by keyword matching alone;
+- replace rhetorical diagnosis with grammar correction;
+- rewrite the whole Discussion unless requested;
+- invent missing findings, literature, explanations, claims, limitations, recommendations, or implications;
+- mark a move as Missing when an equivalent discipline-specific function is present;
+- use the term "optional" in final feedback to criticize the student's text.
+
+Do:
+
+- focus on rhetorical function;
+- preserve and quote original wording;
+- use sentence-level units by default;
+- allow one sentence to carry one primary label and multiple secondary labels;
+- separate Expectedness, Status, and Confidence;
+- distinguish Missing from Weak;
+- judge move coverage and logic-chain coherence separately;
+- explain why each issue matters for Discussion persuasiveness, interpretation, contribution, or reader trust;
+- separate must-fix and suggested-fix items;
+- provide concrete revision directions without inventing content for the student.
+
+
+

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/diagnostic-rubric.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/diagnostic-rubric.md
@@ -1,0 +1,126 @@
+# Discussion Diagnostic Rubric
+
+Use this rubric to judge Discussion move coverage and decide revision priorities.
+
+## Expectedness
+
+Expectedness describes whether a move should be checked for this discipline, article type, and passage.
+
+| Expectedness | Meaning | Can absence be criticized? |
+|---|---|---|
+| Core | A central function for this Discussion type or discipline | Yes |
+| Conventional | Normally expected in this discipline or article type | Yes |
+| Strongly Expected | Highly expected; absence usually creates a serious weakness | Yes |
+| Conditional | Expected only when triggered by findings, study design, article type, or local context | Yes, if triggered |
+| Optional / Enriching | Useful but not required | No |
+| Rare / Not Expected | Normally not expected | No |
+| Not Applicable | Does not fit the study design, discipline, or article type | No |
+
+Use `references/discipline-sensitive-profiles.md` as the default guide for discipline-sensitive expectedness. If no close profile fits, fall back to the nearest broad family and infer cautiously from article type and visible rhetorical needs.
+
+## Fast First Pass
+
+Before doing a full coverage diagnosis, use this simplified check:
+
+1. Is there a clear `M2S1 Finding` or synthesized `M2S1`?
+2. Is there a credible `M6S1 Claim` that says what the finding means?
+3. Where the discipline expects it, is there `M4S1 Reference to Previous Research`?
+4. If the result is surprising or inconsistent, is there `M3S1` and preferably `M5S1`?
+5. If the section closes with future direction, does `M8S1` follow from the findings or limitations?
+
+For many research-paper Discussions, the absence of a clear `M2S1`-`M6S1` backbone is the quickest sign that the Discussion is underdeveloped.
+
+## Coverage Status
+
+Use only these five status labels:
+
+| Status | Definition |
+|---|---|
+| Present | The rhetorical function is clearly realized |
+| Weak | The function is attempted but underdeveloped, vague, unsupported, poorly connected, or lacking necessary detail |
+| Missing | A Core, Conventional, Strongly Expected, or triggered Conditional function is absent |
+| Not Applicable | The function does not fit the study design, discipline, article type, or local context |
+| Unclear | The available text is insufficient to decide whether the function is relevant or realized |
+
+## Status Rules by Move
+
+### M1S1 Information Move
+
+Present when the sentence gives necessary context for interpreting the Discussion, such as aim, scope, theory, method reminder, or review focus.
+
+Weak when context is too broad, repetitive, disconnected from the following interpretation, or used as filler.
+
+Missing only when readers need context to understand the Discussion and the text does not provide it.
+
+### M2S1 Finding
+
+Present when the sentence reports a major empirical finding or synthesizes a review pattern clearly enough for discussion.
+
+Weak when the finding is vague, too general, unsupported by visible results, or not specific enough to support interpretation.
+
+Missing when the Discussion makes claims, explanations, limitations, or recommendations without first making the relevant finding or synthesis clear.
+
+### M3S1 Expected or Unexpected Outcome
+
+Present when the sentence explicitly frames a finding as expected, unexpected, consistent, inconsistent, contrary, or surprising.
+
+Weak when it signals expectation or surprise but does not identify the basis of comparison.
+
+Missing only when the text discusses an anomalous, contradictory, or surprising result but never frames it as such.
+
+### M4S1 Reference to Previous Research
+
+Present when the sentence connects the current finding, synthesis, or claim to previous research, theory, or prior reviews.
+
+Weak when previous research is mentioned as a citation list without explaining agreement, contrast, extension, or correction.
+
+Missing when expected findings or claims are not situated in relation to the relevant literature.
+
+### M5S1 Explanation
+
+Present when the sentence explains why a finding, pattern, or inconsistency may have occurred.
+
+Weak when the explanation is speculative, generic, unsupported, or disconnected from the actual finding.
+
+Missing when findings are reported or compared but not interpreted.
+
+### M6S1 Claim
+
+Present when the sentence draws a higher-level interpretation, contribution, implication, or argument from the finding or synthesis.
+
+Weak when the claim is too broad, unsupported, repetitive, or not clearly derived from the evidence.
+
+Missing when the Discussion reports or summarizes findings without saying what they mean.
+
+### M7S1 Limitation
+
+Present when the sentence identifies a boundary, weakness, unresolved problem, or limitation of the study, method, evidence, or literature.
+
+Weak when the limitation is formulaic, vague, or not tied to interpretation of the findings.
+
+Missing when disciplinary or article-type expectations require limitations for credibility, or when the claim is broad enough that boundaries are needed.
+
+### M8S1 Recommendation
+
+Present when the sentence proposes a future research direction, methodological improvement, theoretical extension, or practical application.
+
+Weak when the recommendation is generic, unsupported, or not clearly derived from findings, limitations, or claims.
+
+Missing when the Discussion ends with unresolved limitations or implications that clearly require a next step.
+
+## Revision Priority
+
+Use `必须修改` for:
+
+- Missing Core, Conventional, Strongly Expected, or triggered Conditional moves;
+- Weak moves that damage the core logic of the Discussion;
+- Unclear functions when ambiguity prevents readers from understanding the Discussion's interpretation or contribution;
+- logic-chain breaks that prevent the Discussion from being persuasive, credible, or coherent.
+
+Use `建议修改` for:
+
+- Weak functions that mainly need more specificity, evidence, comparison, explanation, or clearer wording;
+- local improvements that would strengthen reader trust but do not break the Discussion's central logic;
+- enriching moves that would improve the Discussion but are not required.
+
+Do not duplicate the same issue in both priority blocks.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/discipline-sensitive-profiles.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/discipline-sensitive-profiles.md
@@ -1,0 +1,144 @@
+# Discipline-Sensitive Discussion Profiles
+
+Use this file to decide which Discussion moves are easiest to judge and most pedagogically important for a given discipline.
+
+These profiles simplify the Discussion diagnosis by starting from Peacock-style cross-disciplinary anchors and then narrowing the judgment by discipline.
+
+## Shared Starting Point for Research Papers
+
+Do not require all eight moves.
+
+For research-paper Discussions, begin with these anchor moves:
+
+- `M2S1 Finding`
+- `M6S1 Claim`
+- `M4S1 Reference to Previous Research`
+
+These are the easiest first-pass checks across disciplines. `M8S1 Recommendation` is also common, but not equally strong in every field.
+
+Use the remaining moves more selectively:
+
+- `M1S1 Information Move`: often light or local
+- `M3S1 Expected / Unexpected Outcome`: especially important when results are surprising or contrasted
+- `M5S1 Explanation`: especially important when the field values mechanism or interpretation
+- `M7S1 Limitation`: important when credibility, boundary-setting, or future work depends on it
+
+## Research Paper Profiles
+
+### Physics / Material Science
+
+- Core: `M2S1 Finding`, `M5S1 Explanation`, `M6S1 Claim`
+- Conventional: `M1S1 Information Move`
+- Conditional: `M3S1`, `M4S1`, `M7S1`, `M8S1`
+- Easy diagnostic focus: do not force heavy literature comparison; check whether the finding is interpreted and whether the claim is clear.
+- Common chain: `M2S1 -> M5S1 -> M6S1`
+
+### Biology
+
+- Core: `M2S1 Finding`, `M5S1 Explanation`, `M6S1 Claim`
+- Conventional: `M3S1 Expected / Unexpected Outcome`, `M4S1 Reference to Previous Research`, `M8S1 Recommendation`
+- Conditional: `M7S1 Limitation`, `M1S1 Information Move`
+- Easy diagnostic focus: check whether findings, especially unexpected ones, are fully explained.
+- Common chains: `M2S1 -> M5S1 -> M6S1`; `M2S1 -> M3S1 -> M5S1 -> M6S1`
+
+### Environmental Science
+
+- Core: `M2S1 Finding`, `M5S1 Explanation`, `M6S1 Claim`
+- Conventional: `M1S1 Information Move`
+- Conditional: `M3S1`, `M4S1`, `M7S1`, `M8S1`
+- Easy diagnostic focus: emphasize explanation of results and the central claim; do not mechanically require all eight moves.
+- Common chain: `M2S1 -> M5S1 -> M6S1`
+
+### Business / Management
+
+- Core: `M2S1 Finding`, `M4S1 Reference to Previous Research`, `M6S1 Claim`
+- Conventional: `M8S1 Recommendation`
+- Conditional: `M5S1 Explanation`, `M7S1 Limitation`, `M3S1 Expected / Unexpected Outcome`, `M1S1 Information Move`
+- Easy diagnostic focus: check whether the Discussion turns results into managerial, practical, or future-research meaning.
+- Common chain: `M2S1 -> M4S1 -> M6S1 -> M8S1`
+
+### Language and Linguistics
+
+- Core: `M2S1 Finding`, `M4S1 Reference to Previous Research`, `M6S1 Claim`
+- Conventional: `M5S1 Explanation`
+- Conditional: `M3S1`, `M7S1`, `M8S1`, `M1S1`
+- Easy diagnostic focus: check whether the finding is placed in dialogue with prior studies rather than reported in isolation.
+- Common chain: `M2S1 -> M4S1 -> M6S1`
+
+### Public and Social Administration
+
+- Core: `M2S1 Finding`, `M4S1 Reference to Previous Research`, `M6S1 Claim`
+- Conventional: `M3S1 Expected / Unexpected Outcome`, `M8S1 Recommendation`
+- Conditional: `M5S1 Explanation`, `M7S1 Limitation`, `M1S1 Information Move`
+- Easy diagnostic focus: check whether outcomes and claims are interpreted through social-science literature, theory, or policy context.
+- Common chains: `M2S1 -> M4S1 -> M6S1`; `M3S1 -> M4S1 -> M6S1`
+
+### Law
+
+- Core: `M4S1 Reference to Previous Research`, `M6S1 Claim`
+- Conventional: `M2S1 Finding or evidence-based point`, `M5S1 Explanation`
+- Conditional: `M7S1 Limitation`, `M8S1 Recommendation`, `M1S1 Information Move`, `M3S1`
+- Easy diagnostic focus: allow complex argument cycles; do not force a simple experimental pattern.
+- Common chain: `M2S1 / evidence -> argument cycle -> M6S1`
+
+## Broad Fallback Families
+
+Use these when the exact discipline is unclear.
+
+### Natural Sciences
+
+- Preferred chain: `M2S1 Finding -> M3S1 Expected / Unexpected Outcome -> M5S1 Explanation -> M6S1 Claim`
+- Main judgment: is the result interpreted and turned into a clear claim?
+
+### Social Sciences / Applied Fields
+
+- Preferred chain: `M2S1 Finding -> M4S1 Previous Research -> M6S1 Claim -> M8S1 Recommendation`
+- Main judgment: does the Discussion connect findings to prior research and derive implications or future direction?
+
+### Language and Humanities-Like Fields
+
+- Preferred chain: `M2S1 Finding -> M4S1 Previous Research -> M6S1 Claim`
+- Main judgment: is the finding placed in literature-based dialogue rather than left isolated?
+
+### Law
+
+- Preferred chain: `M2S1 Evidence / finding -> argument cycle -> M6S1 Claim`
+- Main judgment: is there a coherent argument cycle leading to a clear legal claim?
+
+## Review Paper Discussion
+
+Review papers use similar moves, but the object of discussion is the literature rather than one new dataset or experiment.
+
+Treat the four easiest-to-judge parts as:
+
+### 1. Synthesize the main patterns across studies
+
+- Moves: `M2S1 Finding` + `M6S1 Claim`
+- Role: move from listed studies to a synthesized finding and field-level interpretation
+- Example focus: do not accept simple repetition of sections or citation lists
+
+### 2. Identify limitations in the current literature
+
+- Move: `M7S1 Limitation`
+- Role: diagnose weaknesses in datasets, methods, field validation, theory, scope, or fragmentation
+- Example focus: check whether the limitation concerns the field, not only a single study
+
+### 3. Compare the current review with earlier reviews
+
+- Move: `M4S1 Reference to Previous Research`
+- Role: show what this review updates, expands, reclassifies, or newly emphasizes
+- Example focus: check whether the review positions itself against prior reviews when that comparison is relevant
+
+### 4. Propose grounded future directions
+
+- Move: `M8S1 Recommendation`
+- Role: propose specific next research steps derived from the synthesis and limitations
+- Example focus: reject generic statements like "more research is needed" when no concrete direction follows
+
+## Review Paper Defaults
+
+- Core: `M2S1 Synthesized Finding`, `M6S1 Field-Level Claim`
+- Conventional: `M7S1 Limitation`, `M4S1 Comparison with prior reviews or literature streams`, `M8S1 Recommendation`
+- Conditional: `M1S1 Information Move`, `M3S1 Expected / Unexpected Outcome`
+- Easy diagnostic focus: the Discussion should synthesize patterns, evaluate the field's limits, position the review against earlier reviews when needed, and end with specific future directions.
+- Common chain: `M2S1 -> M6S1 -> M7S1 -> M8S1`, with `M4S1` added when comparison with earlier reviews matters.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/discussion-move-definitions.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/discussion-move-definitions.md
@@ -1,0 +1,62 @@
+# Discussion Move Definitions
+
+Use these labels when diagnosing Discussion, Results and Discussion, Discussion and Conclusion, or review-article discussion passages.
+
+This skill uses the unified `M1S1` format. Each of the eight current Discussion moves has one step for now, so the step code represents the move-level function. A sentence may receive one primary label and multiple secondary labels.
+
+## Easy First-Pass Version
+
+For research papers, start with three anchor questions:
+
+1. Is the sentence or paragraph discussing a real `M2S1 Finding`?
+2. Does it connect that finding to a broader `M6S1 Claim`?
+3. In literature-dialogue disciplines, does it use `M4S1 Reference to Previous Research`?
+
+Treat `M8S1 Recommendation` as common but not universally required. Treat `M1S1`, `M3S1`, `M5S1`, and `M7S1` as more discipline-sensitive.
+
+For review papers, reinterpret the key moves:
+
+- `M2S1 Finding` = a synthesized finding or pattern across studies
+- `M6S1 Claim` = a field-level claim or synthesis claim
+- `M7S1 Limitation` = a limitation of the literature or of the review
+- `M4S1 Reference to Previous Research` = comparison with prior reviews, theories, or literature streams
+- `M8S1 Recommendation` = a future research agenda grounded in the synthesis
+
+| Label | Move | Name | Definition | Example |
+|---|---|---|---|---|
+| M1S1 | Move 1 | Information Move | Provides necessary background for interpreting the discussion, such as theoretical context, research aims, methodological reminders, or the scope of the discussion. In a review paper, this may restate the review focus or analytical framework. | "To interpret these findings, it is important to consider the study's focus on first-year undergraduate writers." |
+| M2S1 | Move 2 | Finding | Reports or synthesizes a major finding. In an empirical research paper, this refers to the author's own results. In a review paper, this refers to a synthesized pattern across reviewed studies. | "The results show that genre-based instruction improved students' awareness of rhetorical structure." / "Across the reviewed studies, LLMs were most often applied to text-based safety knowledge management." |
+| M3S1 | Move 3 | Expected or Unexpected Outcome | Comments on whether a finding is expected, surprising, consistent, inconsistent, or contrary to assumptions, theories, or previous research. | "This result was unexpected, as previous studies generally found that peer feedback had only limited effects on revision quality." |
+| M4S1 | Move 4 | Reference to Previous Research | Connects the current finding, synthesis, or claim to previous studies, existing theories, or prior reviews. This may show agreement, contrast, extension, or correction. | "This finding is consistent with Hyland's argument that academic writing conventions vary across disciplines." |
+| M5S1 | Move 5 | Explanation | Explains why a finding, pattern, or inconsistency may have occurred. The explanation may refer to methods, samples, contexts, theoretical assumptions, or disciplinary differences. | "One possible explanation is that students had limited prior experience with academic English writing." |
+| M6S1 | Move 6 | Claim | Draws a higher-level interpretation, contribution, implication, or argument from the finding. In a review paper, this often becomes a field-level claim rather than a claim about one dataset. | "These findings suggest that rhetorical move awareness is essential for improving students' discussion writing." / "This pattern suggests that the field is moving from isolated detection tasks toward integrated safety reasoning systems." |
+| M7S1 | Move 7 | Limitation | Identifies limitations, boundaries, weaknesses, or unresolved problems. In an empirical paper, this may concern the author's study. In a review paper, this may concern the existing literature or the review itself. | "A limitation of this study is its relatively small sample size." / "Existing studies are limited by small datasets and insufficient real-world validation." |
+| M8S1 | Move 8 | Recommendation | Proposes future research directions, methodological improvements, theoretical extensions, or practical applications based on the previous discussion. | "Future research should examine whether this move-based approach works across different disciplines and proficiency levels." |
+
+## Labeling Guidance
+
+Assign the primary label to the sentence's dominant rhetorical function.
+
+Assign secondary labels when the sentence also performs another clear function. For example, a sentence may compare the current finding with previous research and then draw an implication. In that case, M4S1 may be primary and M6S1 secondary, or the reverse, depending on which function controls the sentence.
+
+Do not assign a label only because of a cue word. For example:
+
+- `suggests` may signal M6S1 Claim, but only if the sentence draws a broader interpretation or implication.
+- `consistent with` may signal M4S1 Reference to Previous Research, but only if it actually connects to prior research, theory, or literature.
+- `may be because` may signal M5S1 Explanation, but only if the sentence explains why a finding or pattern occurred.
+
+## Common Multi-Label Patterns
+
+| Pattern | Typical labels | Diagnostic note |
+|---|---|---|
+| Finding plus claim | M2S1 + M6S1 | The sentence reports a result and immediately interprets its broader meaning. |
+| Finding plus previous research | M2S1 + M4S1 | The sentence reports or synthesizes a result and connects it to literature. |
+| Previous research plus claim | M4S1 + M6S1 | The sentence uses literature comparison to support a broader interpretation. |
+| Unexpected outcome plus explanation | M3S1 + M5S1 | The sentence marks surprise or inconsistency and explains why it may have occurred. |
+| Limitation plus recommendation | M7S1 + M8S1 | The sentence identifies a boundary and proposes a future direction or improvement. |
+
+## Research Paper vs Review Paper
+
+When diagnosing a research paper, interpret `M2S1` as the author's own empirical or evidence-based finding.
+
+When diagnosing a review paper, interpret `M2S1` as a synthesized pattern across studies rather than a new experimental result. In that case, `M6S1` usually operates as a field-level claim, and `M7S1` often evaluates weaknesses in the literature rather than only weaknesses in the current paper.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/failure-strategies.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/failure-strategies.md
@@ -1,0 +1,69 @@
+# Discussion Failure Strategies
+
+Use this file when the input is incomplete, ambiguous, or not suitable for Discussion diagnosis.
+
+## Wrong Section
+
+If the text is clearly not a Discussion-related passage, say so briefly and identify the likely section if possible.
+
+Example response:
+
+```text
+This passage appears to function more like a Results section because it mainly reports data without interpretation, comparison with previous research, claims, limitations, or recommendations. A Discussion move diagnosis would be unreliable unless you provide the Discussion or Results and Discussion section.
+```
+
+If the passage has mixed functions, continue but state the inference:
+
+```text
+I will treat this as a Results and Discussion passage because it reports findings and immediately interprets them.
+```
+
+## Insufficient Text
+
+If the user provides only a title, outline, figure caption, table, or isolated sentence, ask for more text unless they requested sentence-level labeling only.
+
+If the text is short but diagnosable, proceed and say:
+
+```text
+The diagnosis is limited because only a short Discussion passage is visible.
+```
+
+## Missing Discipline Metadata
+
+Infer discipline cautiously from topic, terminology, evidence type, and cited concepts.
+
+If inference is weak:
+
+- use a provisional profile;
+- avoid strong discipline-specific claims;
+- mark discipline-sensitive judgments as provisional.
+
+## No Close Discipline Profile
+
+If no close profile in `references/discipline-sensitive-profiles.md` fits the text, do not stop the diagnosis.
+
+Map the text to the nearest broad family:
+
+- Natural sciences
+- Social sciences / applied fields
+- Language and humanities-like fields
+- Law
+
+Then use article type and visible rhetorical needs to build a provisional expectedness model. State that the discipline match is approximate.
+
+## Ambiguous Move Labels
+
+When a sentence could fit more than one move:
+
+- choose the dominant rhetorical function as the primary label;
+- add clear secondary labels;
+- use Medium or Low confidence when the function is implicit or underdeveloped;
+- explain the ambiguity in the Reason column.
+
+Do not split the sentence unless the user asks for clause-level analysis.
+
+## Rewrite-Only Requests
+
+If the user asks only to rewrite, polish, or improve a Discussion, do not perform a full move diagnosis unless useful.
+
+Offer a brief diagnostic note first if the rhetorical problem is obvious, then revise only within the evidence provided. Do not invent findings, explanations, literature, limitations, or recommendations.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/logic-chain-rubric.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/logic-chain-rubric.md
@@ -1,0 +1,159 @@
+# Discussion Logic-Chain Rubric
+
+Use this file to diagnose whether Discussion moves connect into persuasive interpretive logic. Logic-chain diagnosis is separate from move coverage.
+
+## Fast Family Defaults
+
+Use these simplified family chains as a first-pass heuristic:
+
+- Natural sciences: `M2S1 Finding -> M3S1 Expected / Unexpected Outcome -> M5S1 Explanation -> M6S1 Claim`
+- Social sciences / applied fields: `M2S1 Finding -> M4S1 Previous Research -> M6S1 Claim -> M8S1 Recommendation`
+- Language and humanities-like fields: `M2S1 Finding -> M4S1 Previous Research -> M6S1 Claim`
+- Law: `M2S1 Evidence / Finding -> argument cycle -> M6S1 Claim`
+- Review paper: `M2S1 Synthesized Finding -> M6S1 Field-Level Claim -> M7S1 Limitation -> M8S1 Recommendation`
+
+These are heuristics, not rigid templates. Use them to simplify judgment, not to flatten discipline differences.
+
+## Core Chains
+
+### Finding -> Explanation -> Claim
+
+Use when the text reports a finding and should explain what it means.
+
+Strong chain:
+
+- M2S1 clearly states a finding or synthesized pattern.
+- M5S1 explains why the finding or pattern occurred.
+- M6S1 draws a claim that follows from the finding and explanation.
+
+Weak chain patterns:
+
+- finding is reported but not explained;
+- explanation is generic or not tied to the finding;
+- claim is broader than the finding can support;
+- claim repeats the finding instead of interpreting it.
+
+### Finding -> Previous Research -> Claim
+
+Use when the Discussion needs to situate findings in the literature.
+
+Strong chain:
+
+- M2S1 identifies the finding or synthesis.
+- M4S1 shows agreement, contrast, extension, or correction in relation to previous research.
+- M6S1 draws a claim that reflects the comparison.
+
+Weak chain patterns:
+
+- previous research appears as a source list without rhetorical relation;
+- literature comparison does not connect to the current finding;
+- claim is made before the literature relation is clear.
+
+### Finding -> Explanation -> Previous Research -> Claim
+
+Use for full interpretive Discussion paragraphs.
+
+Strong chain:
+
+- finding is clear;
+- explanation identifies a plausible cause, mechanism, context, or methodological reason;
+- previous research supports, contrasts with, or complicates the explanation;
+- claim follows from all three.
+
+Weak chain patterns:
+
+- explanation and literature comparison compete rather than support each other;
+- the paragraph jumps from finding to claim without enough reasoning;
+- the final claim is not anchored in the finding.
+
+### Expected / Unexpected Outcome -> Explanation -> Claim
+
+Use when the text frames a finding as surprising, inconsistent, expected, or contrary to assumptions.
+
+Strong chain:
+
+- M3S1 identifies why the outcome is expected or unexpected;
+- M5S1 explains the pattern or inconsistency;
+- M6S1 draws an appropriately cautious claim.
+
+Weak chain patterns:
+
+- surprise is asserted without a basis of comparison;
+- no explanation is offered for the inconsistency;
+- claim ignores uncertainty created by the unexpected outcome.
+
+### Finding -> Limitation -> Recommendation
+
+Use when a finding has boundaries or when a limitation points to future work.
+
+Strong chain:
+
+- M2S1 or M6S1 identifies the finding or claim;
+- M7S1 defines the boundary, limitation, or unresolved issue;
+- M8S1 proposes a future direction or improvement that follows from the limitation.
+
+Weak chain patterns:
+
+- limitation is formulaic and unrelated to the finding;
+- recommendation is generic and does not answer the limitation;
+- future work is proposed without explaining why it is needed.
+
+### Claim -> Implication -> Recommendation
+
+Use when the Discussion moves from interpretation to practical, theoretical, pedagogical, or methodological consequences.
+
+Strong chain:
+
+- M6S1 states a claim or implication;
+- M8S1 proposes an action, application, or future study grounded in the claim;
+- the recommendation stays within the scope of the evidence.
+
+Weak chain patterns:
+
+- implication is too broad for the evidence;
+- recommendation introduces a new topic not discussed earlier;
+- recommendation is not actionable or specific enough.
+
+### Review Synthesis -> Field-Level Claim -> Future Direction
+
+Use for review articles or literature-based Discussion passages.
+
+Strong chain:
+
+- M2S1 synthesizes a pattern across reviewed studies;
+- M4S1 situates the pattern in prior literature or debates;
+- M6S1 makes a field-level claim;
+- M7S1 and/or M8S1 identify limitations of the literature and future directions.
+
+Weak chain patterns:
+
+- studies are listed rather than synthesized;
+- field-level claim is not supported by the reviewed evidence;
+- limitations concern individual studies but do not lead to a broader recommendation.
+
+### Review Synthesis -> Field-Level Claim -> Limitation -> Recommendation
+
+Use when the review paper Discussion consolidates the literature and ends with a future agenda.
+
+Strong chain:
+
+- `M2S1` synthesizes a pattern across studies;
+- `M6S1` turns that pattern into a field-level claim;
+- `M7S1` identifies weaknesses in the literature or the review scope;
+- `M8S1` proposes specific next steps grounded in the synthesis and limitations.
+
+Weak chain patterns:
+
+- synthesis is only a list of topics or studies;
+- recommendation is generic and not derived from the identified field limitations;
+- the review claims novelty without comparing itself to earlier review work when that comparison is needed.
+
+## Logic-Chain Table
+
+Use this table in full reports:
+
+| Logic chain | Evidence | Break / weak link | Why it weakens Discussion | Revision direction |
+|---|---|---|---|---|
+| Finding -> Explanation -> Claim | ... | ... | ... | ... |
+
+Do not force every chain. Select only chains that fit the passage, discipline, and article type.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/output-templates.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/output-templates.md
@@ -1,117 +1,39 @@
 # Discussion Output Templates
 
-Use these templates to keep Discussion diagnoses consistent with other discourse-diagnostic skills.
+Use this template to keep Discussion diagnoses focused on revision advice only.
 
-## Full Diagnostic Report
+The diagnosis workflow may produce internal article profiles, move-step annotations, expected-move coverage, logic-chain checks, and missing/weak-function lists. Do not include those internal diagnostic sections in the final response unless the user explicitly asks for them.
+
+## Final Output
+
+Output only the content that would normally appear under `Revision Priorities`. Do not include a diagnostic report title, section number, overall diagnosis, article profile, functional-unit annotation, coverage table, logic diagnosis, key missing/weak functions table, or closing note.
+
+Use this exact structure:
 
 ```markdown
-## 1. Overall Diagnosis
-
-[Briefly state likely discipline and article type, what the Discussion already does, the main rhetorical problems, and whether the diagnosis is full, limited, or provisional.]
-
-## 2. Article Profile
-
-| Profile dimension | Diagnosis |
-|---|---|
-| Discipline / subdiscipline | ... |
-| Article type | ... |
-| Research tradition | ... |
-| Data / evidence type | ... |
-| Topic / research object | ... |
-| Intended contribution | ... |
-| Confidence | ... |
-
-## 3. Functional-Unit Move-Step Annotation
-
-| Unit | Text span | Primary label | Secondary label(s) | Confidence | Reason |
-|---|---|---|---|---|---|
-| U1 | ... | ... | ... | ... | ... |
-
-## 4. Expected Move Coverage
-
-| Move / Function | Expectedness | Status | Evidence | Problem | Why it matters |
-|---|---|---|---|---|---|
-| M2S1 Finding | ... | ... | ... | ... | ... |
-
-## 5. Discussion Logic Diagnosis
-
-| Logic chain | Evidence | Break / weak link | Why it weakens Discussion | Revision direction |
-|---|---|---|---|---|
-| ... | ... | ... | ... | ... |
-
-## 6. Key Missing or Weak Functions
-
-| Function | Status | Evidence | Why it matters | Revision direction |
-|---|---|---|---|---|
-| ... | ... | ... | ... | ... |
-
-## 7. Revision Priorities
-
 ### 必须修改
 
-| 原文句子 | 问题 | 为什么影响 Discussion | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens the Discussion when relevant]
+   - 具体改进方向: [specific revision direction in English]
 
 ### 建议修改
 
-| 原文句子 | 问题 | 为什么影响 Discussion | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens the Discussion when relevant]
+   - 具体改进方向: [specific revision direction in English]
 ```
 
-## Short Classroom Feedback
+If one block has no items, keep the heading and write `No items.` under it.
 
-Use when the user asks for brief feedback.
+## Item Rules
 
-```markdown
-## Diagnosis
-
-[2-4 sentences on what the Discussion already does and what most weakens interpretation, comparison, claim, limitation, or recommendation.]
-
-## Most Important Problems
-
-| Function | Status | Evidence | Revision direction |
-|---|---|---|---|
-| ... | ... | ... | ... |
-
-## Revision Priorities
-
-### 必须修改
-
-| 原文句子 | 问题 | 为什么影响 Discussion | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
-
-### 建议修改
-
-| 原文句子 | 问题 | 为什么影响 Discussion | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
-```
-
-## Sentence-Level Annotation Only
-
-Use when the user asks only for move labels.
-
-```markdown
-| Unit | Text span | Primary label | Secondary label(s) | Confidence | Reason |
-|---|---|---|---|---|---|
-| U1 | ... | ... | ... | ... | ... |
-```
-
-Add a short note if a sentence has multiple moves:
-
-```text
-This sentence is assigned multiple labels because it both [function A] and [function B].
-```
-
-## Coverage-Only Output
-
-Use when the user asks only which moves are missing or weak.
-
-```markdown
-| Move / Function | Expectedness | Status | Evidence | Problem | Revision direction |
-|---|---|---|---|---|---|
-| ... | ... | ... | ... | ... | ... |
-```
+- Put missing expected moves and weak items that materially affect Discussion logic, interpretation, contribution, credibility, or reader trust under `必须修改`.
+- Put weak items that would improve specificity, evidence, comparison, explanation, implication, or flow but do not break the core Discussion logic under `建议修改`.
+- Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+- Start each item with `Issue N:` followed by a concise English issue summary.
+- Anchor each item in original wording.
+- Do not invent findings, literature, explanations, claims, limitations, recommendations, or implications for the student.
+- Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/output-templates.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/output-templates.md
@@ -1,0 +1,117 @@
+# Discussion Output Templates
+
+Use these templates to keep Discussion diagnoses consistent with other discourse-diagnostic skills.
+
+## Full Diagnostic Report
+
+```markdown
+## 1. Overall Diagnosis
+
+[Briefly state likely discipline and article type, what the Discussion already does, the main rhetorical problems, and whether the diagnosis is full, limited, or provisional.]
+
+## 2. Article Profile
+
+| Profile dimension | Diagnosis |
+|---|---|
+| Discipline / subdiscipline | ... |
+| Article type | ... |
+| Research tradition | ... |
+| Data / evidence type | ... |
+| Topic / research object | ... |
+| Intended contribution | ... |
+| Confidence | ... |
+
+## 3. Functional-Unit Move-Step Annotation
+
+| Unit | Text span | Primary label | Secondary label(s) | Confidence | Reason |
+|---|---|---|---|---|---|
+| U1 | ... | ... | ... | ... | ... |
+
+## 4. Expected Move Coverage
+
+| Move / Function | Expectedness | Status | Evidence | Problem | Why it matters |
+|---|---|---|---|---|---|
+| M2S1 Finding | ... | ... | ... | ... | ... |
+
+## 5. Discussion Logic Diagnosis
+
+| Logic chain | Evidence | Break / weak link | Why it weakens Discussion | Revision direction |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+## 6. Key Missing or Weak Functions
+
+| Function | Status | Evidence | Why it matters | Revision direction |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+## 7. Revision Priorities
+
+### 必须修改
+
+| 原文句子 | 问题 | 为什么影响 Discussion | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+### 建议修改
+
+| 原文句子 | 问题 | 为什么影响 Discussion | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+```
+
+## Short Classroom Feedback
+
+Use when the user asks for brief feedback.
+
+```markdown
+## Diagnosis
+
+[2-4 sentences on what the Discussion already does and what most weakens interpretation, comparison, claim, limitation, or recommendation.]
+
+## Most Important Problems
+
+| Function | Status | Evidence | Revision direction |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+## Revision Priorities
+
+### 必须修改
+
+| 原文句子 | 问题 | 为什么影响 Discussion | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+### 建议修改
+
+| 原文句子 | 问题 | 为什么影响 Discussion | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+```
+
+## Sentence-Level Annotation Only
+
+Use when the user asks only for move labels.
+
+```markdown
+| Unit | Text span | Primary label | Secondary label(s) | Confidence | Reason |
+|---|---|---|---|---|---|
+| U1 | ... | ... | ... | ... | ... |
+```
+
+Add a short note if a sentence has multiple moves:
+
+```text
+This sentence is assigned multiple labels because it both [function A] and [function B].
+```
+
+## Coverage-Only Output
+
+Use when the user asks only which moves are missing or weak.
+
+```markdown
+| Move / Function | Expectedness | Status | Evidence | Problem | Revision direction |
+|---|---|---|---|---|---|
+| ... | ... | ... | ... | ... | ... |
+```

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/source-notes.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/source-notes.md
@@ -1,0 +1,40 @@
+# Source Notes
+
+The Discussion move framework in this skill is based on the user's local WisePen teaching materials and academic move-analysis literature.
+
+## Local WisePen Sources
+
+The original local source materials have been distilled into this skill's `references/workflow.md`, `references/discussion-move-definitions.md`, and related rubric files. They included:
+
+- a local copy of Peacock's article on communicative moves in research-article Discussion sections;
+- a local WisePen summary of Discussion moves.
+
+The current discipline-sensitive simplification also uses the user's Peacock-based summary for research-paper Discussions:
+
+- no single move is absolutely universal across all research papers;
+- `Claim`, `Finding`, and `Reference to Previous Research` are the most central cross-disciplinary moves;
+- `Recommendation` is also common;
+- the expected prominence of literature comparison, limitation, recommendation, and move cycling varies by discipline.
+
+The current working framework uses eight common Discussion moves:
+
+1. Information Move
+2. Finding
+3. Expected or Unexpected Outcome
+4. Reference to Previous Research
+5. Explanation
+6. Claim
+7. Limitation
+8. Recommendation
+
+The skill adapts these moves to the shared WisePen discourse-diagnostic workflow, including sentence-level unit annotation, expectedness modeling, five coverage status labels, and Discussion-specific logic-chain diagnosis.
+
+The review-paper profile in this skill treats:
+
+- `M2S1` as synthesized finding;
+- `M6S1` as field-level claim;
+- `M7S1` as literature or review limitation;
+- `M4S1` as comparison with prior reviews or literature streams;
+- `M8S1` as a grounded future research agenda.
+
+If the user asks for a citation or theoretical explanation, use the bibliographic notes above and the local move summary already distilled into this skill before giving source-specific claims.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/workflow.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/workflow.md
@@ -239,19 +239,33 @@ Your Discussion already does X. However, it does not yet do Y. This matters beca
 
 ## 9. Output Structure
 
-Return seven sections:
+Steps 1-8 are internal diagnostic work. They support the priority judgment, but they must not appear in the final response.
 
-1. Overall Diagnosis
-2. Article Profile
-3. Functional-Unit Move-Step Annotation
-4. Expected Move Coverage
-5. Discussion Logic Diagnosis
-6. Key Missing or Weak Functions
-7. Revision Priorities
+Final output must contain only the concrete revision priorities.
 
-In section 7, output two blocks in this order:
+Do not output:
+
+- Overall Diagnosis;
+- Article Profile;
+- Functional-Unit Move-Step Annotation;
+- Expected Move Coverage;
+- Discussion Logic Diagnosis;
+- Key Missing or Weak Functions;
+- `Revision Priorities` or any numbered section heading;
+- paragraph summaries, scores, introductions, closing notes, or follow-up questions.
+
+Output two blocks in this order:
 
 - 必须修改: missing expected moves and weak items that materially affect Discussion logic, interpretation, contribution, credibility, or reader trust.
 - 建议修改: weak items that would improve specificity, evidence, comparison, explanation, implication, or flow but do not break the core Discussion logic.
 
-Each item must be anchored in original wording and should not invent content for the student.
+Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+
+Each item must follow this structure:
+
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens the Discussion when relevant]
+   - 具体改进方向: [specific revision direction in English]
+
+Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English. Each item must be anchored in original wording and should not invent content for the student.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/workflow.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnose-discussion-skill/1.0/references/workflow.md
@@ -1,0 +1,257 @@
+# Discussion Discourse Diagnostic Workflow
+
+This workflow diagnoses a submitted Discussion-related section through an 8-move Discussion framework. It should produce teaching-oriented feedback, not grammar correction or full rewriting.
+
+## 0. Input Gate
+
+Confirm that the submitted text can reasonably be diagnosed as a Discussion-related passage.
+
+Continue when:
+
+- the text is explicitly headed `Discussion`, `Results and Discussion`, `Discussion and Conclusion`, or a closely related heading;
+- the heading is absent but the passage interprets findings, compares findings with previous research, explains outcomes, develops claims, states limitations, or proposes recommendations;
+- the user provides a full paper and the Discussion-related section can be cleanly extracted;
+- the passage is short but still diagnosable, in which case state that the diagnosis is limited to the visible text.
+
+Stop or ask for more input when:
+
+- the text clearly belongs to another section and does not perform Discussion functions;
+- the user asks for a full Discussion diagnosis but provides only a title, abstract, outline, table, figure caption, or isolated sentence;
+- a full paper is provided but no Discussion-related passage can be identified;
+- the text has too little rhetorical content to support move diagnosis.
+
+If the section type is uncertain, state the inference and mark later discipline- or section-specific judgments as provisional.
+
+## 1. Identify Article Profile
+
+Infer or read the profile from user metadata and the submitted text.
+
+Use this profile only to select appropriate expectations. It is not a checklist.
+
+| Profile dimension | What to identify |
+|---|---|
+| Discipline / subdiscipline | Broad field and, when possible, local field |
+| Article type | Empirical, review, theoretical, technical, mixed-methods, computational, conceptual, or unclear |
+| Research tradition | Quantitative, qualitative, mixed, computational, laboratory, applied, conceptual, review-based, or unclear |
+| Data / evidence type | Participants, corpus, experiment, dataset, model, texts, sources, cases, materials, or unclear |
+| Topic / research object | The phenomenon, object, population, site, mechanism, method, or problem being discussed |
+| Intended contribution | Finding, claim, explanation, implication, method, model, framework, synthesis, recommendation, or unclear |
+| Confidence | High, Medium, or Low |
+
+Identify discipline first. Use the closest profile in `references/discipline-sensitive-profiles.md` as the first filter for expectedness. Then adjust by article type.
+
+If the exact discipline is unclear, map the text to the nearest broad family:
+
+- Natural sciences
+- Social sciences / applied fields
+- Language and humanities-like fields
+- Law
+
+If the fit is still weak, use cautious default expectations and mark discipline-sensitive judgments as provisional.
+
+## 2. Segment the Discussion into Sentence-Level Units
+
+Segment the submitted text into sentence-level functional units before assigning move labels.
+
+Rules:
+
+- Use one sentence as one unit by default.
+- Use `U1`, `U2`, `U3` numbering for sentence units.
+- Do not split a sentence into clause units merely because it performs more than one move.
+- Preserve original wording for every unit.
+- Use the unit only as evidence; do not rewrite it during diagnosis.
+- Split only when the user explicitly asks for clause-level analysis or when numbered/listed subparts function like independent sentences.
+
+One sentence can count toward more than one move if the secondary function is rhetorically real, not merely implied by a keyword.
+
+## 3. Annotate Moves
+
+Use `references/discussion-move-definitions.md`.
+
+For each sentence unit, assign:
+
+- one primary move-step label for the dominant rhetorical function;
+- secondary label(s), if the sentence also performs additional rhetorical functions;
+- confidence;
+- a short reason grounded in rhetorical function.
+
+Use this table:
+
+| Unit | Text span | Primary label | Secondary label(s) | Confidence | Reason |
+|---|---|---|---|---|---|
+| U1 | ... | M2S1 | M4S1; M6S1 | High | ... |
+
+Confidence labels:
+
+| Confidence | Meaning |
+|---|---|
+| High | The rhetorical function is explicit |
+| Medium | The function is likely but partly implicit |
+| Low | The function is ambiguous or underdeveloped |
+
+Judge rhetorical function in context, not by keyword matching alone.
+
+## 4. Build the Expectedness Model
+
+Build expectedness primarily by discipline, then adjust by article type.
+
+Use `references/discipline-sensitive-profiles.md`.
+
+Use only these expectedness labels:
+
+| Expectedness | Meaning | Can absence be criticized? |
+|---|---|---|
+| Core | A central function for this Discussion type or discipline | Yes |
+| Conventional | Normally expected in this discipline or article type | Yes |
+| Strongly Expected | Highly expected; absence usually creates a serious weakness | Yes |
+| Conditional | Expected only when triggered by findings, study design, article type, or local context | Yes, if triggered |
+| Optional / Enriching | Useful but not required | No |
+| Rare / Not Expected | Normally not expected | No |
+| Not Applicable | Does not fit the study design, discipline, or article type | No |
+
+Do not ask whether all eight moves appear. Ask which moves are pedagogically important for this text's discipline, article type, and research tradition.
+
+For research papers, begin with Peacock's easiest first-pass check:
+
+1. Is there a clear `M2S1 Finding` or evidence-based outcome being discussed?
+2. Is there a clear `M6S1 Claim` about what the finding means?
+3. In disciplines that rely on literature dialogue, is there `M4S1 Reference to Previous Research`?
+
+Treat these as the fastest backbone check before judging the remaining moves.
+
+Research-paper defaults:
+
+- `M6S1 Claim`, `M2S1 Finding`, and `M4S1 Reference to Previous Research` are the main cross-disciplinary anchor moves.
+- `M8S1 Recommendation` is common but should still be judged by discipline and article type.
+- `M1S1`, `M3S1`, `M5S1`, and `M7S1` vary more strongly by discipline, finding type, and section design.
+
+Article-type adjustments:
+
+- Empirical Discussion usually depends on findings, explanation, previous research, claims, and often limitations.
+- Results and Discussion sections may integrate result reporting with interpretation and previous research.
+- Review-article discussion passages usually depend on synthesized findings, field-level claims, limitations of the literature, comparison with earlier reviews when relevant, and recommendations.
+- Theoretical or conceptual Discussion passages may depend more on conceptual explanation, previous research, and claims than on empirical finding restatement.
+- Discussion and Conclusion sections may make limitations, implications, and future directions more expected.
+
+Use `Optional / Enriching` and `Rare / Not Expected` internally, but do not criticize students for missing them in final feedback.
+
+## 5. Evaluate Expected Move Coverage
+
+Use only these five status labels:
+
+| Status | Definition |
+|---|---|
+| Present | The rhetorical function is clearly realized |
+| Weak | The function is attempted but underdeveloped, vague, unsupported, poorly connected, or lacking necessary detail |
+| Missing | A Core, Conventional, Strongly Expected, or triggered Conditional function is absent |
+| Not Applicable | The function does not fit the study design, discipline, article type, or local context |
+| Unclear | The available text is insufficient to decide whether the function is relevant or realized |
+
+Keep three layers separate:
+
+- Expectedness: whether a function should be checked.
+- Status: how well the submitted text realizes that function.
+- Confidence: how certain the annotator is about a sentence-level label.
+
+Use this coverage table:
+
+| Move / Function | Expectedness | Status | Evidence | Problem | Why it matters |
+|---|---|---|---|---|---|
+| M2S1 Finding | Core | Present / Weak / Missing / Not Applicable / Unclear | ... | ... | ... |
+
+Mark Present only when the rhetorical function is achieved, not merely named. Mark Missing only when the function is expected for this specific text.
+
+## 6. Diagnose Discussion Logic Chains
+
+Read `references/logic-chain-rubric.md`.
+
+Diagnose whether the Discussion's rhetorical functions connect to each other. This is separate from move coverage.
+
+Check logic chains that fit the text, such as:
+
+- Finding -> Explanation -> Claim
+- Finding -> Previous Research -> Claim
+- Finding -> Explanation -> Previous Research -> Claim
+- Expected / Unexpected Outcome -> Explanation -> Claim
+- Finding -> Limitation -> Recommendation
+- Claim -> Implication -> Recommendation
+- Review Synthesis -> Field-Level Claim -> Future Direction
+
+Use the simplified family defaults when they fit:
+
+- Natural sciences: Finding -> Expected / Unexpected Outcome -> Explanation -> Claim
+- Social sciences / applied fields: Finding -> Previous Research -> Claim -> Recommendation
+- Language and humanities-like fields: Finding -> Previous Research -> Claim
+- Law: Evidence / Finding -> Argument cycle -> Claim
+- Review paper: Synthesized Finding -> Field-Level Claim -> Limitation -> Recommendation
+
+Use this table:
+
+| Logic chain | Evidence | Break / weak link | Why it weakens Discussion | Revision direction |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+Do not force a chain that does not fit the article type or local passage.
+
+## 7. Identify Key Missing or Weak Functions
+
+Summarize the most important Missing, Weak, or Unclear functions.
+
+Use this table:
+
+| Function | Status | Evidence | Why it matters | Revision direction |
+|---|---|---|---|---|
+| M5S1 Explanation | Weak | ... | ... | ... |
+
+Prioritize issues that weaken Discussion persuasiveness:
+
+- finding is reported but not interpreted;
+- finding is interpreted but not connected to previous research;
+- previous research is mentioned but not used to show agreement, contrast, extension, or correction;
+- explanation is vague or speculative without appropriate grounding;
+- claim is too broad for the evidence;
+- limitation is missing when needed for credibility;
+- recommendation does not follow from the findings, limitations, or claim.
+
+Use the discipline profile to avoid over-diagnosing light moves. For example:
+
+- in physics, materials science, and environmental science, do not force heavy literature comparison or limitation statements when the section is brief and interpretation-focused;
+- in language, linguistics, public administration, and related social fields, treat weak literature connection more seriously;
+- in law, allow recursive argument cycles rather than forcing a single linear experimental pattern.
+
+## 8. Convert Diagnosis into Teaching Feedback
+
+Generate feedback in a teaching style:
+
+- begin from what the Discussion already does;
+- identify missing, weak, or unclear rhetorical functions;
+- explain why each issue affects interpretation, contribution, coherence, credibility, or reader trust;
+- before writing a feedback item, return to the original sentence and confirm that the problem is real;
+- separate the closing feedback into two blocks: 必须修改 and 建议修改;
+- tell the student what kind of content to add or clarify next;
+- avoid replacing diagnosis with polished rewritten prose.
+
+Useful feedback pattern:
+
+```text
+Your Discussion already does X. However, it does not yet do Y. This matters because Z. To revise, add or clarify A, B, and C.
+```
+
+## 9. Output Structure
+
+Return seven sections:
+
+1. Overall Diagnosis
+2. Article Profile
+3. Functional-Unit Move-Step Annotation
+4. Expected Move Coverage
+5. Discussion Logic Diagnosis
+6. Key Missing or Weak Functions
+7. Revision Priorities
+
+In section 7, output two blocks in this order:
+
+- 必须修改: missing expected moves and weak items that materially affect Discussion logic, interpretation, contribution, credibility, or reader trust.
+- 建议修改: weak items that would improve specificity, evidence, comparison, explanation, implication, or flow but do not break the core Discussion logic.
+
+Each item must be anchored in original wording and should not invent content for the student.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/SKILL.md
@@ -41,28 +41,29 @@ Load only the files needed for the current task:
 - `references/introduction-move-step-definitions.md`: read when assigning or explaining Introduction move-step labels.
 - `references/discipline-sensitive-profiles.md`: read when deciding which conventional steps or equivalent functions matter for a discipline.
 - `references/diagnostic-rubric.md`: read when judging Present, Weak, Missing, Not Applicable, or Unclear, and when diagnosing gap quality, gap-aim alignment, or literature organization.
-- `references/output-templates.md`: read when formatting a full diagnostic report, short classroom feedback, sentence-level feedback, or coverage-only answer.
+- `references/output-templates.md`: read when formatting the final revision-priority-only answer.
 - `references/failure-strategies.md`: read when the input may not be an Introduction, is too short, lacks discipline metadata, or asks only for rewriting.
 - `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses this framework.
 
 ## Default Output
 
-Unless the user asks for a shorter format, return seven sections:
+Unless the user explicitly asks for a different format, return only the final concrete revision priorities.
 
-1. Overall Diagnosis
-2. Sentence-Level Move-Step Annotation
-3. Discipline-Sensitive Step Coverage
-4. Gap or Niche Diagnosis
-5. Gap-Aim Alignment
-6. Literature Organization
-7. Revision Priorities
-
-In section 7, split the closing feedback into two tables, in this order:
+Do not include overall diagnosis, sentence-level move-step annotation, step coverage, gap or niche diagnosis, gap-aim alignment, literature-organization tables, diagnostic summaries, or closing notes in the final response. Use those analyses internally, then output only two blocks in this order:
 
 - 必须修改
 - 建议修改
 
-Each table should use `原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向`.
+Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+
+Each issue must follow this structure:
+
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens Introduction when relevant]
+   - 具体改进方向: [specific revision direction in English]
+
+Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.
 
 ## Constraints
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: diagnosing-introduction-discourse
+description: Diagnoses the rhetorical move-step structure of academic Introduction sections using Cotos and Pendar's 3-move/17-step framework with discipline-sensitive conventional steps. Use when Codex needs to check, evaluate, diagnose, or give pedagogical feedback on Introduction discourse, including missing conventional steps, weak gap or niche construction, gap-aim mismatch, source-list literature review, or discipline-appropriate research positioning in academic English writing.
+---
+
+# Diagnosing Introduction Discourse
+
+Use this skill to diagnose whether a student's academic Introduction section establishes a credible territory, identifies a discipline-appropriate niche, and positions the present study clearly.
+
+Produce diagnostic feedback, not grammar correction, style polishing, or a full rewrite unless the user explicitly asks for revision after diagnosis.
+
+## Core Framework
+
+Use Cotos and Pendar's Introduction model:
+
+- Move 1: Establishing a Territory
+- Move 2: Identifying a Niche
+- Move 3: Addressing the Niche
+
+A move is a broad rhetorical function. A step is a more specific rhetorical action that realizes the move.
+
+## Required Workflow
+
+When performing a real diagnosis, first read `references/workflow.md` and follow its sequence:
+
+1. verify that the input is an Introduction section or opening research-positioning passage;
+2. identify discipline, article type, and research tradition;
+3. extract and segment the Introduction into functional units;
+4. annotate moves and steps using Cotos and Pendar's label set;
+5. build the discipline-sensitive conventional-step profile;
+6. judge step coverage without requiring optional or rare steps;
+7. diagnose the gap or niche;
+8. check gap-aim alignment;
+9. diagnose literature organization;
+10. generate teaching-oriented feedback and revision priorities.
+
+## Reference Files
+
+Load only the files needed for the current task:
+
+- `references/introduction-move-step-definitions.md`: read when assigning or explaining Introduction move-step labels.
+- `references/discipline-sensitive-profiles.md`: read when deciding which conventional steps or equivalent functions matter for a discipline.
+- `references/diagnostic-rubric.md`: read when judging Present, Weak, Missing, Not Applicable, or Unclear, and when diagnosing gap quality, gap-aim alignment, or literature organization.
+- `references/output-templates.md`: read when formatting a full diagnostic report, short classroom feedback, sentence-level feedback, or coverage-only answer.
+- `references/failure-strategies.md`: read when the input may not be an Introduction, is too short, lacks discipline metadata, or asks only for rewriting.
+- `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses this framework.
+
+## Default Output
+
+Unless the user asks for a shorter format, return seven sections:
+
+1. Overall Diagnosis
+2. Sentence-Level Move-Step Annotation
+3. Discipline-Sensitive Step Coverage
+4. Gap or Niche Diagnosis
+5. Gap-Aim Alignment
+6. Literature Organization
+7. Revision Priorities
+
+In section 7, split the closing feedback into two tables, in this order:
+
+- 必须修改
+- 建议修改
+
+Each table should use `原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向`.
+
+## Constraints
+
+Do not:
+
+- require all 17 steps;
+- treat optional or rare steps as missing problems;
+- diagnose by keyword matching alone;
+- replace rhetorical diagnosis with grammar correction;
+- rewrite the whole Introduction unless requested;
+- invent missing literature, findings, aims, methods, or contributions;
+- mark a step as Missing when an equivalent discipline-specific function is present;
+- use the term "optional" in the final diagnosis to the student.
+
+Do:
+
+- focus on rhetorical function;
+- quote the student's original sentence or clause for each problem;
+- distinguish Missing from Weak;
+- judge move coverage and step coverage separately;
+- explain why each issue matters for territory, niche, present-study positioning, or disciplinary expectation;
+- separate must-fix and suggested-fix items;
+- provide concrete revision directions without inventing content for the student.
+

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/SKILL.md
@@ -21,29 +21,56 @@ A move is a broad rhetorical function. A step is a more specific rhetorical acti
 
 ## Required Workflow
 
-When performing a real diagnosis, first read `references/workflow.md` and follow its sequence:
+When performing a real diagnosis, first call `load_skill_asset` on `references/workflow.md` and follow its sequence.
+
+For every workflow step below, you MUST call `load_skill_asset` for each listed file before completing that step. If the same file has already been loaded earlier in the current turn, reuse the already loaded content instead of calling `load_skill_asset` again.
 
 1. verify that the input is an Introduction section or opening research-positioning passage;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/failure-strategies.md`
 2. identify discipline, article type, and research tradition;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/discipline-sensitive-profiles.md`
 3. extract and segment the Introduction into functional units;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
 4. annotate moves and steps using Cotos and Pendar's label set;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/introduction-move-step-definitions.md`
 5. build the discipline-sensitive conventional-step profile;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/discipline-sensitive-profiles.md`
 6. judge step coverage without requiring optional or rare steps;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
+   - MUST load via `load_skill_asset`: `references/discipline-sensitive-profiles.md`
 7. diagnose the gap or niche;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
+   - MUST load via `load_skill_asset`: `references/introduction-move-step-definitions.md`
 8. check gap-aim alignment;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
 9. diagnose literature organization;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
 10. generate teaching-oriented feedback and revision priorities.
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/output-templates.md`
 
 ## Reference Files
 
-Load only the files needed for the current task:
+For a real Introduction diagnosis, the following files are required by the workflow above and must be loaded through `load_skill_asset` when their workflow step is reached:
 
-- `references/introduction-move-step-definitions.md`: read when assigning or explaining Introduction move-step labels.
-- `references/discipline-sensitive-profiles.md`: read when deciding which conventional steps or equivalent functions matter for a discipline.
-- `references/diagnostic-rubric.md`: read when judging Present, Weak, Missing, Not Applicable, or Unclear, and when diagnosing gap quality, gap-aim alignment, or literature organization.
-- `references/output-templates.md`: read when formatting the final revision-priority-only answer.
-- `references/failure-strategies.md`: read when the input may not be an Introduction, is too short, lacks discipline metadata, or asks only for rewriting.
-- `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses this framework.
+- `references/workflow.md`: required for every real Introduction diagnosis.
+- `references/failure-strategies.md`: required during input-gate and failure-mode handling.
+- `references/discipline-sensitive-profiles.md`: required when identifying article profile and deciding which conventional steps or equivalent functions matter for a discipline.
+- `references/introduction-move-step-definitions.md`: required when assigning or explaining Introduction move-step labels.
+- `references/diagnostic-rubric.md`: required when judging Present, Weak, Missing, Not Applicable, or Unclear, and when diagnosing gap quality, gap-aim alignment, or literature organization.
+- `references/output-templates.md`: required when formatting the final revision-priority-only answer.
+
+Conditional reference:
+
+- `references/source-notes.md`: MUST load via `load_skill_asset` when the user asks about the theoretical basis, citations, source basis, or why the skill uses this framework.
 
 ## Default Output
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/diagnostic-rubric.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/diagnostic-rubric.md
@@ -1,0 +1,136 @@
+# Diagnostic Rubric
+
+Use this file to convert move-step annotation into a pedagogical diagnosis.
+
+## Step Status Rules
+
+Use only these status labels:
+
+- Present
+- Weak
+- Missing
+- Not Applicable
+- Unclear
+
+### Present
+
+Mark Present only when the rhetorical function is clearly realized.
+
+### Weak
+
+Mark Weak when the function is attempted but underdeveloped, vague, unsupported, poorly connected, or too generic.
+
+Common Weak cases:
+
+- the topic is introduced but its importance is not clear;
+- prior studies are listed but not synthesized;
+- the gap is too broad, vague, or unsupported;
+- the aim is stated but does not specify object, scope, population, method, or context;
+- the value claim is generic and not tied to the stated gap;
+- the method or outcome preview is too thin for a discipline that expects it.
+
+Place Weak items in `必须修改` if they damage Introduction logic, gap construction, gap-aim fit, or discipline-required positioning. Place them in `建议修改` if they mainly improve clarity, specificity, or reader trust.
+
+### Missing
+
+Mark Missing when a conventional step or equivalent function is required for this discipline but absent from the submitted Introduction.
+
+Missing items usually belong in `必须修改`.
+
+### Not Applicable
+
+Mark Not Applicable when the step does not fit the discipline, article type, or research design.
+
+### Unclear
+
+Mark Unclear when the text does not provide enough information to decide whether the step is relevant or realized.
+
+## Avoid Keyword-Only Judgment
+
+Judge rhetorical function, not surface vocabulary.
+
+Examples:
+
+- "This study investigates..." may be M3S9, but it is Weak if the object and scope are unclear.
+- "However, little is known..." may be M2S4, but it is Weak if the previous review does not support the claim.
+- A conservation problem can realize M2S5 even without a traditional literature-gap phrase.
+- A Chemical Biology Introduction may realize Move 3 through outcomes and value rather than an explicit aim sentence.
+
+## Gap or Niche Types
+
+Identify the main gap or niche type:
+
+- literature gap;
+- methodological or technical limitation;
+- conceptual or theoretical gap;
+- empirical gap involving population, dataset, context, setting, species, site, period, or material;
+- unresolved mechanism;
+- practical, social, clinical, environmental, or conservation problem;
+- unresolved debate or contradiction in previous findings;
+- broad research question or hypothesis.
+
+## Gap Quality Checks
+
+A strong gap should be:
+
+- specific enough to guide the present study;
+- credible and supported by the reviewed literature;
+- naturally developed from previous sentences;
+- appropriately scoped for the article;
+- aligned with the discipline's normal niche-building strategy;
+- not overstated beyond what cited literature can support.
+
+Treat as `必须修改` when:
+
+- no real gap, problem, question, or niche is visible;
+- the gap is generic or impossible to study;
+- the gap does not follow from the reviewed literature;
+- the text overclaims, such as "no studies have..." without adequate support;
+- the gap belongs to a different problem from the aim;
+- the gap is too broad for the study's data, method, or scope.
+
+Treat as `建议修改` when:
+
+- the gap is valid but could be narrower;
+- the gap needs clearer population, object, method, context, or mechanism;
+- the transition from prior research to the gap is weak but repairable;
+- citation support should be stronger but the logic is not broken.
+
+## Gap-Aim Alignment Checks
+
+Compare the gap, aim, research questions, hypotheses, method preview, contribution, and value claim.
+
+Check whether:
+
+- the aim answers the same gap created earlier;
+- population, object, context, variables, method, and scope match;
+- the method preview can plausibly address the stated gap;
+- the contribution follows from the gap;
+- the aim is not too broad, too narrow, or shifted to a different problem.
+
+Treat mismatch as `必须修改`. Quote both the gap sentence and the aim or contribution sentence.
+
+## Literature Organization Checks
+
+Diagnose source-driven review when the Introduction lists sources without synthesis.
+
+Problem patterns:
+
+- A says X, B says Y, C says Z without explaining relationships;
+- isolated study summaries without contrast or development;
+- no grouping by theme, method, population, finding, or limitation;
+- previous research does not lead to the gap;
+- general claims lack source support;
+- irrelevant studies are reviewed;
+- citation-heavy sentences replace the writer's own synthesis.
+
+Treat as `必须修改` when source-list organization prevents the reader from seeing the niche. Treat as `建议修改` when the review is understandable but could be better synthesized.
+
+## Final Feedback Split
+
+Write two blocks in this order:
+
+1. 必须修改
+2. 建议修改
+
+Before placing an item, reread the original sentence or clause and confirm that the proposed feedback is supported by the text. Do not duplicate the same issue in both blocks.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/discipline-sensitive-profiles.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/discipline-sensitive-profiles.md
@@ -1,0 +1,128 @@
+# Discipline-Sensitive Conventional Profiles
+
+Use this file to decide which steps are conventional enough to check as teaching-required. The profiles are distilled from the local WisePen Introduction move-step notes and represented here as skill-internal guidance.
+
+Only conventional or strongly expected steps are listed here. Do not penalize the absence of steps that are optional, rare, or only useful in some cases.
+
+## Default Profile When Discipline Is Unknown
+
+| Required function | Conventional step or equivalent |
+|---|---|
+| Establish territory | M1S2 Making topic generalizations and/or M1S3 Reviewing previous research |
+| Identify niche | M2S4 Indicating a gap or M2S5 Highlighting a problem |
+| Address niche | M3S9 Introducing present research descriptively or M3S10 Introducing present research purposefully |
+
+Default rule: a complete Introduction should normally establish a territory, identify a niche, and introduce the present study. The exact step combination depends on discipline.
+
+## Software Engineering / Computer Science
+
+| Conventional step | Discipline-sensitive reason |
+|---|---|
+| M1S2 Making topic generalizations | Technical background is commonly needed. |
+| M1S3 Reviewing previous research | Existing methods or systems must be positioned. |
+| M2S4 Indicating a gap | Limitations of existing work commonly create the niche. |
+| M3S9 Introducing present research descriptively | The proposed system, model, algorithm, or study is usually introduced. |
+| M3S14 Summarizing methods | Method, system, algorithm, or evaluation preview is important. |
+| M3S15 Announcing principal outcomes | Conference-style papers often preview results. |
+| M3S16 Stating the value of the present research | Contribution, novelty, or improvement should be explicit. |
+
+Skill rule: do not only check for gap plus purpose. Also check for method preview, outcome preview, and contribution/value claim.
+
+## Civil Engineering
+
+| Conventional step | Discipline-sensitive reason |
+|---|---|
+| M1S2 Making topic generalizations | Technical background is strongly expected. |
+| M1S3 Reviewing previous research | Prior engineering studies must be positioned. |
+| M2S4 Indicating a gap | The main niche is usually an engineering limitation or unresolved technical issue. |
+| M3S10 Introducing present research purposefully | The study purpose is expected. |
+| M3S14 Summarizing methods | Method preview is common and useful. |
+
+Skill rule: the core pattern is background, previous studies, gap/problem, purpose, and method preview. Do not require principal outcomes, value claim, or paper structure preview.
+
+## Biomedical Engineering
+
+| Conventional step | Discipline-sensitive reason |
+|---|---|
+| M1S1 Claiming centrality | Health, clinical, diagnostic, or safety relevance often needs emphasis. |
+| M1S2 Making topic generalizations | Biomedical and technical background is strongly expected. |
+| M1S3 Reviewing previous research | Prior biomedical or engineering studies must be positioned. |
+| M2S4 Indicating a gap | The niche is commonly built through a research or technical gap. |
+| M3S10 Introducing present research purposefully | The study aim or objective is expected. |
+| M3S14 Summarizing methods | Method preview is strongly expected. |
+
+Skill rule: even though M2S8 is not listed as a conventional step, give extra diagnostic attention to justification when the study involves human health, clinical value, diagnosis, treatment, safety, or ethical relevance.
+
+## Biochemistry
+
+| Conventional step | Discipline-sensitive reason |
+|---|---|
+| M1S2 Making topic generalizations | Biological or biochemical background is expected. |
+| M1S3 Reviewing previous research | Prior findings are expected. |
+| M2S4 Indicating a gap | The niche often involves an unresolved mechanism or unknown process. |
+| M3S10 Introducing present research purposefully | Experimental purpose is expected. |
+| M3S14 Summarizing methods | Procedure preview is normal in experimental science Introductions. |
+| M3S15 Announcing principal outcomes | Key findings may be previewed in the Introduction. |
+
+Skill rule: do not treat method preview or finding preview as misplaced content.
+
+## Chemical Biology
+
+| Conventional step | Discipline-sensitive reason |
+|---|---|
+| M1S1 Claiming centrality | Biological or chemical relevance is often important. |
+| M1S2 Making topic generalizations | Background is expected. |
+| M1S3 Reviewing previous research | Prior chemical or biological studies are expected. |
+| M2S4 Indicating a gap | A research gap is strongly expected. |
+| M3S15 Announcing principal outcomes | Main results are strongly expected. |
+| M3S16 Stating the value of the present research | Value, significance, or novelty is strongly expected. |
+
+Skill rule: do not over-penalize the absence of an explicit "The aim of this study is..." sentence if the Introduction clearly contains gap, principal outcome, and value.
+
+## Wildlife Behavior
+
+| Conventional step | Discipline-sensitive reason |
+|---|---|
+| M1S2 Making topic generalizations | Background on behavior, ecology, or research object is expected. |
+| M1S3 Reviewing previous research | Prior behavioral or ecological research is expected. |
+| M2S4 Indicating a gap | Literature gap is strongly expected. |
+| M3S9 Introducing present research descriptively | The present study is expected. |
+| M3S10 Introducing present research purposefully | The goal or purpose is expected. |
+| WB-LS1 Species/site/research-object background | Species, site, behavior, or ecological setting is often necessary. |
+
+Skill rule: allow the local species/site/research-object background step. Do not force all such content into previous-research review.
+
+## Conservation Biology
+
+| Conventional step | Discipline-sensitive reason |
+|---|---|
+| M1S1 Claiming centrality | Real-world environmental importance is strongly expected. |
+| M1S2 Making topic generalizations | Conservation or ecological background is expected. |
+| M2S5 Highlighting a real-world problem | Environmental, conservation, or management problem is the core niche strategy. |
+| M3S9 Introducing present research descriptively | The present study is expected. |
+| M3S10 Introducing present research purposefully | Goal or purpose is expected. |
+
+Skill rule: do not require every Conservation Biology Introduction to contain a pure "few studies have examined..." literature gap. A real-world conservation problem can realize the niche.
+
+## Social Sciences
+
+| Conventional step or function | Discipline-sensitive reason |
+|---|---|
+| M1S1 Claiming centrality | Topic importance, social relevance, or theoretical significance is common. |
+| M1S2 Making topic generalizations | Conceptual or contextual background is expected. |
+| M2 niche-building through M2S4 or M2S5 | The niche may be a literature gap, conceptual gap, social problem, policy issue, or unresolved debate. |
+| M3S9 Introducing present research descriptively | The present study is expected. |
+| M3S10 Introducing present research purposefully | Purpose or aim is expected. |
+
+Subdisciplinary adjustments:
+
+| Subdiscipline | Increase diagnostic attention to |
+|---|---|
+| Anthropology | Context, conceptual framing, and research setting. |
+| Applied Linguistics | Literature gap, pedagogical/applied justification, and research questions. |
+| Political Science | Problem framing, theory, hypotheses, and contribution. |
+| Psychology | Hypotheses, variables, and study rationale. |
+| Sociology | Social problem framing, conceptual gap, and research questions. |
+
+Skill rule: do not impose a hard-science pattern such as technical gap, method, and result. Check whether the Introduction establishes conceptual territory, literature/problem niche, research purpose, and contribution.
+

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/failure-strategies.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/failure-strategies.md
@@ -1,0 +1,72 @@
+# Failure Strategies
+
+Use these rules when the input does not cleanly fit the Introduction diagnostic workflow.
+
+## No Clear Introduction
+
+If the text is not an Introduction or opening research-positioning passage:
+
+- state that the skill cannot fully apply;
+- identify any Introduction-like content that is present;
+- ask for the Introduction section if a full diagnosis is needed.
+
+If the heading is missing but the passage clearly establishes territory, niche, or present-study positioning, continue and state that the diagnosis is based on an inferred Introduction passage.
+
+## Full Paper Provided
+
+If the user provides a full paper:
+
+- extract the Introduction if it is clearly marked;
+- stop and ask for the Introduction if it cannot be found;
+- do not diagnose Methods, Results, Discussion, or Conclusion with this skill.
+
+## Missing Discipline
+
+If the discipline is missing:
+
+- infer cautiously from the text if possible;
+- use the default profile when uncertain;
+- state that discipline-specific judgments are provisional;
+- avoid over-specific expectations.
+
+## Missing Article Type
+
+If the article type is missing:
+
+- infer it from the aim, method preview, research questions, hypotheses, or contribution;
+- if inference is uncertain, mark it as unclear;
+- use only broadly applicable conventional functions.
+
+## Insufficient Text
+
+If the submitted text is too short:
+
+- diagnose only what is visible;
+- do not assume missing information appears elsewhere;
+- ask for the full Introduction if the user wants a complete diagnosis.
+
+## Ambiguous Step Label
+
+If a segment could belong to multiple steps:
+
+- assign the strongest primary label;
+- add secondary labels when appropriate;
+- mark confidence as Medium or Low;
+- explain the ambiguity briefly.
+
+## User Requests Rewriting Only
+
+If the user asks only for rewriting:
+
+- first provide a brief diagnosis of major rhetorical problems;
+- rewrite only if the user explicitly requested revision;
+- preserve the student's intended topic, gap, aim, method, and contribution;
+- do not invent literature, findings, data, methods, or claims.
+
+## Non-Introduction Section
+
+If the text appears to be Methods, Results, Discussion, Conclusion, or a general Literature Review:
+
+- do not force Introduction labels onto it;
+- state which section it appears to be;
+- recommend using the corresponding section-specific skill if available.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/introduction-move-step-definitions.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/introduction-move-step-definitions.md
@@ -1,0 +1,59 @@
+# Introduction Move-Step Definitions
+
+Use Cotos and Pendar's 3 moves plus 17 steps as the main label set for Introduction diagnosis.
+
+## Labeling Rules
+
+- Assign one primary label to each functional unit.
+- Add secondary labels when one sentence or clause performs more than one rhetorical function.
+- Split a sentence into clauses only when needed to preserve distinct rhetorical functions.
+- Judge function in context, not keywords alone.
+- Mark confidence as High, Medium, or Low.
+
+## Move 1: Establishing a Territory
+
+Move 1 builds the research field, topic, or problem space.
+
+| Code | Step | Function |
+|---|---|---|
+| M1S1 | Claiming centrality | Show that the topic is important, timely, widespread, or worth studying. |
+| M1S2 | Making topic generalizations | Provide general background, definitions, trends, or accepted knowledge. |
+| M1S3 | Reviewing previous research | Summarize or synthesize prior studies. |
+
+## Move 2: Identifying a Niche
+
+Move 2 shows a gap, problem, limitation, question, or justification.
+
+| Code | Step | Function |
+|---|---|---|
+| M2S4 | Indicating a gap | Point out what previous research has not addressed. |
+| M2S5 | Highlighting a problem | Identify a theoretical, practical, technical, social, or real-world problem. |
+| M2S6 | Raising general questions | Raise broad questions that motivate the study. |
+| M2S7 | Proposing general hypotheses | Suggest general hypotheses before presenting the present study. |
+| M2S8 | Presenting a justification | Explain why the study is necessary, valuable, or appropriate. |
+
+## Move 3: Addressing the Niche
+
+Move 3 introduces the present study and its contribution.
+
+| Code | Step | Function |
+|---|---|---|
+| M3S9 | Introducing present research descriptively | Describe what the present study does. |
+| M3S10 | Introducing present research purposefully | State the aim, purpose, or objective. |
+| M3S11 | Presenting research questions | State specific research questions. |
+| M3S12 | Presenting research hypotheses | State specific hypotheses. |
+| M3S13 | Clarifying definitions | Define key terms, concepts, constructs, or scope. |
+| M3S14 | Summarizing methods | Preview data, materials, participants, system, model, experiment, or method. |
+| M3S15 | Announcing principal outcomes | Preview main findings or expected outcomes. |
+| M3S16 | Stating the value of the present research | State contribution, novelty, usefulness, or significance. |
+| M3S17 | Outlining the structure of the paper | Preview the organization of the article. |
+
+## Discipline-Specific Local Step
+
+Use this local step only when the discipline profile calls for it.
+
+| Code | Local step | Function |
+|---|---|---|
+| WB-LS1 | Species/site/research-object background | Introduce the species, site, behavior, ecological setting, or research object needed to understand the study. |
+
+Do not force Wildlife Behavior species/site background into M1S3 if it is not reviewing previous studies. It may function as background, justification, or present-study positioning.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/output-templates.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/output-templates.md
@@ -1,0 +1,111 @@
+# Output Templates
+
+Use these templates to format diagnostic output. Adapt length to the user's request.
+
+## Full Diagnostic Report
+
+```markdown
+## 1. Overall Diagnosis
+
+[Brief paragraph identifying discipline, article type if known, what the Introduction already does, and the main rhetorical problems.]
+
+## 2. Sentence-Level Move-Step Annotation
+
+| ID | Text span | Primary label | Secondary label(s) | Confidence | Reason |
+|---|---|---|---|---|---|
+| S1 | ... | M1S2 | ... | High | ... |
+
+## 3. Discipline-Sensitive Step Coverage
+
+| Conventional step or function | Status | Evidence | Problem | Why it matters |
+|---|---|---|---|---|
+| M1S2 Making topic generalizations | Present/Weak/Missing/Not Applicable/Unclear | ... | ... | ... |
+
+## 4. Gap or Niche Diagnosis
+
+| Gap/niche evidence | Gap type | Evaluation | Revision direction |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+## 5. Gap-Aim Alignment
+
+| Gap sentence | Aim/contribution sentence | Alignment problem | Revision direction |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+## 6. Literature Organization
+
+| Evidence | Problem pattern | Why it weakens the Introduction | Revision direction |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+## 7. Revision Priorities
+
+### 必须修改
+
+| 原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+### 建议修改
+
+| 原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+```
+
+## Short Classroom Feedback
+
+```markdown
+## Diagnosis
+
+[2-4 sentences on what the Introduction already does and what most weakens territory, niche, or present-study positioning.]
+
+## Most Important Revisions
+
+### 必须修改
+
+| 原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+### 建议修改
+
+| 原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向 |
+|---|---|---|---|
+| ... | ... | ... | ... |
+```
+
+## Sentence-Level Comment Template
+
+Use when the user wants feedback attached to specific sentences.
+
+```markdown
+| Sentence | Move-step label | Problem | Teaching feedback |
+|---|---|---|---|
+| ... | M2S4 / M3S10 | ... | ... |
+```
+
+## Coverage-Only Template
+
+Use when the user asks only which moves or steps are present or missing.
+
+```markdown
+| Conventional step or function | Status | Evidence | Note |
+|---|---|---|---|
+| M2S4 Indicating a gap | Present/Weak/Missing/Not Applicable/Unclear | ... | ... |
+```
+
+## Revision Priority Rules
+
+End with two blocks in this order:
+
+1. 必须修改
+2. 建议修改
+
+Use `原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向` in both blocks.
+
+- Put Missing conventional functions and serious Weak items in `必须修改`.
+- Put less serious Weak items in `建议修改`.
+- Keep feedback evidence-based.
+- Do not invent literature, aims, methods, data, findings, or contribution claims.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/output-templates.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/output-templates.md
@@ -1,111 +1,39 @@
 # Output Templates
 
-Use these templates to format diagnostic output. Adapt length to the user's request.
+Use this template to keep Introduction diagnoses focused on revision advice only.
 
-## Full Diagnostic Report
+The diagnosis workflow may produce internal sentence-level move-step annotations, discipline-sensitive step coverage, gap or niche diagnosis, gap-aim alignment, and literature-organization checks. Do not include those internal diagnostic sections in the final response unless the user explicitly asks for them.
+
+## Final Output
+
+Output only the content that would normally appear under `Revision Priorities`. Do not include a diagnostic report title, section number, overall diagnosis, sentence-level annotation, step coverage, gap diagnosis, gap-aim alignment table, literature-organization table, or closing note.
+
+Use this exact structure:
 
 ```markdown
-## 1. Overall Diagnosis
-
-[Brief paragraph identifying discipline, article type if known, what the Introduction already does, and the main rhetorical problems.]
-
-## 2. Sentence-Level Move-Step Annotation
-
-| ID | Text span | Primary label | Secondary label(s) | Confidence | Reason |
-|---|---|---|---|---|---|
-| S1 | ... | M1S2 | ... | High | ... |
-
-## 3. Discipline-Sensitive Step Coverage
-
-| Conventional step or function | Status | Evidence | Problem | Why it matters |
-|---|---|---|---|---|
-| M1S2 Making topic generalizations | Present/Weak/Missing/Not Applicable/Unclear | ... | ... | ... |
-
-## 4. Gap or Niche Diagnosis
-
-| Gap/niche evidence | Gap type | Evaluation | Revision direction |
-|---|---|---|---|
-| ... | ... | ... | ... |
-
-## 5. Gap-Aim Alignment
-
-| Gap sentence | Aim/contribution sentence | Alignment problem | Revision direction |
-|---|---|---|---|
-| ... | ... | ... | ... |
-
-## 6. Literature Organization
-
-| Evidence | Problem pattern | Why it weakens the Introduction | Revision direction |
-|---|---|---|---|
-| ... | ... | ... | ... |
-
-## 7. Revision Priorities
-
 ### 必须修改
 
-| 原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens the Introduction when relevant]
+   - 具体改进方向: [specific revision direction in English]
 
 ### 建议修改
 
-| 原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens the Introduction when relevant]
+   - 具体改进方向: [specific revision direction in English]
 ```
 
-## Short Classroom Feedback
+If one block has no items, keep the heading and write `No items.` under it.
 
-```markdown
-## Diagnosis
+## Item Rules
 
-[2-4 sentences on what the Introduction already does and what most weakens territory, niche, or present-study positioning.]
-
-## Most Important Revisions
-
-### 必须修改
-
-| 原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
-
-### 建议修改
-
-| 原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向 |
-|---|---|---|---|
-| ... | ... | ... | ... |
-```
-
-## Sentence-Level Comment Template
-
-Use when the user wants feedback attached to specific sentences.
-
-```markdown
-| Sentence | Move-step label | Problem | Teaching feedback |
-|---|---|---|---|
-| ... | M2S4 / M3S10 | ... | ... |
-```
-
-## Coverage-Only Template
-
-Use when the user asks only which moves or steps are present or missing.
-
-```markdown
-| Conventional step or function | Status | Evidence | Note |
-|---|---|---|---|
-| M2S4 Indicating a gap | Present/Weak/Missing/Not Applicable/Unclear | ... | ... |
-```
-
-## Revision Priority Rules
-
-End with two blocks in this order:
-
-1. 必须修改
-2. 建议修改
-
-Use `原文句子 | 问题 | 为什么影响 Introduction | 具体改进方向` in both blocks.
-
-- Put Missing conventional functions and serious Weak items in `必须修改`.
-- Put less serious Weak items in `建议修改`.
-- Keep feedback evidence-based.
-- Do not invent literature, aims, methods, data, findings, or contribution claims.
+- Put missing conventional functions and serious weak items that harm Introduction logic, gap construction, gap-aim fit, or discipline-expected positioning under `必须修改`.
+- Put weaker items that would improve specificity, synthesis, citation support, or rhetorical clarity but do not break the Introduction under `建议修改`.
+- Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+- Start each item with `Issue N:` followed by a concise English issue summary.
+- Anchor each item in original wording.
+- Do not invent literature, aims, methods, data, findings, or contribution claims for the student.
+- Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/source-notes.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/source-notes.md
@@ -1,0 +1,45 @@
+# Source Notes
+
+Use this file when the user asks about the theoretical basis, source framework, or rationale behind the skill.
+
+## Main Source
+
+This skill is based on local WisePen Introduction teaching material that defines a discipline-sensitive Introduction profile based on Cotos and Pendar's 3 moves plus 17 steps. The relevant content has been distilled into `references/introduction-move-step-definitions.md`, `references/discipline-sensitive-profiles.md`, and `references/diagnostic-rubric.md`.
+
+## Core Principle
+
+Across most research article Introductions, the three major moves are relatively stable:
+
+- Move 1: Establishing a territory
+- Move 2: Identifying a niche
+- Move 3: Addressing the niche
+
+Disciplinary differences appear mainly at the step level. The skill therefore checks whether the Introduction performs the three core rhetorical functions, then judges whether its step choices match disciplinary expectations.
+
+## Conventionality Rule
+
+The source document uses three expectation categories:
+
+- Conventional: commonly expected in the discipline.
+- Optional: may appear but should not be required.
+- Rare / normally not expected: should not be required.
+
+The source document notes a practical threshold: a move or step appearing in at least 60 percent of texts in empirical move-analysis studies can be treated as conventional.
+
+## Why This Skill Lists Only Conventional Steps
+
+The discipline profile file intentionally lists only conventional or strongly expected steps to reduce context size and avoid over-penalizing students.
+
+Optional and rare steps are not deleted from the conceptual framework. They remain available in the full 17-step label set, but absence of those steps should not be diagnosed as a missing-step problem.
+
+## Pedagogical Orientation
+
+The skill is designed for academic English writing pedagogy. Its goal is to help students see whether an Introduction:
+
+- builds a research territory;
+- creates a credible niche;
+- introduces the present study;
+- aligns gap, aim, and contribution;
+- organizes literature by content rather than by author list.
+
+It should provide evidence-based feedback anchored in the student's original wording, not a full rewrite unless explicitly requested.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/workflow.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/workflow.md
@@ -160,19 +160,33 @@ Treat literature organization as `必须修改` when it prevents the reader from
 
 Use `references/output-templates.md` for formatting.
 
-Default output sections:
+Steps 1-8 are internal diagnostic work. They support the priority judgment, but they must not appear in the final response.
 
-1. Overall Diagnosis
-2. Sentence-Level Move-Step Annotation
-3. Discipline-Sensitive Step Coverage
-4. Gap or Niche Diagnosis
-5. Gap-Aim Alignment
-6. Literature Organization
-7. Revision Priorities
+Final output must contain only the concrete revision priorities.
 
-In section 7, output two blocks in this order:
+Do not output:
+
+- Overall Diagnosis;
+- Sentence-Level Move-Step Annotation;
+- Discipline-Sensitive Step Coverage;
+- Gap or Niche Diagnosis;
+- Gap-Aim Alignment;
+- Literature Organization;
+- `Revision Priorities` or any numbered section heading;
+- paragraph summaries, scores, introductions, closing notes, or follow-up questions.
+
+Output two blocks in this order:
 
 - 必须修改: missing conventional steps and weak items that materially harm Introduction logic, gap construction, gap-aim fit, or discipline-expected positioning.
 - 建议修改: weak items that would improve specificity, synthesis, citation support, or rhetorical clarity but do not break the Introduction.
 
-Each item must be anchored in original wording and should not invent content for the student.
+Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+
+Each item must follow this structure:
+
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English, including why it weakens the Introduction when relevant]
+   - 具体改进方向: [specific revision direction in English]
+
+Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English. Each item must be anchored in original wording and should not invent content for the student.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/workflow.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-introduction-discourse/1.0/references/workflow.md
@@ -1,0 +1,178 @@
+# Introduction Discourse Diagnostic Workflow
+
+This workflow diagnoses a submitted Introduction through Cotos and Pendar's 3-move/17-step model. It should produce teaching-oriented feedback, not grammar correction or full rewriting.
+
+## 0. Input Gate
+
+Confirm that the submitted text is an Introduction section or a clearly identifiable opening passage that establishes research territory, niche, and present-study positioning.
+
+Continue when:
+
+- the text is explicitly an Introduction section;
+- the text has no heading but clearly performs Introduction functions;
+- the user provides a full paper and the Introduction can be cleanly extracted.
+
+Stop or ask for more input when:
+
+- the passage is not an Introduction or related opening section;
+- the user asks for a full Introduction diagnosis but provides only a title, abstract, outline, or isolated sentence;
+- the full paper has no identifiable Introduction.
+
+If the passage is short but diagnosable, continue and state that the diagnosis is limited to the visible text.
+
+## 1. Identify Article Profile
+
+Infer or read from user metadata:
+
+- discipline or subdiscipline;
+- article type: empirical, experimental, theoretical, review, technical, mixed-methods, or unclear;
+- research tradition: quantitative, qualitative, mixed, computational, laboratory, applied, conceptual, or unclear;
+- likely topic, research object, and intended contribution.
+
+Use this profile only to select discipline-sensitive expectations. If the discipline is unclear, use the default profile in `references/discipline-sensitive-profiles.md` and mark discipline-specific judgments as provisional.
+
+## 2. Extract and Segment the Introduction
+
+Extract only the Introduction-related passage if the user provides surrounding text.
+
+Segment the Introduction into functional units:
+
+- usually sentence-level;
+- split a sentence into clauses when different clauses perform different rhetorical functions;
+- keep a sentence intact when splitting would obscure the student's logic;
+- preserve original wording for every unit.
+
+Each unit should receive an ID such as `S1`, `S2`, or `S3a`.
+
+## 3. Annotate Moves and Steps
+
+Use the detailed labels in `references/introduction-move-step-definitions.md`.
+
+For each unit record:
+
+- text span;
+- primary move-step label;
+- secondary label(s), if any;
+- confidence: High, Medium, or Low;
+- brief reason.
+
+Judge rhetorical function in context, not keywords alone. A sentence can realize more than one step.
+
+## 4. Build the Discipline-Sensitive Conventional Profile
+
+Read `references/discipline-sensitive-profiles.md`.
+
+Use only conventional steps or equivalent functions as teaching-required checks. Do not require optional or rare steps, and do not list them as missing in the final diagnosis.
+
+Use equivalent-function logic where appropriate:
+
+- Default niche: M2S4 Indicating a gap or M2S5 Highlighting a problem.
+- Default present study: M3S9 Introducing present research descriptively or M3S10 Introducing present research purposefully.
+- Conservation Biology: a real-world conservation problem can realize the niche even without a pure literature gap.
+- Chemical Biology: principal outcomes plus value can realize Move 3 even when an explicit purpose sentence is absent.
+- Wildlife Behavior: species/site/research-object background may be required local background.
+- Social Sciences: research questions or hypotheses may become important depending on subfield and method.
+
+## 5. Evaluate Conventional-Step Coverage
+
+Use these final status labels:
+
+- Present
+- Weak
+- Missing
+- Not Applicable
+- Unclear
+
+For each conventional step or equivalent function, decide its status and provide evidence from the student's wording.
+
+Mark Present only when the rhetorical function is achieved, not merely when a keyword appears.
+
+Put Missing items and serious Weak items into `必须修改` when they harm one of these Introduction functions:
+
+- establishing a credible research territory;
+- identifying a clear niche, gap, problem, unresolved question, or debate;
+- introducing the present study in a way that addresses the niche;
+- showing the value, contribution, method, outcome, or research question expected by the discipline.
+
+Put less serious Weak items into `建议修改` when they mainly need sharper wording, clearer support, or stronger synthesis.
+
+## 6. Diagnose the Gap or Niche
+
+Identify how the Introduction builds its niche.
+
+Possible gap or niche types:
+
+- literature gap;
+- methodological or technical limitation;
+- conceptual or theoretical gap;
+- empirical gap involving population, dataset, context, setting, species, site, period, or material;
+- unresolved mechanism;
+- practical, social, clinical, environmental, or conservation problem;
+- unresolved debate or contradiction in previous findings;
+- broad research question or hypothesis that motivates the study.
+
+Evaluate whether the gap is:
+
+- specific enough to guide the study;
+- credible and supported by reviewed literature;
+- naturally developed from previous sentences;
+- appropriately scoped for the article;
+- aligned with the discipline's normal niche-building strategy;
+- not overstated beyond what the cited literature can support.
+
+Do not invent a better gap. Tell the student what kind of gap, support, or narrowing the text needs.
+
+## 7. Check Gap-Aim Alignment
+
+Extract and compare:
+
+- gap, problem, debate, or unresolved question;
+- research aim, objective, research question, hypothesis, contribution, or value claim;
+- method preview, outcome preview, or principal finding when the discipline expects them.
+
+Ask:
+
+- Does the aim answer the same gap that the Introduction created?
+- Do the population, object, context, variables, method, and scope match?
+- Does the method preview look capable of addressing the stated gap?
+- Does the contribution or value claim follow from the gap?
+- Is the aim too broad, too narrow, or shifted to a different problem?
+
+When gap and aim do not correspond, quote both the gap sentence and the aim or contribution sentence.
+
+## 8. Diagnose Literature Organization
+
+Check whether the literature review is content-driven rather than source-driven.
+
+Problem patterns include:
+
+- source list pattern: A says X, B says Y, C says Z without synthesis;
+- isolated study summaries without relationships among them;
+- no contrast, development, grouping, or tension across studies;
+- previous research does not lead to the gap;
+- claims of importance or background lack source support;
+- reviewed studies are irrelevant to the territory or niche;
+- citation-heavy sentences replace the writer's own synthesis.
+
+Treat literature organization as `必须修改` when it prevents the reader from seeing the research gap or niche. Treat it as `建议修改` when the review is understandable but could be grouped more clearly by theme, method, population, finding, or limitation.
+
+## 9. Convert Diagnosis into Teaching Feedback
+
+Use `references/output-templates.md` for formatting.
+
+Default output sections:
+
+1. Overall Diagnosis
+2. Sentence-Level Move-Step Annotation
+3. Discipline-Sensitive Step Coverage
+4. Gap or Niche Diagnosis
+5. Gap-Aim Alignment
+6. Literature Organization
+7. Revision Priorities
+
+In section 7, output two blocks in this order:
+
+- 必须修改: missing conventional steps and weak items that materially harm Introduction logic, gap construction, gap-aim fit, or discipline-expected positioning.
+- 建议修改: weak items that would improve specificity, synthesis, citation support, or rhetorical clarity but do not break the Introduction.
+
+Each item must be anchored in original wording and should not invent content for the student.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/SKILL.md
@@ -42,29 +42,29 @@ Load only the files needed for the current task:
 - `references/draC-move-step-definitions.md`: read when assigning or explaining DRaC move-step labels.
 - `references/discipline-required-profiles.md`: read when deciding which steps are teaching-required for a discipline or research type.
 - `references/diagnostic-rubric.md`: read when judging Present, Weak, Missing, Not Applicable, or Unclear, and when identifying rationale gaps or logic issues.
-- `references/output-templates.md`: read when formatting a full diagnostic report, short classroom feedback, or sentence-level feedback.
+- `references/output-templates.md`: read when formatting the final revision-priority-only answer.
 - `references/failure-strategies.md`: read when the input may not be a Methods section, is too short, lacks discipline metadata, or asks only for rewriting.
 - `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses DRaC.
 
 ## Default Output
 
-Unless the user asks for a shorter format, return six sections:
+Unless the user explicitly asks for a different format, return only the final concrete revision priorities.
 
-1. Overall Diagnosis
-2. Move-Step Annotation
-3. Required Step Coverage
-4. Unjustified Methodological Decisions
-5. Method Logic Issues
-6. Revision Priorities
+Do not include overall diagnosis, move-step annotation, required-step coverage, unjustified-decision tables, method-logic tables, diagnostic summaries, or closing notes in the final response. Use those analyses internally, then output only two blocks in this order:
 
-In section 6, split the closing feedback into two tables, in this order:
+- 必须修改
+- 建议修改
 
-- 必须补充
-- 建议补充
+Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
 
-Each table should use `原文句子 | 问题 | 具体改进方向`.
+Each issue must follow this structure:
 
-Use tables where they make the diagnosis easier to inspect.
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English]
+   - 具体改进方向: [specific revision direction in English]
+
+Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.
 
 ## Constraints
 
@@ -86,6 +86,6 @@ Do:
 - identify decisions that need justification;
 - identify logical breaks in the method chain;
 - explain why each issue matters for rigour, credibility, or reproducibility;
-- in the final feedback, separate must-add and suggested-add items, and re-check each one against the original wording before writing it;
+- in the final feedback, separate must-fix and suggested-fix items, and re-check each one against the original wording before writing it;
 - provide concrete revision priorities without inventing content for the student.
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: diagnosing-method-discourse
+description: Diagnoses the rhetorical move-step structure of academic Methods sections using the DRaC model. Use when Codex needs to check, evaluate, diagnose, or give pedagogical feedback on Methods discourse, including move-step coverage, missing required steps, weak methodological explanation, unjustified method choices, or method-chain logic problems in academic English writing.
+---
+
+# Diagnosing Method Discourse
+
+Use this skill to diagnose whether a student's academic Methods section demonstrates methodological rigour and credibility.
+
+This skill is for academic English writing pedagogy. Produce diagnostic feedback, not grammar correction, style polishing, or a full rewrite unless the user explicitly asks for revision after diagnosis.
+
+## Core Framework
+
+Use the DRaC model: Demonstrating Rigour and Credibility.
+
+Diagnose Methods discourse through three moves:
+
+- Move 1: Contextualizing Study Methods
+- Move 2: Describing the Study
+- Move 3: Establishing Credibility
+
+A move is a broad rhetorical function. A step is a more specific rhetorical action that realizes the move.
+
+## Required Workflow
+
+When performing a real diagnosis, first read `references/workflow.md` and follow its sequence:
+
+1. verify that the input is a Methods section or methodology passage;
+2. identify discipline and research type;
+3. extract and segment the Methods text;
+4. annotate DRaC moves and steps;
+5. build the discipline-sensitive required-step profile;
+6. judge step status;
+7. detect rationale gaps;
+8. detect method-chain logic issues;
+9. generate teaching-oriented feedback and revision priorities.
+
+## Reference Files
+
+Load only the files needed for the current task:
+
+- `references/draC-move-step-definitions.md`: read when assigning or explaining DRaC move-step labels.
+- `references/discipline-required-profiles.md`: read when deciding which steps are teaching-required for a discipline or research type.
+- `references/diagnostic-rubric.md`: read when judging Present, Weak, Missing, Not Applicable, or Unclear, and when identifying rationale gaps or logic issues.
+- `references/output-templates.md`: read when formatting a full diagnostic report, short classroom feedback, or sentence-level feedback.
+- `references/failure-strategies.md`: read when the input may not be a Methods section, is too short, lacks discipline metadata, or asks only for rewriting.
+- `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses DRaC.
+
+## Default Output
+
+Unless the user asks for a shorter format, return six sections:
+
+1. Overall Diagnosis
+2. Move-Step Annotation
+3. Required Step Coverage
+4. Unjustified Methodological Decisions
+5. Method Logic Issues
+6. Revision Priorities
+
+In section 6, split the closing feedback into two tables, in this order:
+
+- 必须补充
+- 建议补充
+
+Each table should use `原文句子 | 问题 | 具体改进方向`.
+
+Use tables where they make the diagnosis easier to inspect.
+
+## Constraints
+
+Do not:
+
+- invent missing methodological details;
+- treat all 16 DRaC steps as universally required;
+- diagnose by keyword matching alone;
+- replace rhetorical diagnosis with grammar correction;
+- rewrite the whole Methods section unless requested;
+- mark a step as Missing when it is not applicable to the research design;
+- use the term "optional" in the final diagnosis.
+
+Do:
+
+- focus on rhetorical function;
+- use evidence from the student's text;
+- distinguish Missing from Weak;
+- identify decisions that need justification;
+- identify logical breaks in the method chain;
+- explain why each issue matters for rigour, credibility, or reproducibility;
+- in the final feedback, separate must-add and suggested-add items, and re-check each one against the original wording before writing it;
+- provide concrete revision priorities without inventing content for the student.
+

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/SKILL.md
@@ -23,28 +23,51 @@ A move is a broad rhetorical function. A step is a more specific rhetorical acti
 
 ## Required Workflow
 
-When performing a real diagnosis, first read `references/workflow.md` and follow its sequence:
+When performing a real diagnosis, first call `load_skill_asset` on `references/workflow.md` and follow its sequence.
+
+For every workflow step below, you MUST call `load_skill_asset` for each listed file before completing that step. If the same file has already been loaded earlier in the current turn, reuse the already loaded content instead of calling `load_skill_asset` again.
 
 1. verify that the input is a Methods section or methodology passage;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/failure-strategies.md`
 2. identify discipline and research type;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/discipline-required-profiles.md`
 3. extract and segment the Methods text;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
 4. annotate DRaC moves and steps;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/draC-move-step-definitions.md`
 5. build the discipline-sensitive required-step profile;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/discipline-required-profiles.md`
 6. judge step status;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
 7. detect rationale gaps;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
 8. detect method-chain logic issues;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/diagnostic-rubric.md`
 9. generate teaching-oriented feedback and revision priorities.
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/output-templates.md`
 
 ## Reference Files
 
-Load only the files needed for the current task:
+For a real Methods diagnosis, the following files are required by the workflow above and must be loaded through `load_skill_asset` when their workflow step is reached:
 
-- `references/draC-move-step-definitions.md`: read when assigning or explaining DRaC move-step labels.
-- `references/discipline-required-profiles.md`: read when deciding which steps are teaching-required for a discipline or research type.
-- `references/diagnostic-rubric.md`: read when judging Present, Weak, Missing, Not Applicable, or Unclear, and when identifying rationale gaps or logic issues.
-- `references/output-templates.md`: read when formatting the final revision-priority-only answer.
-- `references/failure-strategies.md`: read when the input may not be a Methods section, is too short, lacks discipline metadata, or asks only for rewriting.
-- `references/source-notes.md`: read when the user asks about the theoretical basis, citations, or why the skill uses DRaC.
+- `references/workflow.md`: required for every real Methods diagnosis.
+- `references/failure-strategies.md`: required during input-gate and failure-mode handling.
+- `references/discipline-required-profiles.md`: required when identifying article profile and deciding which steps are teaching-required for a discipline or research type.
+- `references/draC-move-step-definitions.md`: required when assigning or explaining DRaC move-step labels.
+- `references/diagnostic-rubric.md`: required when judging Present, Weak, Missing, Not Applicable, or Unclear, and when identifying rationale gaps or logic issues.
+- `references/output-templates.md`: required when formatting the final revision-priority-only answer.
+
+Conditional reference:
+
+- `references/source-notes.md`: MUST load via `load_skill_asset` when the user asks about the theoretical basis, citations, source basis, or why the skill uses DRaC.
 
 ## Default Output
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/diagnostic-rubric.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/diagnostic-rubric.md
@@ -1,0 +1,135 @@
+# Diagnostic Rubric
+
+Use this file to convert move-step annotation into a pedagogical diagnosis.
+
+## Step Status Rules
+
+Use only these status labels:
+
+- Present
+- Weak
+- Missing
+- Not Applicable
+- Unclear
+
+### Present
+
+Mark Present only when the rhetorical function is clearly realized.
+
+The text should give enough information for a reader to understand the method function, not merely recognize a keyword.
+
+### Weak
+
+Mark Weak when the step is mentioned but lacks necessary detail, precision, sequence, or explanation.
+
+Common Weak cases:
+
+- the student names a tool but not how it was used;
+- the student names participants but not selection criteria or relevant characteristics;
+- the student names an analysis method but not the analytic procedure;
+- the student states a choice that needs rationale but gives none;
+- the student gives partial data preparation but omits key cleaning, coding, or exclusion details.
+
+When converting Weak items into final feedback, decide whether they belong in 必须补充 or 建议补充:
+
+- place them in 必须补充 if the missing detail affects rigour, credibility, reproducibility, validity, or the method chain;
+- place them in 建议补充 if the missing detail mainly improves transparency or completeness.
+
+For example, a clear participant profile with only an unclear recruitment channel usually belongs in 建议补充, not 必须补充.
+
+### Missing
+
+Mark Missing when the step is required for this discipline/research type but absent from the submitted Methods text.
+
+Do not assume the missing information appears elsewhere unless the user provides it.
+
+Missing items belong in 必须补充 in the final feedback.
+
+### Not Applicable
+
+Mark Not Applicable when the step does not fit the research design.
+
+Examples:
+
+- participant recruitment is Not Applicable for a purely computational benchmark using public datasets;
+- laboratory equipment is Not Applicable for a discourse analysis of existing texts;
+- treatment/control variables may be Not Applicable for a descriptive qualitative interview study.
+
+### Unclear
+
+Mark Unclear when the text does not provide enough information to decide whether the step is relevant or realized.
+
+Use Unclear when the research type, discipline, data type, or research aim is ambiguous.
+
+## Avoid Keyword-Only Judgment
+
+Judge rhetorical function, not surface vocabulary.
+
+Examples:
+
+- "SPSS was used" may indicate M2-S4, but it is not enough for M3-S2 unless the analysis procedure is described.
+- "Participants were selected" may indicate M1-S5 or M2-S1, but it does not rationalize sampling unless the reason or criterion is given.
+- "Data were cleaned" may gesture toward M3-S1, but it is Weak if the cleaning method, exclusion criteria, or transformation procedure is absent.
+
+## Rationale Gap Categories
+
+Identify a rationale gap when a methodological decision is stated but not justified.
+
+Common decision types:
+
+- selecting participants, samples, materials, cases, sites, or datasets;
+- choosing an instrument, questionnaire, interview protocol, corpus, model, software, or tool;
+- adapting or modifying an existing tool;
+- defining variables, categories, constructs, groups, or coding schemes;
+- setting thresholds, criteria, cutoffs, time windows, search terms, or inclusion/exclusion rules;
+- excluding data or participants;
+- transforming, coding, normalizing, cleaning, or preprocessing data;
+- choosing statistical, qualitative, computational, or evaluation methods;
+- choosing baselines, metrics, models, or comparison procedures.
+
+For each rationale gap, explain:
+
+- what choice was made;
+- why the choice affects credibility or validity;
+- what kind of reason the student should provide;
+- which DRaC rationalizing step is affected: M1-S6, M2-S6, or M3-S3.
+
+Do not invent a rationale.
+
+## Method Logic Issue Categories
+
+Check the method chain:
+
+Research aim/question -> research design -> data/participants/materials -> procedure/tools/variables -> data preparation -> data analysis -> credible findings.
+
+Common issue types:
+
+- research question-method mismatch;
+- data-analysis mismatch;
+- participant-claim mismatch;
+- tool-construct mismatch;
+- variable-analysis mismatch;
+- procedure-result mismatch;
+- missing or unclear data preparation;
+- missing rationale for key choices;
+- method sequence confusion;
+- overclaiming beyond what the method supports.
+
+## Teaching Feedback Rule
+
+Feedback should explain both the discourse problem and the consequence.
+
+Use this pattern:
+
+Your Methods section already does X. However, it does not yet do Y. This matters because Z. To revise, add or clarify A, B, and C.
+
+Keep feedback evidence-based. Anchor comments in the student's wording whenever possible.
+
+## Final Feedback Split
+
+When writing the closing feedback, split the items into two blocks in this order:
+
+1. 必须补充
+2. 建议补充
+
+Re-read the source sentence before placing an item in either block and make sure the suggested revision is supported by the text and the study design. Do not use the same issue in both blocks.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/diagnostic-rubric.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/diagnostic-rubric.md
@@ -30,12 +30,12 @@ Common Weak cases:
 - the student states a choice that needs rationale but gives none;
 - the student gives partial data preparation but omits key cleaning, coding, or exclusion details.
 
-When converting Weak items into final feedback, decide whether they belong in 必须补充 or 建议补充:
+When converting Weak items into final feedback, decide whether they belong in 必须修改 or 建议修改:
 
-- place them in 必须补充 if the missing detail affects rigour, credibility, reproducibility, validity, or the method chain;
-- place them in 建议补充 if the missing detail mainly improves transparency or completeness.
+- place them in 必须修改 if the missing detail affects rigour, credibility, reproducibility, validity, or the method chain;
+- place them in 建议修改 if the missing detail mainly improves transparency or completeness.
 
-For example, a clear participant profile with only an unclear recruitment channel usually belongs in 建议补充, not 必须补充.
+For example, a clear participant profile with only an unclear recruitment channel usually belongs in 建议修改, not 必须修改.
 
 ### Missing
 
@@ -43,7 +43,7 @@ Mark Missing when the step is required for this discipline/research type but abs
 
 Do not assume the missing information appears elsewhere unless the user provides it.
 
-Missing items belong in 必须补充 in the final feedback.
+Missing items belong in 必须修改 in the final feedback.
 
 ### Not Applicable
 
@@ -129,7 +129,7 @@ Keep feedback evidence-based. Anchor comments in the student's wording whenever 
 
 When writing the closing feedback, split the items into two blocks in this order:
 
-1. 必须补充
-2. 建议补充
+1. 必须修改
+2. 建议修改
 
 Re-read the source sentence before placing an item in either block and make sure the suggested revision is supported by the text and the study design. Do not use the same issue in both blocks.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/discipline-required-profiles.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/discipline-required-profiles.md
@@ -1,0 +1,168 @@
+# Discipline-Sensitive Required Profiles
+
+Use this file to decide which DRaC steps are teaching-required for the submitted Methods section. These profiles guide diagnosis; they are not universal checklists.
+
+Do not use the term "optional" in final feedback. If a step does not fit the research design, mark it Not Applicable.
+
+## General Empirical Research
+
+Usually check:
+
+- M1-S3 Identifying the methodological approach
+- M2-S1 Acquiring the data
+- M2-S2 Describing the data
+- M2-S3 Describing experimental/study procedures
+- M2-S4 Describing tools
+- M2-S5 Identifying variables
+- M3-S1 Preparing the data
+- M3-S2 Describing the data analysis
+- M3-S3 Rationalizing data processing/analysis
+
+## Social Sciences, Education, Applied Linguistics, and Business
+
+Usually check strongly for:
+
+- M1-S3 methodological approach
+- M1-S5 participants
+- M1-S6 rationale for sampling, setting, or design
+- M2-S1 data collection
+- M2-S2 data description
+- M2-S4 instruments, questionnaires, interview protocols, coding tools, or software
+- M2-S5 variables, dimensions, categories, or coding schemes
+- M2-S6 rationale for grouping, coding, or design choices
+- M3-S1 data cleaning, transcription, coding, exclusion, or preparation
+- M3-S2 statistical, thematic, content, discourse, or coding analysis
+- M3-S3 reliability, validity, inter-rater agreement, or analysis rationale
+
+## Questionnaire Studies
+
+Usually check strongly for:
+
+- M1-S3 survey or questionnaire design
+- M1-S5 participants or respondents
+- M1-S6 sampling rationale or design rationale
+- M2-S1 questionnaire distribution and response collection
+- M2-S2 sample size, response rate, respondent characteristics, or item structure
+- M2-S4 questionnaire source, instrument, platform, scales, or software
+- M2-S5 variables, constructs, dimensions, scales, or coding
+- M2-S6 rationale for questionnaire adaptation, sampling, scale choice, or grouping
+- M3-S1 invalid response removal, missing data, coding, reliability screening, or data cleaning
+- M3-S2 descriptive statistics, regression, correlation, factor analysis, or other analysis procedure
+- M3-S3 reliability, validity, model-fit, or why the statistical method fits the research question
+
+## Interview or Qualitative Studies
+
+Usually check strongly for:
+
+- M1-S3 qualitative design or interview approach
+- M1-S5 participants and recruitment
+- M1-S6 rationale for sampling, site, or participant selection
+- M2-S1 interview data collection
+- M2-S2 interview corpus, number of interviews, duration, or participant characteristics
+- M2-S4 interview protocol, recording tools, transcription tools, coding software, or materials
+- M2-S5 themes, categories, coding dimensions, or analytic focus
+- M2-S6 rationale for interview design, sampling, coding scheme, or theme construction
+- M3-S1 transcription, anonymization, coding, cleaning, memoing, or data organization
+- M3-S2 thematic, content, discourse, grounded theory, or other qualitative analysis
+- M3-S3 coder reliability, triangulation, member checking, audit trail, or analytic credibility
+
+## Mixed-Methods Studies
+
+Usually check strongly for:
+
+- M1-S3 mixed-methods design and integration logic
+- M1-S5 participants, cases, or data sources for each strand
+- M1-S6 rationale for using mixed methods
+- M2-S1 data collection for each strand
+- M2-S2 data characteristics for each strand
+- M2-S3 procedure sequence or concurrent/embedded design
+- M2-S4 instruments and tools for each strand
+- M2-S5 variables, codes, categories, or integration points
+- M2-S6 rationale for sequencing, weighting, or integration decisions
+- M3-S1 preparation of quantitative and qualitative data
+- M3-S2 analysis procedures for each strand and integration method
+- M3-S3 credibility rationale for integration and interpretation
+
+## Classroom or Educational Intervention Studies
+
+Usually check strongly for:
+
+- M1-S3 intervention or quasi-experimental design
+- M1-S4 classroom, institution, time, or instructional setting
+- M1-S5 students, teachers, classes, or groups
+- M1-S6 rationale for group selection, intervention design, or teaching context
+- M2-S1 data collection before, during, and after intervention
+- M2-S2 data type, sample, task, test, or assessment description
+- M2-S3 intervention procedure and timeline
+- M2-S4 teaching materials, tests, rubrics, platforms, or software
+- M2-S5 independent/dependent variables, treatment/control groups, or assessment dimensions
+- M2-S6 rationale for grouping, intervention, instruments, or assessment criteria
+- M3-S1 scoring, coding, cleaning, exclusion, or preparation
+- M3-S2 statistical or qualitative analysis
+- M3-S3 reliability, validity, inter-rater agreement, or rationale for analysis
+
+## Corpus-Based Studies
+
+Usually check strongly for:
+
+- M1-S3 corpus-based approach
+- M1-S6 rationale for corpus selection or corpus design
+- M2-S1 corpus compilation or data extraction
+- M2-S2 corpus size, genre, time span, source, language, metadata, or sampling frame
+- M2-S3 search, extraction, annotation, or coding procedure
+- M2-S4 corpus tools, taggers, concordancers, scripts, or software
+- M2-S5 linguistic features, categories, variables, or search patterns
+- M2-S6 rationale for corpus criteria, annotation scheme, or search terms
+- M3-S1 cleaning, deduplication, tagging, filtering, normalization, or annotation checking
+- M3-S2 frequency, collocation, keyword, discourse, or statistical analysis
+- M3-S3 reliability of annotation, tool validity, or why the analysis fits the research question
+
+## Natural Sciences, Laboratory Sciences, and Engineering
+
+Usually check strongly for:
+
+- M1-S1 previous methods or protocols
+- M1-S4 experimental setting or conditions
+- M1-S5 samples, materials, biological objects, or experimental objects
+- M2-S1 sample or data acquisition
+- M2-S3 reproducible procedures
+- M2-S4 instruments, materials, reagents, software, equipment, or parameters
+- M2-S5 variables, treatments, controls, conditions, or groups
+- M2-S7 necessary intermediate measurements or observations
+- M3-S1 data screening, correction, transformation, or preprocessing
+- M3-S2 statistical, computational, or analytical method
+- M3-S3 rationale for processing, statistics, or model choices
+
+## Computational, Data Science, or Model-Based Studies
+
+Usually check strongly for:
+
+- M1-S1 previous models, baselines, or methods
+- M1-S3 overall method or experimental design
+- M2-S1 dataset source and split
+- M2-S2 dataset size, labels, features, and task type
+- M2-S3 training, testing, or evaluation procedure
+- M2-S4 models, libraries, hardware, parameters, or software environment
+- M2-S5 variables, hyperparameters, metrics, baselines, or experimental conditions
+- M2-S6 rationale for baselines, metrics, dataset split, or parameter choices
+- M3-S1 preprocessing, cleaning, normalization, filtering, or splitting
+- M3-S2 training, testing, evaluation, and statistical analysis
+- M3-S3 rationale for evaluation validity and metric suitability
+
+## Review-Based Papers with a Methods-Like Section
+
+Use only when the paper includes a clear review methodology, not when it is a purely narrative literature review.
+
+Usually check strongly for:
+
+- M1-S3 review type or methodological approach
+- M1-S6 rationale for review scope or inclusion logic
+- M2-S1 database search, source selection, or corpus construction
+- M2-S2 number and type of sources, time range, fields, or search scope
+- M2-S3 screening, selection, extraction, or coding procedure
+- M2-S4 databases, search engines, reference managers, coding tools, or software
+- M2-S5 inclusion/exclusion criteria, categories, variables, or coding dimensions
+- M2-S6 rationale for criteria, databases, search terms, or coding scheme
+- M3-S1 deduplication, screening, quality appraisal, coding, or data extraction
+- M3-S2 synthesis, thematic analysis, bibliometric analysis, meta-analysis, or coding analysis
+- M3-S3 credibility of search, coding reliability, quality appraisal, or synthesis rationale

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/draC-move-step-definitions.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/draC-move-step-definitions.md
@@ -1,0 +1,119 @@
+# DRaC Move-Step Definitions
+
+Use these definitions when annotating Methods section functional units. A sentence may realize more than one step. Assign the strongest primary label and add secondary labels when needed.
+
+## Move 1: Contextualizing Study Methods
+
+**Summary:** Provides background for the research approach, sets the scene for the study description, and frames the later explanation of procedures and analysis.
+
+### M1-S1: Referencing Previous Works
+
+Situates the chosen methodology in relation to previous studies, accepted methods, or representative methodological traditions.
+
+Example: "The near surface stress variation has been previously determined by micro-slotting and is similar to that characteristic of shot-peening profiles [20]."
+
+### M1-S2: Providing General Information
+
+Gives theoretical, empirical, or informational background that supports the methodology and connects the study to research traditions.
+
+Example: "Tree cover is usually lower than 50%, but it can be higher on abandoned land and game reserves."
+
+### M1-S3: Identifying the Methodological Approach
+
+Specifies the research design or methodological approach, either briefly or in detail depending on its complexity or novelty.
+
+Example: "The design was a randomized complete block with eight treatments (plastic film mulch) and four replications."
+
+### M1-S4: Describing the Setting
+
+Presents key features of the research environment, such as place, temperature, time, lighting, or other contextual conditions.
+
+Example: "The pens were in a conventional open-sided house with cyclic temperatures (minimum, 24 C; maximum, 32 C)."
+
+### M1-S5: Introducing the Subjects/Participants
+
+Describes the human, animate, or inanimate subjects involved in the study, including number, origin, composition, construction, recruitment, or selection.
+
+Example: "This study included 20 healthy infants with at least one first-degree relative suffering from CD."
+
+### M1-S6: Rationalizing Pre-Experiment Decisions
+
+Justifies methodological choices made before the experiment or study, such as the choice of approach, subjects, setting, or tools.
+
+Example: "Together these criteria ensure a suitable sample size that balances between the data collection effort and sufficient statistical power for the subsequent regression analysis."
+
+## Move 2: Describing the Study
+
+**Summary:** Details what was done before data analysis, including procedures, conditions, treatments, controls, data, tools, and in-process decisions. It mainly supports clarity and potential replication.
+
+### M2-S1: Acquiring the Data
+
+Explains how primary or secondary data were collected, sampled, selected, or drawn.
+
+Example: "Perirenal fat and liver samples from pigs (n = 10) representative of each typology were drawn and pooled on an equal gravimetric basis for the assessment of chemicals of interest."
+
+### M2-S2: Describing the Data
+
+Presents characteristics of the data, such as data type, size, source, units, scales, or qualities.
+
+Example: "All data were comprised in the MODELKEY database which covered a total of more than 5 million physico-chemical data entries."
+
+### M2-S3: Describing Experimental/Study Procedures
+
+Explains how the experimental or study steps were carried out, often in sequence.
+
+Example: "Clones were identified and plasmid DNA was prepared (Clontech) for each of the mutants."
+
+### M2-S4: Describing Tools
+
+Describes the instruments, materials, software, statistical packages, recording devices, or measurement equipment used in the study.
+
+Example: "It was examined under a fluorescence microscope (OLYMPUS BX41) equipped with a 50W high-pressure Hg lamp and a calcein filter."
+
+### M2-S5: Identifying Variables
+
+Specifies treatments, dependent variables, independent variables, experimental conditions, or compared aspects.
+
+Example: "The variables include CAPE, PW, 850-hPa wind direction, and KI, along with its individual components: 850-hPa Td, 700-hPa dewpoint depression, and the 850-500-hPa lapse rate (g)."
+
+### M2-S6: Rationalizing Experiment Decisions
+
+Justifies decisions made during the study procedure, especially choices related to data, tools, or procedures.
+
+Example: "The R-band isophote was chosen so that the region inside it contained the same area as the aperture of the r-band halflight radius (PetroR50) of SDSS because the bright galaxies in our R-band image had saturated pixels and we were not able to measure the radius in our data directly."
+
+### M2-S7: Reporting Incrementals
+
+Reports minor calculations, observations, or preliminary measurements relevant to the procedure but not central enough for the Results section.
+
+Example: "Analyses of purified populations showed that the purified BM cells were 80% CD11b+F4/80+, whereas the intestinal cells were 80% CD11b+ and contained both F4/80+ and CD11c+ cells."
+
+## Move 3: Establishing Credibility
+
+**Summary:** Persuades readers that the analysis is trustworthy and that the study procedure can lead to valid and credible findings.
+
+### M3-S1: Preparing the Data
+
+Explains how data were handled before analysis, including selection, screening, cleaning, inclusion/exclusion, correction, transformation, coding, tabulation, or estimation.
+
+Example: "All 30 interactomes were converted into binary interaction networks by setting a threshold of 5 standard deviations above the mean edge probability, retaining around 1% of all edges."
+
+### M3-S2: Describing the Data Analysis
+
+Specifies how the data were analyzed, either briefly or in detail, often including statistical techniques or coding schemes.
+
+Example: "The standard deviation (SD) was estimated using the equation SD = B[(A/4B)^4 + (A/B)^3 + (A/2B)^2]."
+
+### M3-S3: Rationalizing Data Processing/Analysis
+
+Justifies data processing or analysis choices by explaining credibility, validity, or limitations.
+
+Example: "We adjust standard errors to allow for clustering of error terms by birth country."
+
+## Annotation Guidance
+
+Prefer functional meaning over keywords. For example, a sentence naming "SPSS" is M2-S4 only if it describes a tool, and may also be M3-S2 if it explains the analysis procedure.
+
+Use M1-S6, M2-S6, and M3-S3 only when the text gives a reason, criterion, credibility claim, or fit between method choice and research purpose. Merely naming a choice is not rationalizing it.
+
+When a unit is ambiguous, assign a primary label with Medium or Low confidence and explain the ambiguity briefly.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/failure-strategies.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/failure-strategies.md
@@ -1,0 +1,72 @@
+# Failure Strategies
+
+Use these rules when the input does not cleanly fit the Methods diagnostic workflow.
+
+## No Clear Methods Section
+
+If the text is not a Methods section:
+
+- state that the skill cannot fully apply;
+- identify any method-related content that is present;
+- ask for the Methods section or methodology paragraph if a full diagnosis is needed.
+
+If the heading is missing but the passage clearly describes research design, data, procedure, tools, variables, or analysis, continue and state that the diagnosis is based on an inferred Methods passage.
+
+## Full Paper Provided
+
+If the user provides a full paper:
+
+- extract the Methods-related section if it is clearly marked;
+- stop and ask for the Methods section if the section cannot be found;
+- do not diagnose Introduction, Results, or Discussion with this skill.
+
+## Missing Discipline
+
+If the discipline is missing:
+
+- infer cautiously from the text if possible;
+- use the general empirical-research profile when uncertain;
+- state that discipline-specific judgments are provisional;
+- avoid over-specific expectations.
+
+## Missing Research Type
+
+If the research type is missing:
+
+- infer it from the Methods section;
+- if inference is uncertain, mark it as unclear;
+- use only broadly applicable required steps.
+
+## Insufficient Text
+
+If the submitted text is too short:
+
+- diagnose only what is visible;
+- do not assume missing information exists elsewhere;
+- ask for the full Methods section if the user wants a complete diagnosis.
+
+## Ambiguous Step Label
+
+If a segment could belong to multiple steps:
+
+- assign the strongest primary label;
+- add secondary labels when appropriate;
+- mark confidence as Medium or Low;
+- explain the ambiguity briefly.
+
+## User Requests Rewriting Only
+
+If the user asks only for rewriting:
+
+- first provide a brief diagnosis of major rhetorical problems;
+- rewrite only if the user explicitly requested revision;
+- preserve the student's intended method;
+- do not invent data, tools, participants, procedures, or analysis methods.
+
+## Non-Methods Section
+
+If the text appears to be Introduction, Literature Review, Results, Discussion, or Conclusion:
+
+- do not force DRaC labels onto it;
+- state which section it appears to be;
+- recommend using the corresponding section-specific skill if available.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/output-templates.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/output-templates.md
@@ -1,106 +1,40 @@
 # Output Templates
 
-Use these templates to format diagnostic output. Adapt length to the user's request.
+Use this template to keep Methods diagnoses focused on revision advice only.
 
-## Full Diagnostic Report
+The diagnosis workflow may produce internal move-step annotations, required-step coverage, unjustified-decision checks, and method-logic checks. Do not include those internal diagnostic sections in the final response unless the user explicitly asks for them.
 
-```markdown
-## 1. Overall Diagnosis
+## Final Output
 
-[Brief paragraph identifying research type, discipline if known, main strengths, and main credibility problems.]
+Output only the content that would normally appear under `Revision Priorities`. Do not include a diagnostic report title, section number, overall diagnosis, move-step annotation, required-step coverage, unjustified-methodological-decision table, method-logic table, or closing note.
 
-## 2. Move-Step Annotation
-
-| ID | Text span | Primary label | Secondary label(s) | Confidence | Reason |
-|---|---|---|---|---|---|
-| S1 | ... | M1-S3 | ... | High | ... |
-
-## 3. Required Step Coverage
-
-| Step | Status | Evidence | Problem | Why it matters |
-|---|---|---|---|---|
-| M1-S3 | Present/Weak/Missing/Not Applicable/Unclear | ... | ... | ... |
-
-## 4. Unjustified Methodological Decisions
-
-| Sentence | Decision type | Why justification is needed | Missing rationale | Suggested direction |
-|---|---|---|---|---|
-| ... | ... | ... | ... | ... |
-
-## 5. Method Logic Issues
-
-| Issue type | Evidence | Problem | Affected step(s) | Revision direction |
-|---|---|---|---|---|
-| ... | ... | ... | ... | ... |
-
-## 6. Revision Priorities
-
-### 必须补充
-
-| 原文句子 | 问题 | 具体改进方向 |
-|---|---|---|
-| ... | ... | ... |
-
-### 建议补充
-
-| 原文句子 | 问题 | 具体改进方向 |
-|---|---|---|
-| ... | ... | ... |
-```
-
-## Short Classroom Feedback
+Use this exact structure:
 
 ```markdown
-## Diagnosis
+### 必须修改
 
-[2-4 sentences on what the Methods section already does and what weakens rigour or credibility.]
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English]
+   - 具体改进方向: [specific revision direction in English]
 
-## Most Important Gaps
+### 建议修改
 
-### 必须补充
-
-| 原文句子 | 问题 | 具体改进方向 |
-|---|---|---|
-| ... | ... | ... |
-
-### 建议补充
-
-| 原文句子 | 问题 | 具体改进方向 |
-|---|---|---|
-| ... | ... | ... |
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English]
+   - 具体改进方向: [specific revision direction in English]
 ```
 
-## Sentence-Level Comment Template
+If one block has no items, keep the heading and write `No items.` under it.
 
-Use when the user wants feedback attached to specific sentences.
+## Item Rules
 
-```markdown
-| Sentence | DRaC label | Problem | Teaching feedback |
-|---|---|---|---|
-| ... | M2-S4 / M3-S2 | ... | ... |
-```
-
-## Coverage-Only Template
-
-Use when the user asks only which moves or steps are present/missing.
-
-```markdown
-| Step | Status | Evidence | Note |
-|---|---|---|---|
-| M1-S3 | ... | ... | ... |
-```
-
-## Revision Priority Rules
-
-End with two blocks in this order: 必须补充, then 建议补充.
-
-Use `原文句子 | 问题 | 具体改进方向` in both blocks. The 原文句子 column must quote the corresponding English sentence or clause from the student text.
-
-- Put Missing items and Weak items that affect rigour, credibility, reproducibility, validity, or method-chain logic in 必须补充.
-- Before listing a 必须补充 item, re-check the original sentence to confirm the information is truly absent or too weak to support the method chain.
-- Put Weak items that mainly improve transparency, completeness, or reader trust in 建议补充.
-- Treat details as 不必补充 when they are unrelated to the study design or already sufficiently covered; do not output a separate 不必补充 table.
-- Keep the feedback evidence-based and do not invent details that are not supported by the student's study.
-
-Do not write priorities that require inventing information not present in the student's study.
-
+- Put missing items and weak items that affect rigour, credibility, reproducibility, validity, or method-chain logic under `必须修改`.
+- Before listing a `必须修改` item, re-check the original sentence to confirm the information is truly absent or too weak to support the method chain.
+- Put weak items that mainly improve transparency, completeness, or reader trust under `建议修改`.
+- Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+- Start each item with `Issue N:` followed by a concise English issue summary.
+- Anchor each item in original wording.
+- Do not write priorities that require inventing information not present in the student's study.
+- Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/output-templates.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/output-templates.md
@@ -1,0 +1,106 @@
+# Output Templates
+
+Use these templates to format diagnostic output. Adapt length to the user's request.
+
+## Full Diagnostic Report
+
+```markdown
+## 1. Overall Diagnosis
+
+[Brief paragraph identifying research type, discipline if known, main strengths, and main credibility problems.]
+
+## 2. Move-Step Annotation
+
+| ID | Text span | Primary label | Secondary label(s) | Confidence | Reason |
+|---|---|---|---|---|---|
+| S1 | ... | M1-S3 | ... | High | ... |
+
+## 3. Required Step Coverage
+
+| Step | Status | Evidence | Problem | Why it matters |
+|---|---|---|---|---|
+| M1-S3 | Present/Weak/Missing/Not Applicable/Unclear | ... | ... | ... |
+
+## 4. Unjustified Methodological Decisions
+
+| Sentence | Decision type | Why justification is needed | Missing rationale | Suggested direction |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+## 5. Method Logic Issues
+
+| Issue type | Evidence | Problem | Affected step(s) | Revision direction |
+|---|---|---|---|---|
+| ... | ... | ... | ... | ... |
+
+## 6. Revision Priorities
+
+### 必须补充
+
+| 原文句子 | 问题 | 具体改进方向 |
+|---|---|---|
+| ... | ... | ... |
+
+### 建议补充
+
+| 原文句子 | 问题 | 具体改进方向 |
+|---|---|---|
+| ... | ... | ... |
+```
+
+## Short Classroom Feedback
+
+```markdown
+## Diagnosis
+
+[2-4 sentences on what the Methods section already does and what weakens rigour or credibility.]
+
+## Most Important Gaps
+
+### 必须补充
+
+| 原文句子 | 问题 | 具体改进方向 |
+|---|---|---|
+| ... | ... | ... |
+
+### 建议补充
+
+| 原文句子 | 问题 | 具体改进方向 |
+|---|---|---|
+| ... | ... | ... |
+```
+
+## Sentence-Level Comment Template
+
+Use when the user wants feedback attached to specific sentences.
+
+```markdown
+| Sentence | DRaC label | Problem | Teaching feedback |
+|---|---|---|---|
+| ... | M2-S4 / M3-S2 | ... | ... |
+```
+
+## Coverage-Only Template
+
+Use when the user asks only which moves or steps are present/missing.
+
+```markdown
+| Step | Status | Evidence | Note |
+|---|---|---|---|
+| M1-S3 | ... | ... | ... |
+```
+
+## Revision Priority Rules
+
+End with two blocks in this order: 必须补充, then 建议补充.
+
+Use `原文句子 | 问题 | 具体改进方向` in both blocks. The 原文句子 column must quote the corresponding English sentence or clause from the student text.
+
+- Put Missing items and Weak items that affect rigour, credibility, reproducibility, validity, or method-chain logic in 必须补充.
+- Before listing a 必须补充 item, re-check the original sentence to confirm the information is truly absent or too weak to support the method chain.
+- Put Weak items that mainly improve transparency, completeness, or reader trust in 建议补充.
+- Treat details as 不必补充 when they are unrelated to the study design or already sufficiently covered; do not output a separate 不必补充 table.
+- Keep the feedback evidence-based and do not invent details that are not supported by the student's study.
+
+Do not write priorities that require inventing information not present in the student's study.
+

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/source-notes.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/source-notes.md
@@ -1,0 +1,50 @@
+# Source Notes
+
+Use this file when explaining the theoretical basis of the skill or revising its source grounding. It is not necessary for every diagnosis.
+
+## Core Theoretical Basis
+
+This skill is grounded in Cotos, Huffman, and Link's DRaC model: Demonstrating Rigour and Credibility.
+
+The model analyzes Methods sections as rhetorical discourse rather than as a simple list of research procedures. It organizes Methods discourse into:
+
+- Move 1: Contextualizing Study Methods
+- Move 2: Describing the Study
+- Move 3: Establishing Credibility
+
+The background source states that the DRaC model was developed from a corpus of 900 research article Methods sections across 30 disciplines and identifies 3 moves and 16 steps.
+
+## Pedagogical Positioning
+
+The skill is designed for academic English writing instruction. Its purpose is to help students see what their Methods section does rhetorically:
+
+- whether it presents research design, data, tools, variables, procedures, preparation, and analysis clearly;
+- whether key method choices are justified;
+- whether the method chain supports the research question and credible findings.
+
+The skill should not function as:
+
+- a grammar checker;
+- a style polisher;
+- an automatic Methods-section writer;
+- a universal checklist that treats all 16 steps as mandatory.
+
+## Discipline Sensitivity
+
+Methods sections differ across disciplines and research designs.
+
+Social sciences, education, applied linguistics, and business often require stronger attention to participants, sampling rationale, instruments, coding, validity, reliability, and analysis rationale.
+
+Natural sciences and engineering often require stronger attention to materials, conditions, instruments, variables, controls, procedures, and reproducibility.
+
+Computational and data science studies often require stronger attention to datasets, splits, preprocessing, models, baselines, metrics, environments, and evaluation validity.
+
+## Local Source Files
+
+The original local source materials have been distilled into this skill's `references/workflow.md`, `references/draC-move-step-definitions.md`, `references/discipline-required-profiles.md`, and `references/diagnostic-rubric.md`. They included:
+
+- Cotos, Huffman, and Link's DRaC source article on Methods sections;
+- local WisePen notes on the purpose and background of Methods diagnosis;
+- the local DRaC move-step definition notes now represented by `references/draC-move-step-definitions.md`.
+
+Use `references/draC-move-step-definitions.md` as the local source for the current DRaC step definitions and examples. Use the DRaC paper when citations or source validation are needed.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/workflow.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/workflow.md
@@ -1,0 +1,169 @@
+# Method Discourse Diagnostic Workflow
+
+This workflow diagnoses a submitted Methods section through the DRaC move-step model. It should produce teaching-oriented feedback, not grammar correction or full rewriting.
+
+## 0. Input Gate
+
+Confirm that the submitted text is a Methods section or a clearly identified methodology paragraph.
+
+Stop the workflow when:
+
+- the text is not from a Methods section;
+- the text has no explicit or inferable method content;
+- the user asks to diagnose a full paper but does not provide the Methods section.
+
+If the Methods heading is absent but the passage clearly describes research design, data, procedure, tools, variables, or analysis, continue and state that the diagnosis is based on an inferred Methods passage.
+
+## 1. Identify Discipline and Research Type
+
+Infer or read from user metadata:
+
+- discipline or broad field;
+- research type;
+- data type;
+- method family;
+- whether the study is empirical, experimental, qualitative, quantitative, mixed-methods, computational, review-based, or unclear.
+
+Use this classification only to select teaching-required steps. Do not force all 16 DRaC steps onto every text.
+
+## 2. Extract and Segment the Method Text
+
+Extract only the Methods-related passage if the user provides surrounding content.
+
+Segment the passage into functional units:
+
+- usually sentence-level;
+- split a sentence into clauses when different clauses perform different rhetorical functions;
+- keep a sentence intact when splitting would obscure the student's logic.
+
+Each unit must keep its original wording so feedback can point to exact evidence.
+
+## 3. Annotate Moves and Steps
+
+Assign one primary DRaC label to each functional unit and add secondary labels when a unit performs more than one function.
+
+Use the detailed definitions and examples in `references/draC-move-step-definitions.md`. Keep only short DRaC definitions in `SKILL.md`.
+
+For each unit record:
+
+- text span;
+- primary move-step label;
+- secondary label(s), if any;
+- confidence;
+- brief reason.
+
+Confidence scale:
+
+- High: the rhetorical function is explicit.
+- Medium: the function is likely but partly implicit.
+- Low: the function is ambiguous or underdeveloped.
+
+Feedback priority scale:
+
+- 必须补充: absence or weakness would affect the method chain, credibility, validity, reproducibility, or reader trust.
+- 建议补充: adding the detail would improve transparency, but the current text is not logically broken.
+- 不必补充: the detail is unrelated to the study design or the current wording is already sufficient. Do not list these items in the final priority tables.
+
+## 4. Build the Required-Step Profile
+
+Using the discipline and research type from Step 1, decide which steps are teaching-required for this text.
+
+Status labels must be:
+
+- Present: clearly realized.
+- Weak: mentioned but lacking necessary detail.
+- Missing: required but absent.
+- Not Applicable: does not fit the research design.
+- Unclear: insufficient evidence to decide.
+
+Avoid the word "optional" in the final diagnosis. Use "Not Applicable" when a step genuinely does not fit the design.
+
+## 5. Evaluate Required-Step Coverage
+
+Compare the annotated labels from Step 3 with the required profile from Step 4.
+
+For each teaching-required step, decide its status and provide:
+
+- evidence from the student's text;
+- the problem, if any;
+- why the issue matters for rigour, credibility, reproducibility, or reader trust.
+
+Mark Present only when the rhetorical function is achieved, not merely when a keyword appears.
+
+## 6. Detect Rationale Gaps
+
+From Missing and Weak steps, identify methodological choices that are stated but not justified.
+
+Look especially for choices involving:
+
+- participants, samples, sites, materials, or datasets;
+- tools, instruments, questionnaires, software, models, or corpora;
+- variables, categories, groups, thresholds, and inclusion/exclusion criteria;
+- cleaning, coding, transformation, normalization, or preprocessing;
+- statistical, qualitative, computational, or evaluation methods.
+
+For each gap, explain:
+
+- which sentence or unit contains the choice;
+- what choice needs justification;
+- why readers need the rationale;
+- what kind of rationale the student should add.
+
+Do not invent the missing rationale.
+
+## 7. Detect Method Logic Issues
+
+Check the method chain:
+
+Research aim/question -> research design -> data/participants/materials -> procedure/tools/variables -> data preparation -> data analysis -> credible findings.
+
+Find logic problems such as:
+
+- research question-method mismatch;
+- data-analysis mismatch;
+- participant-claim mismatch;
+- tool-construct mismatch;
+- variable-analysis mismatch;
+- procedure-result mismatch;
+- missing data preparation;
+- unjustified analysis choice;
+- sequence confusion;
+- claims that exceed what the method can support.
+
+Explain the issue through the affected sentence(s), affected DRaC step(s), and revision direction.
+
+## 8. Convert Diagnosis into Teaching Feedback
+
+Generate feedback in a teaching style:
+
+- begin from what the text already does;
+- identify missing, weak, or unclear rhetorical functions;
+- explain why each issue affects credibility or reproducibility;
+- before writing a feedback item, return to the original sentence or unit and confirm that the gap is real, the severity is correct, and the proposed fix still fits the study design;
+- separate the closing feedback into two blocks: 必须补充 and 建议补充;
+- tell the student what to add or clarify next;
+- avoid replacing diagnosis with polished rewritten prose.
+
+Preferred feedback pattern:
+
+Your Methods section already does X. However, it does not yet do Y. This matters because Z. To revise, add or clarify A, B, and C.
+
+## 9. Output Structure
+
+Return six sections:
+
+1. Overall Diagnosis
+2. Move-Step Annotation
+3. Required Step Coverage
+4. Unjustified Methodological Decisions
+5. Method Logic Issues
+6. Revision Priorities
+
+In section 6, output two blocks in this order:
+
+- 必须补充: Missing steps and Weak items that materially affect rigour, credibility, reproducibility, validity, or method-chain logic. Re-check the original sentence before listing the item; if the evidence is only a minor transparency issue, downgrade it to 建议补充.
+- 建议补充: Weak items and rationale gaps that would improve transparency, completeness, or reader trust but are not necessary to the method chain.
+- 不必补充: items that are unrelated to the study design or already sufficiently covered. Do not include this as a final table; use it only to avoid over-diagnosis.
+
+End with 3-5 prioritized revision actions across both blocks. Each item must be anchored in the original wording and should not invent content for the student.
+

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/workflow.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/diagnosing-method-discourse/1.0/references/workflow.md
@@ -60,8 +60,8 @@ Confidence scale:
 
 Feedback priority scale:
 
-- 必须补充: absence or weakness would affect the method chain, credibility, validity, reproducibility, or reader trust.
-- 建议补充: adding the detail would improve transparency, but the current text is not logically broken.
+- 必须修改: absence or weakness would affect the method chain, credibility, validity, reproducibility, or reader trust.
+- 建议修改: adding the detail would improve transparency, but the current text is not logically broken.
 - 不必补充: the detail is unrelated to the study design or the current wording is already sufficient. Do not list these items in the final priority tables.
 
 ## 4. Build the Required-Step Profile
@@ -140,7 +140,7 @@ Generate feedback in a teaching style:
 - identify missing, weak, or unclear rhetorical functions;
 - explain why each issue affects credibility or reproducibility;
 - before writing a feedback item, return to the original sentence or unit and confirm that the gap is real, the severity is correct, and the proposed fix still fits the study design;
-- separate the closing feedback into two blocks: 必须补充 and 建议补充;
+- separate the closing feedback into two blocks: 必须修改 and 建议修改;
 - tell the student what to add or clarify next;
 - avoid replacing diagnosis with polished rewritten prose.
 
@@ -150,20 +150,34 @@ Your Methods section already does X. However, it does not yet do Y. This matters
 
 ## 9. Output Structure
 
-Return six sections:
+Steps 1-8 are internal diagnostic work. They support the priority judgment, but they must not appear in the final response.
 
-1. Overall Diagnosis
-2. Move-Step Annotation
-3. Required Step Coverage
-4. Unjustified Methodological Decisions
-5. Method Logic Issues
-6. Revision Priorities
+Final output must contain only the concrete revision priorities.
 
-In section 6, output two blocks in this order:
+Do not output:
 
-- 必须补充: Missing steps and Weak items that materially affect rigour, credibility, reproducibility, validity, or method-chain logic. Re-check the original sentence before listing the item; if the evidence is only a minor transparency issue, downgrade it to 建议补充.
-- 建议补充: Weak items and rationale gaps that would improve transparency, completeness, or reader trust but are not necessary to the method chain.
-- 不必补充: items that are unrelated to the study design or already sufficiently covered. Do not include this as a final table; use it only to avoid over-diagnosis.
+- Overall Diagnosis;
+- Move-Step Annotation;
+- Required Step Coverage;
+- Unjustified Methodological Decisions;
+- Method Logic Issues;
+- `Revision Priorities` or any numbered section heading;
+- paragraph summaries, scores, introductions, closing notes, or follow-up questions.
 
-End with 3-5 prioritized revision actions across both blocks. Each item must be anchored in the original wording and should not invent content for the student.
+Output two blocks in this order:
+
+- 必须修改: Missing steps and Weak items that materially affect rigour, credibility, reproducibility, validity, or method-chain logic. Re-check the original sentence before listing the item; if the evidence is only a minor transparency issue, downgrade it to 建议修改.
+- 建议修改: Weak items and rationale gaps that would improve transparency, completeness, or reader trust but are not necessary to the method chain.
+- 不必补充: items that are unrelated to the study design or already sufficiently covered. Do not include this in the final response; use it only to avoid over-diagnosis.
+
+Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+
+Each item must follow this structure:
+
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original sentence or clause]
+   - 问题: [diagnosis in English]
+   - 具体改进方向: [specific revision direction in English]
+
+Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English. Each item must be anchored in the original wording and should not invent content for the student.
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: reviewing-reference-use
+description: Reviews student academic writing for citation style, reference-list consistency, and source relevance. Use when Codex needs to check references, bibliographies, works cited pages, in-text citations, discipline-appropriate citation style, missing or uncited references, malformed reference entries, or whether cited sources are relevant to a student's article.
+---
+
+# Reviewing Reference Use
+
+Use this skill to diagnose how a student article uses sources. Focus on citation style fit, internal consistency, in-text/reference-list matching, and whether the cited sources are relevant to the article's topic and argument.
+
+Produce diagnostic feedback and safe correction guidance, not a complete rewritten bibliography unless the user explicitly asks for one.
+
+## Required Workflow
+
+For a real review, first read `references/workflow.md` and follow its sequence:
+
+1. validate the input and extract citation data;
+2. identify the article's discipline, article type, and review scope;
+3. select the expected citation style from explicit requirements first, then discipline conventions;
+4. detect the actual in-text citation style and reference-list style;
+5. check style fit, consistency, and in-text/reference-list correspondence;
+6. suggest safe corrections without inventing missing bibliographic metadata;
+7. assess reference relevance from title, citation context, and, when needed and available, web-verified abstracts or introductions;
+8. produce the final reference review report.
+
+## Reference Files
+
+Load only the files needed for the current task:
+
+- `references/workflow.md`: read for every full reference review.
+- `references/citation-style-guide.md`: read when classifying citation style, judging discipline fit, or correcting format issues.
+- `references/relevance-rubric.md`: read when judging whether references match the student's topic, research question, or citation context.
+- `references/output-templates.md`: read when formatting a full report, short report, or correction-only answer.
+- `references/failure-strategies.md`: read when the input lacks a reference list, lacks in-text citations, is interdisciplinary, has mixed styles, or cannot be web-verified.
+- `references/source-notes.md`: read when the user asks about the basis of the citation rules or when a style-specific rule is uncertain.
+
+## Default Output
+
+Unless the user asks for a shorter answer, return seven sections:
+
+1. Discipline Identification
+2. Expected Citation Style
+3. Detected Citation Style
+4. Format Problems
+5. In-text Citation and Reference List Matching
+6. Reference Relevance Review
+7. Priority Revision Suggestions
+
+Use tables for issue lists. Split final priorities into must-fix and suggested-fix items when there are enough issues to justify the distinction.
+
+## Constraints
+
+Do not:
+
+- invent authors, titles, years, journal names, publishers, DOIs, URLs, page ranges, or abstracts;
+- treat a discipline inference as stronger than an assignment, course, journal, or instructor requirement;
+- force APA, MLA, or Chicago onto fields where numbered, legal, chemical, or biomedical styles are more plausible;
+- judge a reference as irrelevant from title alone when the title is ambiguous;
+- claim a source was checked online unless it was actually searched and the source used is named;
+- silently normalize a mixed style without explaining what was mixed.
+
+Do:
+
+- use the student's requested language unless the user asks otherwise;
+- preserve evidence from the student's text in every diagnosis;
+- distinguish expected style, actual style, and acceptable alternatives;
+- classify uncertain cases explicitly as uncertain;
+- prioritize consistency, traceability, and discipline appropriateness;
+- mark missing bibliographic details as needing manual verification unless they are verified from a reliable source;
+- when using web search, cite the consulted source and explain what was verified.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/SKILL.md
@@ -29,23 +29,29 @@ Load only the files needed for the current task:
 - `references/workflow.md`: read for every full reference review.
 - `references/citation-style-guide.md`: read when classifying citation style, judging discipline fit, or correcting format issues.
 - `references/relevance-rubric.md`: read when judging whether references match the student's topic, research question, or citation context.
-- `references/output-templates.md`: read when formatting a full report, short report, or correction-only answer.
+- `references/output-templates.md`: read when formatting the final revision-priority-only answer.
 - `references/failure-strategies.md`: read when the input lacks a reference list, lacks in-text citations, is interdisciplinary, has mixed styles, or cannot be web-verified.
 - `references/source-notes.md`: read when the user asks about the basis of the citation rules or when a style-specific rule is uncertain.
 
 ## Default Output
 
-Unless the user asks for a shorter answer, return seven sections:
+Unless the user explicitly asks for a different format, return only the final concrete revision priorities.
 
-1. Discipline Identification
-2. Expected Citation Style
-3. Detected Citation Style
-4. Format Problems
-5. In-text Citation and Reference List Matching
-6. Reference Relevance Review
-7. Priority Revision Suggestions
+Do not include discipline identification, expected citation style, detected citation style, format-problem tables, in-text/reference matching tables, reference relevance review, diagnostic summaries, or closing notes in the final response. Use the workflow internally, then output only two blocks in this order:
 
-Use tables for issue lists. Split final priorities into must-fix and suggested-fix items when there are enough issues to justify the distinction.
+- 必须修改
+- 建议修改
+
+Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+
+Each issue must follow this structure:
+
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original citation, reference entry, sentence, or text span]
+   - 问题: [diagnosis in English]
+   - 具体改进方向: [specific revision direction in English]
+
+Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.
 
 ## Constraints
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/SKILL.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/SKILL.md
@@ -11,27 +11,49 @@ Produce diagnostic feedback and safe correction guidance, not a complete rewritt
 
 ## Required Workflow
 
-For a real review, first read `references/workflow.md` and follow its sequence:
+For a real review, first call `load_skill_asset` on `references/workflow.md` and follow its sequence.
+
+For every workflow step below, you MUST call `load_skill_asset` for each listed file before completing that step. If the same file has already been loaded earlier in the current turn, reuse the already loaded content instead of calling `load_skill_asset` again.
 
 1. validate the input and extract citation data;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/failure-strategies.md`
 2. identify the article's discipline, article type, and review scope;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/citation-style-guide.md`
 3. select the expected citation style from explicit requirements first, then discipline conventions;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/citation-style-guide.md`
 4. detect the actual in-text citation style and reference-list style;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/citation-style-guide.md`
 5. check style fit, consistency, and in-text/reference-list correspondence;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/citation-style-guide.md`
+   - MUST load via `load_skill_asset`: `references/failure-strategies.md`
 6. suggest safe corrections without inventing missing bibliographic metadata;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/citation-style-guide.md`
 7. assess reference relevance from title, citation context, and, when needed and available, web-verified abstracts or introductions;
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/relevance-rubric.md`
 8. produce the final reference review report.
+   - MUST load via `load_skill_asset`: `references/workflow.md`
+   - MUST load via `load_skill_asset`: `references/output-templates.md`
 
 ## Reference Files
 
-Load only the files needed for the current task:
+For a real reference review, the following files are required by the workflow above and must be loaded through `load_skill_asset` when their workflow step is reached:
 
-- `references/workflow.md`: read for every full reference review.
-- `references/citation-style-guide.md`: read when classifying citation style, judging discipline fit, or correcting format issues.
-- `references/relevance-rubric.md`: read when judging whether references match the student's topic, research question, or citation context.
-- `references/output-templates.md`: read when formatting the final revision-priority-only answer.
-- `references/failure-strategies.md`: read when the input lacks a reference list, lacks in-text citations, is interdisciplinary, has mixed styles, or cannot be web-verified.
-- `references/source-notes.md`: read when the user asks about the basis of the citation rules or when a style-specific rule is uncertain.
+- `references/workflow.md`: required for every full reference review.
+- `references/failure-strategies.md`: required during input-gate, style-mismatch, missing-data, mixed-style, and web-verification failure handling.
+- `references/citation-style-guide.md`: required when classifying citation style, judging discipline fit, or correcting format issues.
+- `references/relevance-rubric.md`: required when judging whether references match the student's topic, research question, or citation context.
+- `references/output-templates.md`: required when formatting the final revision-priority-only answer.
+
+Conditional reference:
+
+- `references/source-notes.md`: MUST load via `load_skill_asset` when the user asks about the basis of the citation rules, citations, source basis, or when a style-specific rule is uncertain.
 
 ## Default Output
 

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/citation-style-guide.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/citation-style-guide.md
@@ -1,0 +1,36 @@
+# Citation Style Guide
+
+Use this guide for first-pass diagnosis. It is not a substitute for a target journal, course, assignment, or official style manual.
+
+## Selection priority
+
+1. Explicit user, assignment, course, instructor, template, or journal requirement.
+2. Discipline convention and article type.
+3. Actual style used in the paper, if the expected style is not specified.
+
+When no requirement is specified, do not require a single style if the discipline commonly permits variants. Judge whether the chosen style is plausible and consistently applied.
+
+## Common discipline and style signals
+
+| Style | Common disciplines | In-text signal | Reference-list signal | Review cautions |
+|---|---|---|---|---|
+| APA | Psychology, education, applied linguistics, communication, many social sciences | `(Smith, 2020)` or `Smith (2020)` | Author initials, year in parentheses, sentence-case article titles, DOI/URL when available; usually alphabetical | Check APA 7 expectations. Do not confuse with Harvard solely because both are author-date. |
+| MLA | Literature, literary studies, language studies, cultural studies, humanities | `(Smith 23)` or author in prose plus page | Works Cited entries built from core elements; article titles often in quotation marks; usually alphabetical | Page/location markers are central when available. Dates are not the normal in-text key. |
+| Chicago Notes-Bibliography | History, art history, architecture, design history, many humanities fields | Superscript note numbers with footnotes/endnotes | Bibliography entries; notes may contain full or shortened source details | Chicago 18 no longer requires publication place for books unless needed for clarity. |
+| Chicago Author-Date | Sciences, social sciences, interdisciplinary humanities using Chicago | `(Smith 2020, 23)` | Author. Year. Title. Source details; usually alphabetical | Similar to Harvard but punctuation, date placement, and bibliography details differ. |
+| IEEE | Engineering, electronics, telecommunications, computing, information technology | Numbered citations in square brackets, such as `[1]` | Numbered references in order of first appearance; author initials before surname; article titles in quotation marks | Do not alphabetize IEEE references. Reuse the same number for repeated citations. |
+| ACM | Computer science, HCI, software engineering, computing conferences | Usually numbered `[1]`; some ACM templates use author-year forms such as `Author [1999]` | ACM reference format often includes full names, year after authors, venue, pages, DOI | Do not treat ordinary APA-like `(Smith, 2020)` as ACM by default. Identify the selected ACM template. |
+| Vancouver | Medicine, nursing, public health, biomedical sciences | Numbered citations, commonly parentheses, brackets, or superscripts depending on journal | Numbered references in citation order; compact medical journal format; abbreviated journal titles common | ICMJE/Vancouver is journal-sensitive. Do not assume one bracket style without a target requirement. |
+| AMA | Medicine, health sciences, pharmacy, clinical research | Superscript Arabic numerals | Numbered references in citation order; compact journal format; DOI often included | Similar to Vancouver but has AMA-specific punctuation and superscript placement rules. |
+| Harvard | Business, management, economics, environmental studies, some social sciences | `(Smith, 2020)` or `Smith (2020)` | Author-date reference list; details vary by institution | There is no single definitive Harvard manual. Consistency and enough source information matter most. |
+| ACS | Chemistry, chemical engineering, materials chemistry | Superscript numbers, italic numbers in parentheses, or author-date depending on journal/course | ACS journal style: author, title, abbreviated journal, year, volume, pages/DOI | First identify which ACS in-text system is being used. Do not require one ACS variant universally. |
+| CSE | Biology, ecology, environmental science, life sciences | Citation-sequence or citation-name numbers; or name-year `(Smith 2020)` | Three systems: citation-sequence, citation-name, and name-year; end-reference order depends on system | Identify the CSE system before judging ordering or date placement. |
+| Bluebook / legal citation | Law and legal studies | Footnotes with cases, statutes, regulations, and legal abbreviations | Jurisdiction-specific legal citations rather than ordinary academic reference entries | Do not force legal writing into APA/MLA/Chicago. Legal citation needs jurisdiction awareness. |
+
+## Common diagnosis rules
+
+- Mixed style is a real issue only when it affects the same citation layer. APA-style in-text citations with Harvard-like references should be reported as mixed; a Chicago Notes paper with both notes and bibliography is not mixed.
+- Reference-list title casing differs by style. APA usually uses sentence case for article titles; MLA and many Chicago examples use title-style capitalization.
+- Numbered styles usually require reference order to follow first citation order, but CSE citation-name is an exception because references are alphabetized before numbers are assigned.
+- If a student entry lacks metadata, diagnose the missing element but do not fabricate it.
+- If a style is plausible for the discipline but the teacher asked for another, mark it as style mismatch even if it is internally consistent.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/failure-strategies.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/failure-strategies.md
@@ -1,0 +1,51 @@
+# Failure Strategies
+
+Use these strategies when the input is incomplete, ambiguous, or outside normal citation-style review.
+
+## Missing article body
+
+- Review reference-list formatting only.
+- Do not assess reference relevance beyond title-level plausibility.
+- Ask for or mark missing article context if relevance is requested.
+
+## Missing reference list
+
+- Extract visible in-text citations.
+- Report that reference-list correspondence cannot be checked.
+- Suggest creating a reference list in the required or inferred style.
+
+## Missing in-text citations
+
+- Review reference-list formatting and discipline fit.
+- Report that citation/reference matching cannot be checked.
+- Mark all reference entries as `uncited in provided text` rather than assuming they are unused.
+
+## No explicit required style
+
+- Infer expected style from discipline.
+- Provide acceptable alternatives.
+- Prioritize internal consistency if the actual style is plausible for the discipline.
+
+## Mixed or unclear style
+
+- Identify which layer is mixed: in-text citations, notes, reference list, or ordering.
+- Give examples of each pattern.
+- Recommend converting the whole paper to the required style or to the most discipline-appropriate style.
+
+## Interdisciplinary article
+
+- Identify primary and secondary disciplines.
+- Do not reject a style just because it belongs to the secondary field.
+- Use the article's target course, journal, or assignment context if available.
+
+## Web verification unavailable or not useful
+
+- Do not claim abstract/introduction verification.
+- Use `uncertain` for relevance judgments that require source checking.
+- Provide a manual verification checklist: title, abstract, keywords, methods, and cited claim.
+
+## Legal sources
+
+- If the paper uses cases, statutes, regulations, or legal footnotes, treat it as legal citation.
+- Do not normalize legal citations into ordinary author-date or numbered academic references.
+- Ask for the required jurisdiction or legal citation guide when precise correction is needed.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/output-templates.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/output-templates.md
@@ -1,0 +1,88 @@
+# Output Templates
+
+Use the user's requested language. If no language is specified, match the user's prompt.
+
+## Full report
+
+```markdown
+# Reference Review Report
+
+## 1. Discipline Identification
+
+- Primary discipline:
+- Secondary discipline:
+- Article type:
+- Confidence:
+- Evidence:
+- Review scope and limitations:
+
+## 2. Expected Citation Style
+
+- Required style, if specified:
+- Recommended style:
+- Acceptable alternatives:
+- Reason:
+
+## 3. Detected Citation Style
+
+- In-text citation style:
+- Reference-list style:
+- Overall consistency:
+- Evidence:
+
+## 4. Format Problems
+
+| Location | Current form | Problem | Suggested correction |
+|---|---|---|---|
+
+## 5. In-text Citation and Reference List Matching
+
+| Citation / Reference | Issue | Suggested action |
+|---|---|---|
+
+## 6. Reference Relevance Review
+
+| Reference | Relevance level | Reason | Suggested action |
+|---|---|---|---|
+
+## 7. Priority Revision Suggestions
+
+### Must fix
+
+1. ...
+
+### Suggested fixes
+
+1. ...
+
+## Items Needing Manual Verification
+
+| Item | Why verification is needed |
+|---|---|
+```
+
+## Short report
+
+```markdown
+## Overall Judgment
+
+## Main Citation Style Issues
+
+## Main Reference-Content Issues
+
+## Priority Fixes
+```
+
+## Correction-only answer
+
+```markdown
+| Original | Problem | Safer corrected form | Verification needed |
+|---|---|---|---|
+```
+
+## Tone
+
+- Write as teaching-oriented diagnostic feedback.
+- Be concrete and evidence-based.
+- Avoid overstating certainty when the source metadata or relevance evidence is incomplete.
+- Explain why each issue matters for academic writing, source traceability, or disciplinary expectation.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/output-templates.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/output-templates.md
@@ -1,88 +1,40 @@
 # Output Templates
 
-Use the user's requested language. If no language is specified, match the user's prompt.
+Use this template to keep reference-use reviews focused on concrete revision advice only.
 
-## Full report
+The review workflow may produce internal citation-style identification, format checks, in-text/reference matching checks, relevance judgments, and verification notes. Do not include those internal diagnostic sections in the final response unless the user explicitly asks for them.
 
-```markdown
-# Reference Review Report
+## Final Output
 
-## 1. Discipline Identification
+Output only the content that would normally appear under priority revision suggestions. Do not include a report title, section number, discipline identification, expected style, detected style, format-problem table, matching table, relevance-review table, manual-verification table, diagnostic summary, or closing note.
 
-- Primary discipline:
-- Secondary discipline:
-- Article type:
-- Confidence:
-- Evidence:
-- Review scope and limitations:
-
-## 2. Expected Citation Style
-
-- Required style, if specified:
-- Recommended style:
-- Acceptable alternatives:
-- Reason:
-
-## 3. Detected Citation Style
-
-- In-text citation style:
-- Reference-list style:
-- Overall consistency:
-- Evidence:
-
-## 4. Format Problems
-
-| Location | Current form | Problem | Suggested correction |
-|---|---|---|---|
-
-## 5. In-text Citation and Reference List Matching
-
-| Citation / Reference | Issue | Suggested action |
-|---|---|---|
-
-## 6. Reference Relevance Review
-
-| Reference | Relevance level | Reason | Suggested action |
-|---|---|---|---|
-
-## 7. Priority Revision Suggestions
-
-### Must fix
-
-1. ...
-
-### Suggested fixes
-
-1. ...
-
-## Items Needing Manual Verification
-
-| Item | Why verification is needed |
-|---|---|
-```
-
-## Short report
+Use this exact structure:
 
 ```markdown
-## Overall Judgment
+### 必须修改
 
-## Main Citation Style Issues
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original citation, reference entry, sentence, or text span]
+   - 问题: [diagnosis in English]
+   - 具体改进方向: [specific revision direction in English]
 
-## Main Reference-Content Issues
+### 建议修改
 
-## Priority Fixes
+1. Issue 1: [concise issue summary in English]
+   - 原文句子: [original citation, reference entry, sentence, or text span]
+   - 问题: [diagnosis in English]
+   - 具体改进方向: [specific revision direction in English]
 ```
 
-## Correction-only answer
+If one block has no items, keep the heading and write `No items.` under it.
 
-```markdown
-| Original | Problem | Safer corrected form | Verification needed |
-|---|---|---|---|
-```
+## Item Rules
 
-## Tone
-
-- Write as teaching-oriented diagnostic feedback.
-- Be concrete and evidence-based.
-- Avoid overstating certainty when the source metadata or relevance evidence is incomplete.
-- Explain why each issue matters for academic writing, source traceability, or disciplinary expectation.
+- Put issues that clearly break the required or expected citation style, traceability, in-text/reference correspondence, or source relevance under `必须修改`.
+- Put issues that improve consistency, completeness, style fit, or source integration but do not break traceability under `建议修改`.
+- Use ordered lists for issues and unordered bullet points for item details. Do not use Markdown tables.
+- Start each item with `Issue N:` followed by a concise English issue summary.
+- Use `原文句子` for the original citation, reference entry, sentence, or relevant text span.
+- Use `问题` for the diagnosis. Include missing metadata, style inconsistency, unmatched citation/reference, weak source relevance, or uncertainty as needed.
+- Use `具体改进方向` for the safe correction direction. Do not invent missing authors, titles, years, journal names, publishers, DOIs, URLs, page ranges, or abstracts.
+- Only the two block headings and fixed field labels may be Chinese. All issue summaries and explanatory content must be in English.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/relevance-rubric.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/relevance-rubric.md
@@ -1,0 +1,44 @@
+# Reference Relevance Rubric
+
+Use this rubric to judge whether each reference supports the student's article. Prefer conservative judgments when only the title is available.
+
+## Evidence hierarchy
+
+1. Citation context in the student's article.
+2. Reference title and source type.
+3. Abstract, introduction, keywords, or journal/conference scope from a reliable source.
+4. Full text, if the user provides it or it is clearly available.
+
+Do not use title alone to make a strong irrelevance claim when the title is broad or ambiguous.
+
+## Relevance levels
+
+| Level | Meaning | Typical action |
+|---|---|---|
+| Direct | The source directly studies the same topic, population, material, method, problem, or research question. | Keep and cite at the most relevant claim. |
+| Methodological | The source supports the method, model, instrument, dataset, or analytical procedure. | Keep if cited in the methods or method justification context. |
+| Theoretical | The source provides the theory, framework, concept, or construct used by the article. | Keep, but ensure the article explains the conceptual link. |
+| Background | The source gives general context, history, definitions, or field overview. | Keep if not overused and placed in background sections. |
+| Weak | The source is only loosely related or supports a broad claim without clear need. | Better integrate, replace with a closer source, or narrow the claim. |
+| Irrelevant | The source appears unrelated to the article's topic, claim, method, or field after checking available evidence. | Remove or replace, unless the student can justify the connection. |
+| Uncertain | Available evidence is insufficient, ambiguous, or the title/context conflicts. | Mark for manual verification or web-check abstract/introduction. |
+
+## Review procedure
+
+For each reference:
+
+1. Extract the source title and any visible metadata.
+2. Locate where it is cited in the article, if possible.
+3. Compare the cited claim with the source title and field.
+4. Assign a relevance level.
+5. For weak, irrelevant, or uncertain items, explain the reason and recommended action.
+6. If web search is used, name the source consulted and what was verified.
+
+## Red flags
+
+- A reference title belongs to a different discipline with no visible bridge to the article.
+- A source is cited for a method it does not appear to describe.
+- A general background source is used to support a specific empirical claim.
+- The article cites outdated or generic sources when the claim requires current empirical evidence.
+- A source appears only in the reference list and is never cited in the body.
+- Multiple references share the same broad keyword but not the same concept, population, or problem.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/source-notes.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/source-notes.md
@@ -1,0 +1,23 @@
+# Source Notes
+
+Use these notes to resolve uncertainty and to explain the basis of the skill. Citation rules change by edition, publisher, journal, and assignment. Prefer the user's required guide over this file.
+
+## Public guidance checked while designing this skill
+
+- APA: APA 7 is an author-date style commonly used in psychology and social sciences. Use official APA Style guidance when accessible; Purdue OWL's APA 7 pages are a useful secondary teaching guide. Sources: https://apastyle.apa.org/ and https://owl.purdue.edu/owl/research_and_citation/apa_style/
+- MLA: MLA uses brief in-text citations keyed to Works Cited entries, with page/location markers when relevant. Source: https://style.mla.org/in-text-citations-overview/ and https://style.mla.org/works-cited/citations-by-format/
+- Chicago: Chicago has Notes-Bibliography and Author-Date systems. Students should follow instructor/publisher requirements. Chicago 18 no longer requires publication place for books unless needed for clarity. Sources: https://www.chicagomanualofstyle.org/tools_citationguide.html and https://owl.purdue.edu/owl/research_and_citation/chicago_manual_18th_edition/
+- IEEE: IEEE is a numbered style commonly used in engineering and computing; references are numbered in first-citation order. Source: https://journals.ieeeauthorcenter.ieee.org/create-your-ieee-journal-article/create-the-text-of-your-article/ieee-editorial-style-manual/
+- ACM: ACM publications usually use numbered citations, while some templates use author-year variants. ACM prefers its own reference formatting. Source: https://www.acm.org/publications/authors/reference-formatting
+- Vancouver/ICMJE: Biomedical journals often use numbered references based on ICMJE/Vancouver conventions, but journal implementations vary. Source: https://www.icmje.org/recommendations/ and https://www.nlm.nih.gov/bsd/uniform_requirements.html
+- AMA: AMA is common in medicine and health sciences and is similar to Vancouver in compact numbered medical-journal formatting, but has AMA-specific superscript and punctuation rules. Use the AMA Manual of Style or the target journal/course guide for final micro-format decisions. Source: https://www.amamanualofstyle.com/
+- Harvard: Harvard is a generic author-date family rather than one definitive standard. Consistency and the required institutional variant matter. Source: https://www.anu.edu.au/students/academic-skills/academic-integrity/referencing/harvard
+- ACS: ACS supports several in-text citation systems and detailed chemistry reference conventions; identify the course/journal variant before enforcing details. Source: https://pubs.acs.org/doi/full/10.1021/acsguide.40303
+- CSE: CSE defines three systems: citation-sequence, name-year, and citation-name. The chosen system affects reference ordering. Source: https://www.csemanual.org/Tools/CSE-Citation-Quick-Guide.html
+- Bluebook/legal citation: legal citation is jurisdiction-sensitive and should not be forced into ordinary academic citation styles. Source: https://www.law.cornell.edu/wex/bluebook
+
+## Practical limits
+
+- This skill can identify likely style problems and relevance concerns, but final publication compliance may require the full official manual or a target journal guide.
+- When a student source lacks metadata, correction should stop at the visible information unless the missing data is verified.
+- When judging relevance, title-level evidence is a screening tool, not a substitute for checking the abstract, introduction, or full text.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/workflow.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/workflow.md
@@ -52,9 +52,9 @@ Follow this workflow for full reviews of student academic writing. If the user a
 - For weak, irrelevant, or uncertain sources, search for the abstract/introduction only when web access is available and the task warrants it.
 - Explain whether the source should be kept, replaced, removed, or better integrated.
 
-## 8. Produce the report
+## 8. Produce the final priorities
 
-- Use `output-templates.md` for the report shape.
+- Use `output-templates.md` for the final response shape.
 - Put high-impact issues first.
 - Separate formatting problems from relevance problems.
-- End with concrete revision priorities.
+- Use the style, matching, and relevance checks internally, but output only concrete revision priorities.

--- a/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/workflow.md
+++ b/services/wisepen-chat-service/dev_fixtures/skill_bundles/reviewing-reference-use/1.0/references/workflow.md
@@ -1,0 +1,60 @@
+# Reference Review Workflow
+
+Follow this workflow for full reviews of student academic writing. If the user asks for a narrower task, apply only the relevant steps and state the narrowed scope.
+
+## 1. Validate input and extract citation data
+
+- Identify whether the input includes the article body, title/abstract/introduction, in-text citations, and a reference list.
+- Extract in-text citations, footnotes/endnotes, and reference-list entries separately.
+- Preserve useful location evidence such as section names, paragraph labels, or page numbers when available.
+- If the article is provided as a document file, extract text first and keep citation/reference boundaries visible.
+
+## 2. Identify discipline and article type
+
+- Use the title, abstract, introduction, keywords, methods, and main argument to infer the primary discipline.
+- If interdisciplinary, identify primary and secondary fields rather than forcing one label.
+- Output discipline, article type, evidence, and confidence.
+
+## 3. Select expected citation style
+
+- First check whether an assignment, course, journal, instructor, template, or user instruction specifies a required style.
+- If specified, use that style as the standard even if another style is common in the discipline.
+- If not specified, infer common styles from the discipline using `citation-style-guide.md`.
+- List the most likely expected style and acceptable alternatives.
+
+## 4. Detect actual citation style
+
+- Analyze in-text citations and the reference list separately.
+- Classify each as APA, MLA, Chicago Notes-Bibliography, Chicago Author-Date, IEEE, ACM, Vancouver, AMA, Harvard, ACS, CSE, Bluebook/legal, mixed, or unclear.
+- Record evidence such as author-date citations, page-number citations, numbered brackets, footnotes, superscripts, entry ordering, title casing, date position, and punctuation patterns.
+
+## 5. Check consistency and correspondence
+
+- Check whether actual style matches the expected or acceptable style.
+- Check whether all in-text citations use one style.
+- Check whether all reference entries use one style.
+- Check whether every in-text citation has a matching reference entry.
+- Check whether every reference entry is cited in the article.
+- Check ordering rules: alphabetical for most author-date/name styles, first-appearance order for many numbered styles, or style-specific ordering when evident.
+
+## 6. Suggest safe corrections
+
+- For each issue, provide the original form, problem, and suggested correction.
+- Correct only visible information.
+- Do not invent missing metadata. Use `needs manual verification` for missing details unless a reliable external source has been checked.
+- If style requirements are ambiguous, provide a correction direction rather than a fabricated final reference.
+
+## 7. Assess reference relevance
+
+- Summarize the article's central topic, research question, and key concepts.
+- Compare each reference title with the topic and, when possible, the citation context.
+- Use `relevance-rubric.md` to classify relevance.
+- For weak, irrelevant, or uncertain sources, search for the abstract/introduction only when web access is available and the task warrants it.
+- Explain whether the source should be kept, replaced, removed, or better integrated.
+
+## 8. Produce the report
+
+- Use `output-templates.md` for the report shape.
+- Put high-impact issues first.
+- Separate formatting problems from relevance problems.
+- End with concrete revision priorities.

--- a/services/wisepen-chat-service/src/chat/api/converters/ui_message_converter.py
+++ b/services/wisepen-chat-service/src/chat/api/converters/ui_message_converter.py
@@ -95,9 +95,10 @@ def _build_assistant_ui_message(group: List[ChatMessage]) -> Optional[Dict[str, 
 
             if msg.tool_calls:
                 for tc in msg.tool_calls:
-                    tool_name = tc.get("function", {}).get_published_skill("name")
+                    function = tc.get("function") or {}
+                    tool_name = function.get("name")
                     tool_call_id = tc.get("id", "")
-                    raw_args = tc.get("function", {}).get_published_skill("arguments")
+                    raw_args = function.get("arguments")
                     try:
                         parsed_input = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
                     except (json.JSONDecodeError, TypeError):

--- a/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
@@ -109,7 +109,7 @@ class ChatContextAssembler:
         2. Contextual Grounding: Base your answers ONLY on the `<retrieved_context>`. Do not introduce outside information or hallucinate facts. 
         3. Handling Unknowns: If the provided context does not contain the information needed to answer the question, clearly and politely state that you do not have enough information, rather than guessing.
         4. Tone: Maintain a professional, encouraging, and clear tone suitable for users of an advanced educational and productivity tool.
-        5. Formatting: Use Markdown (e.g., bullet points, bold text, code blocks) to structure your response for maximum readability.
+        5. Formatting: Use Markdown to structure your response for readability unless a loaded skill specifies a stricter output format. If a loaded skill specifies an Output Format or Constraints section, follow the loaded skill exactly.
         """ # 全局指令
 
         # 如果有从 Mem0 召回的相关事实，作为补充信息拼接到 System Prompt 中

--- a/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
@@ -1,10 +1,17 @@
+import re
 from typing import Any, Dict, List, Optional, Tuple
 from common.logger import log_fail, log_error
 
 from chat.core.config.app_settings import settings
+from chat.application.skill_prompt_builder import SkillPromptBuilder
 from chat.domain.entities import ChatMessage, Role, ChatSession
 from chat.domain.entities.skill import SkillMeta
-from chat.domain.repositories import MessageRepository, HotContextRepository, SessionRepository
+from chat.domain.repositories import MessageRepository, HotContextRepository, SessionRepository, SkillRepository
+
+
+_SKILL_LOADED_ACK_RE = re.compile(
+    r"^\[Skill loaded:\s*(?P<skill_id>[^\s\]]+)\s+version=(?P<version>[^\]]+)\]$"
+)
 
 
 class ChatContextAssembler:
@@ -15,10 +22,12 @@ class ChatContextAssembler:
         message_repo: MessageRepository,
         session_repo: SessionRepository,
         hot_context_repo: HotContextRepository,
+        skill_repo: SkillRepository,
     ):
         self.message_repo = message_repo
         self.session_repo = session_repo
         self.hot_context_repo = hot_context_repo
+        self.skill_repo = skill_repo
 
     async def get_or_repopulate_hot_context(self, session_id: str) -> List[ChatMessage]:
         """
@@ -85,6 +94,75 @@ class ChatContextAssembler:
         needs_compression = total_token >= high_budget # 由于高水位线（如 80%）预留了安全 Buffer，即便把它们全发给模型，也不会触发 Token 溢出报错
 
         return messages_keep, messages_compress_candidates, needs_compression
+
+    @staticmethod
+    def _extract_restorable_skill(msg: ChatMessage) -> Optional[Tuple[str, Optional[str]]]:
+        if msg.role != Role.TOOL:
+            return None
+
+        metadata = msg.metadata or {}
+        if metadata.get("restore_ephemeral_in_context"):
+            skill_id = metadata.get("skill_id")
+            version = metadata.get("version")
+            if skill_id:
+                return str(skill_id), str(version) if version else None
+
+        # 兼容旧数据：历史记录可能没有 metadata，甚至 name 写错，但保留了 load_skill ack。
+        content = (msg.content or "").strip()
+        match = _SKILL_LOADED_ACK_RE.match(content)
+        if match:
+            return match.group("skill_id"), match.group("version")
+
+        return None
+
+    async def restore_ephemeral_context_injections(
+        self,
+        session_id: str,
+        windowed_messages: List[ChatMessage],
+    ) -> List[ChatMessage]:
+        """
+        持久化历史只保存 load_skill 的短 ack，不保存 SKILL.md 正文。
+        每次组装上下文时，遇到需要恢复的 TOOL ack，就在其后补回正式 load_skill 同款 USER 注入。
+        """
+        restored: List[ChatMessage] = []
+        for msg in windowed_messages:
+            restored.append(msg)
+            skill_ref = self._extract_restorable_skill(msg)
+            if not skill_ref:
+                continue
+
+            skill_id, expected_version = skill_ref
+            try:
+                skill = await self.skill_repo.get_published_skill(skill_id)
+            except Exception as e:
+                log_error("恢复 Skill 上下文", e, session=session_id, skill_id=skill_id)
+                continue
+            if skill is None:
+                log_fail("恢复 Skill 上下文", "skill 不存在", session=session_id, skill_id=skill_id)
+                continue
+            if expected_version and skill.version != expected_version:
+                log_fail(
+                    "恢复 Skill 上下文",
+                    "skill 版本与历史 ack 不一致，使用当前发布版本恢复",
+                    session=session_id,
+                    skill_id=skill_id,
+                    expected_version=expected_version,
+                    actual_version=skill.version,
+                )
+
+            restored.append(ChatMessage(
+                session_id=session_id,
+                role=Role.USER,
+                content=SkillPromptBuilder.build_loaded_skill_injection(skill),
+                metadata={
+                    "restored_from_tool_call_id": msg.tool_call_id,
+                    "restored_skill_id": skill.skill_id,
+                    "restored_skill_version": skill.version,
+                },
+                ephemeral=True,
+            ))
+
+        return restored
 
     def assemble_prompt(
         self,

--- a/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
@@ -6,6 +6,7 @@ from chat.core.config.app_settings import settings
 from chat.application.skill_prompt_builder import SkillPromptBuilder
 from chat.domain.entities import ChatMessage, Role, ChatSession
 from chat.domain.entities.skill import SkillMeta
+from chat.domain.message_lifecycle import MessageLifecycle, PersistenceMode
 from chat.domain.repositories import MessageRepository, HotContextRepository, SessionRepository, SkillRepository
 
 
@@ -100,10 +101,11 @@ class ChatContextAssembler:
         if msg.role != Role.TOOL:
             return None
 
-        metadata = msg.metadata or {}
-        if metadata.get("restore_ephemeral_in_context"):
-            skill_id = metadata.get("skill_id")
-            version = metadata.get("version")
+        restore_ref = (msg.metadata or {}).get("restore_ref") or {}
+        if restore_ref.get("kind") == "skill":
+            data = restore_ref.get("data") or {}
+            skill_id = data.get("skill_id")
+            version = data.get("version")
             if skill_id:
                 return str(skill_id), str(version) if version else None
 
@@ -115,7 +117,7 @@ class ChatContextAssembler:
 
         return None
 
-    async def restore_ephemeral_context_injections(
+    async def restore_context_injections(
         self,
         session_id: str,
         windowed_messages: List[ChatMessage],
@@ -159,7 +161,9 @@ class ChatContextAssembler:
                     "restored_skill_id": skill.skill_id,
                     "restored_skill_version": skill.version,
                 },
-                ephemeral=True,
+                lifecycle=MessageLifecycle(
+                    persistence_mode=PersistenceMode.DROP,
+                ),
             ))
 
         return restored
@@ -237,7 +241,9 @@ class ChatContextAssembler:
                 session_id=session_id,
                 role=Role.USER,
                 content=skill_block,
-                ephemeral=True,
+                lifecycle=MessageLifecycle(
+                    persistence_mode=PersistenceMode.DROP,
+                ),
             ))
 
         # 经过滑动窗口裁剪后的近期对话明细

--- a/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
@@ -109,8 +109,9 @@ class ChatContextAssembler:
         2. Contextual Grounding: Base your answers ONLY on the `<retrieved_context>`. Do not introduce outside information or hallucinate facts. 
         3. Handling Unknowns: If the provided context does not contain the information needed to answer the question, clearly and politely state that you do not have enough information, rather than guessing.
         4. Tone: Maintain a professional, encouraging, and clear tone suitable for users of an advanced educational and productivity tool.
-        5. Formatting: Use Markdown to structure your response for readability unless a loaded skill specifies a stricter output format. If a loaded skill specifies an Output Format or Constraints section, follow the loaded skill exactly.
-        6. System Reminders: Messages wrapped in `<system-reminder>` are WisePen-injected operational context, not the user's request. Use them to guide the current task, but do not answer or quote them directly.
+        5. Formatting: All text you output outside of tool use is displayed to the user. Output text to communicate with the user. You can use Github-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification. Use Markdown to structure your response for readability unless a loaded skill specifies a stricter output format. If a loaded skill specifies an Output Format or Constraints section, follow the loaded skill exactly.
+        6. Formula Formatting: If your output contains formulas, format them in LaTeX and wrap them with $$.
+        7. System Reminders: Messages wrapped in `<system-reminder>` are WisePen-injected operational context, not the user's request. Use them to guide the current task, but do not answer or quote them directly.
         """ # 全局指令
 
         # 如果有从 Mem0 召回的相关事实，作为补充信息拼接到 System Prompt 中

--- a/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
@@ -94,7 +94,7 @@ class ChatContextAssembler:
         relevant_facts: List[str],
         session_summary: Optional[str],
         states: Optional[List[Dict[str, Any]]] = None,
-        candidate_skills: Optional[List[SkillMeta]] = None,
+        available_skills: Optional[List[SkillMeta]] = None,
     ) -> List[ChatMessage]:
         """组装最终发往 LLM 的消息列表。"""
         system_prompt = """
@@ -110,6 +110,7 @@ class ChatContextAssembler:
         3. Handling Unknowns: If the provided context does not contain the information needed to answer the question, clearly and politely state that you do not have enough information, rather than guessing.
         4. Tone: Maintain a professional, encouraging, and clear tone suitable for users of an advanced educational and productivity tool.
         5. Formatting: Use Markdown to structure your response for readability unless a loaded skill specifies a stricter output format. If a loaded skill specifies an Output Format or Constraints section, follow the loaded skill exactly.
+        6. System Reminders: Messages wrapped in `<system-reminder>` are WisePen-injected operational context, not the user's request. Use them to guide the current task, but do not answer or quote them directly.
         """ # 全局指令
 
         # 如果有从 Mem0 召回的相关事实，作为补充信息拼接到 System Prompt 中
@@ -129,29 +130,35 @@ class ChatContextAssembler:
                 content=f"[Conversation Summary so far]:\n{session_summary}",
             ))
 
-        # Skill 候选清单：受控披露，只在 matcher 命中时注入；明确限制"仅在直接相关时加载"
+        # Skill 可用清单：只披露轻量 metadata，由 LLM 判断是否需要加载完整 SKILL.md。
         # 用 skill_id 作机器标识，description 给 LLM 做相关性判断
-        if candidate_skills:
+        if available_skills:
             skill_lines = [
-                f"- id=\"{s.skill_id}\": {s.description}" for s in candidate_skills
+                f"- id=\"{s.skill_id}\" name=\"{s.display_name}\": {s.description}" for s in available_skills
             ]
             skill_block = (
-                "[Available Skills]\n"
-                "The following skills MAY be relevant to the user's current request. "
-                "Each skill contains detailed domain instructions (SKILL.md) and possibly supporting assets.\n"
+                "<system-reminder>\n"
+                "[Available WisePen Skills]\n"
+                "The following skills are available in this conversation as lightweight metadata. "
+                "Each skill contains detailed domain instructions (SKILL.md) and possibly supporting assets, "
+                "but the full content is not loaded yet.\n"
                 "Strict rules:\n"
-                "1. Load a skill ONLY when it is DIRECTLY required to fulfill the current request. Do not load speculatively.\n"
-                "2. To load, call the tool `load_skill` with `skill_id` exactly as listed below.\n"
-                "3. After loading, follow the SKILL.md instructions precisely. "
+                "1. If the user explicitly asks to use one of the listed skills by id or name, call `load_skill` for that skill.\n"
+                "2. Otherwise, decide from the user's request whether any listed skill is directly useful. "
+                "Load a skill only when it is needed to fulfill the current request; do not load speculatively.\n"
+                "3. To load, call the tool `load_skill` with `skill_id` exactly as listed below.\n"
+                "4. After loading, follow the SKILL.md instructions precisely. "
                 "Use `load_skill_asset` to open a specific reference/template only if SKILL.md explicitly says to.\n"
-                "4. If none of the skills apply, simply ignore this list and answer normally.\n\n"
+                "5. If none of the skills apply, ignore this list and answer normally.\n\n"
                 "Skills:\n"
                 + "\n".join(skill_lines)
+                + "\n</system-reminder>"
             )
             messages.append(ChatMessage(
                 session_id=session_id,
-                role=Role.SYSTEM,
+                role=Role.USER,
                 content=skill_block,
+                ephemeral=True,
             ))
 
         # 经过滑动窗口裁剪后的近期对话明细

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -129,7 +129,7 @@ class ChatTurnCoordinator:
             if precomputed_summary is None:
                 candidate_window = compress_block + candidate_window
 
-            restored_window_messages = await self._context_assembler.restore_ephemeral_context_injections(
+            restored_window_messages = await self._context_assembler.restore_context_injections(
                 session_id,
                 candidate_window,
             )

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -24,7 +24,7 @@ from common.kafka.producer import KafkaProducerClient
 
 
 # Skill 脚手架工具的名字集合：Registry 内部它们 reserved=True 默认隐藏
-# 只有 skill 命中时 Coordinator 把本集合作为 `expose` 传入 derive()，从而解禁 schema
+# 只有存在可用 skill 时 Coordinator 把本集合作为 `expose` 传入 derive()，从而解禁 schema
 _SKILL_TOOL_NAMES = frozenset({"load_skill", "load_skill_asset"})
 
 
@@ -111,17 +111,17 @@ class ChatTurnCoordinator:
             "user_id": user_id,
         } 
 
-        # [Skill Match] 预筛当前 query 可能相关的 Skill，命中才暴露 schema + 注入 Available Skills
-        candidate_skills = self._skill_matcher.match(user_query)
-        print(candidate_skills)
+        # [Skill Discovery] 注入当前会话可用 Skill 的轻量 metadata，由 LLM 决定是否调用 load_skill。
+        # 不再用字符串 triggers 预筛，避免关键词未命中导致 Skill 无法被模型看见。
+        available_skills = self._skill_matcher.match(user_query)
         expose_tool_name_set = None
-        if candidate_skills:
+        if available_skills:
             # 解禁 Registry 里默认隐藏的 skill 脚手架工具（reserved=True）
             expose_tool_name_set = set(_SKILL_TOOL_NAMES)
-            tool_context["allowed_skill_ids"] = [s.skill_id for s in candidate_skills]
+            tool_context["allowed_skill_ids"] = [s.skill_id for s in available_skills]
 
         # [Tool Scope] 派生本请求的工具视图快照
-        # expose_tool_name_set 仅在 skill 命中时解禁 load_skill 系列，未命中时它们保持隐藏
+        # expose_tool_name_set 仅在存在可用 skill 时解禁 load_skill 系列，否则它们保持隐藏
         # runtime_discovered_tools 预留给"运行时动态发现的工具"（如 Skill bundle 自带 tools），暂时留空
         # allow_tool_name_set/deny_tool_name_set 预留给未来"用户级工具偏好"接入，暂时留空
         tool_scope = self._tool_registry.derive(
@@ -137,7 +137,7 @@ class ChatTurnCoordinator:
         messages_for_llm = self._context_assembler.assemble_prompt(
             session_id, user_query, messages_keep+messages_compress_candidates, relevant_facts, session_summary,
             states=states,
-            candidate_skills=candidate_skills or None,
+            available_skills=available_skills or None,
         )
 
         # 记录进入 Agent 循环前的列表长度

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -26,6 +26,7 @@ from common.kafka.producer import KafkaProducerClient
 # Skill 脚手架工具的名字集合：Registry 内部它们 reserved=True 默认隐藏
 # 只有存在可用 skill 时 Coordinator 把本集合作为 `expose` 传入 derive()，从而解禁 schema
 _SKILL_TOOL_NAMES = frozenset({"load_skill", "load_skill_asset"})
+_HISTORY_SEARCH_TOOL_NAMES = frozenset({"search_historical_messages"})
 
 
 class ChatTurnCoordinator:
@@ -114,14 +115,22 @@ class ChatTurnCoordinator:
         # [Skill Discovery] 注入当前会话可用 Skill 的轻量 metadata，由 LLM 决定是否调用 load_skill。
         # 不再用字符串 triggers 预筛，避免关键词未命中导致 Skill 无法被模型看见。
         available_skills = self._skill_matcher.match(user_query)
-        expose_tool_name_set = None
+        expose_tool_name_set = set()
         if available_skills:
             # 解禁 Registry 里默认隐藏的 skill 脚手架工具（reserved=True）
-            expose_tool_name_set = set(_SKILL_TOOL_NAMES)
+            expose_tool_name_set.update(_SKILL_TOOL_NAMES)
             tool_context["allowed_skill_ids"] = [s.skill_id for s in available_skills]
 
+        # 历史搜索工具默认隐藏。只有当前会话已经有摘要（说明早期明细发生过压缩）时，
+        # 才解禁给模型，避免短会话/未压缩会话里频繁冗余检索。
+        history_search_disabled = not bool(session_summary)
+        if not history_search_disabled:
+            expose_tool_name_set.update(_HISTORY_SEARCH_TOOL_NAMES)
+
+        expose_tool_name_set = expose_tool_name_set or None
+
         # [Tool Scope] 派生本请求的工具视图快照
-        # expose_tool_name_set 仅在存在可用 skill 时解禁 load_skill 系列，否则它们保持隐藏
+        # expose_tool_name_set 仅在满足系统条件时解禁 reserved 工具，否则它们保持隐藏
         # runtime_discovered_tools 预留给"运行时动态发现的工具"（如 Skill bundle 自带 tools），暂时留空
         # allow_tool_name_set/deny_tool_name_set 预留给未来"用户级工具偏好"接入，暂时留空
         tool_scope = self._tool_registry.derive(

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional, List, Dict, Any
 from beanie import PydanticObjectId
 from fastapi import BackgroundTasks
@@ -5,9 +7,10 @@ from common.logger import log_error, log_ok
 
 from chat.core.config.app_settings import settings
 from chat.domain.entities import ChatMessage, Role
+from chat.domain.error_codes import ChatErrorCode
 from chat.domain.interfaces.llm import LLMProvider
 from chat.domain.interfaces.memory import MemoryProvider
-from chat.domain.repositories import SessionRepository, MessageRepository, HotContextRepository, ModelRepository, ProviderRepository
+from chat.domain.repositories import SessionRepository, MessageRepository, HotContextRepository, ModelRepository, ProviderRepository, SkillRepository
 from common.core.exceptions import ServiceException
 from chat.application.chat_context_assembler import ChatContextAssembler
 from chat.application.query_loop_runtime import (
@@ -29,6 +32,14 @@ _SKILL_TOOL_NAMES = frozenset({"load_skill", "load_skill_asset"})
 _HISTORY_SEARCH_TOOL_NAMES = frozenset({"search_historical_messages"})
 
 
+@dataclass(frozen=True)
+class PromptAssemblyResult:
+    messages_for_llm: List[ChatMessage]
+    messages_keep_for_hot_context: List[ChatMessage]
+    precomputed_summary: Optional[str]
+    summary_updated_at: Optional[datetime]
+
+
 class ChatTurnCoordinator:
     """
     Chat协调器：负责编排聊天流程中的各个环节，包含上下文管理、LLM ReAct、记忆更新等。
@@ -47,13 +58,18 @@ class ChatTurnCoordinator:
             tool_registry: ToolRegistry,
             kafka_producer: KafkaProducerClient,
             skill_matcher: SkillMatcher,
+            skill_repo: SkillRepository,
     ):
         self._memory = memory
         self._model_repo = model_repo
         self._context_assembler = ChatContextAssembler(
-            message_repo=message_repo, session_repo=session_repo, hot_context_repo=hot_context_repo
+            message_repo=message_repo,
+            session_repo=session_repo,
+            hot_context_repo=hot_context_repo,
+            skill_repo=skill_repo,
         )
         self._tool_registry = tool_registry
+        self._llm = llm
         self._query_loop_runtime = QueryLoopRuntime(llm=llm)
         self._turn_finalizer = ChatTurnFinalizer(
             llm=llm, memory=memory,
@@ -62,6 +78,118 @@ class ChatTurnCoordinator:
             kafka_producer=kafka_producer
         )
         self._skill_matcher = skill_matcher
+
+    @staticmethod
+    def _group_history_messages(messages: List[ChatMessage]) -> List[List[ChatMessage]]:
+        groups: List[List[ChatMessage]] = []
+        current: List[ChatMessage] = []
+        for msg in sorted(messages, key=lambda m: m.created_at):
+            if msg.role == Role.USER and current:
+                groups.append(current)
+                current = [msg]
+            else:
+                current.append(msg)
+        if current:
+            groups.append(current)
+        return groups
+
+    async def _count_final_prompt_tokens(
+        self,
+        messages: List[ChatMessage],
+        tool_schemas: List[Dict[str, Any]],
+        model_name: str,
+    ) -> int:
+        text = QueryLoopRuntime._serialize_prompt_for_counting(messages, tool_schemas)
+        return await self._llm.count_tokens(text, model_name)
+
+    async def _assemble_prompt_with_final_budget(
+        self,
+        *,
+        session_id: str,
+        user_query: str,
+        messages_keep: List[ChatMessage],
+        messages_compress_candidates: List[ChatMessage],
+        relevant_facts: List[str],
+        session_summary: Optional[str],
+        states: Optional[List[Dict[str, Any]]],
+        available_skills,
+        tool_scope,
+        model_name: str,
+        prompt_budget_tokens: int,
+    ) -> PromptAssemblyResult:
+        keep_groups = self._group_history_messages(messages_keep)
+        compress_block = sorted(messages_compress_candidates, key=lambda m: m.created_at)
+        precomputed_summary: Optional[str] = None
+        summary_updated_at: Optional[datetime] = None
+        tool_schemas = tool_scope.schemas()
+
+        while True:
+            candidate_window = [msg for group in keep_groups for msg in group]
+            summary_for_prompt = precomputed_summary or session_summary
+            if precomputed_summary is None:
+                candidate_window = compress_block + candidate_window
+
+            restored_window_messages = await self._context_assembler.restore_ephemeral_context_injections(
+                session_id,
+                candidate_window,
+            )
+            messages_for_llm = self._context_assembler.assemble_prompt(
+                session_id,
+                user_query,
+                restored_window_messages,
+                relevant_facts,
+                summary_for_prompt,
+                states=states,
+                available_skills=available_skills or None,
+            )
+            token_count = await self._count_final_prompt_tokens(
+                messages_for_llm,
+                tool_schemas,
+                model_name,
+            )
+            if token_count <= prompt_budget_tokens:
+                return PromptAssemblyResult(
+                    messages_for_llm=messages_for_llm,
+                    messages_keep_for_hot_context=candidate_window,
+                    precomputed_summary=precomputed_summary,
+                    summary_updated_at=summary_updated_at,
+                )
+
+            if not compress_block and keep_groups:
+                compress_block.extend(keep_groups.pop(0))
+            elif precomputed_summary is not None and keep_groups:
+                compress_block.extend(keep_groups.pop(0))
+            elif precomputed_summary is not None:
+                raise ServiceException(
+                    ChatErrorCode.CONTEXT_LIMIT_EXCEEDED,
+                    custom_msg=(
+                        "最终提示词在压缩全部可压缩历史后仍超出模型上下文预算，"
+                        f"tokens={token_count}, budget={prompt_budget_tokens}"
+                    ),
+                )
+            elif not compress_block:
+                raise ServiceException(
+                    ChatErrorCode.CONTEXT_LIMIT_EXCEEDED,
+                    custom_msg=(
+                        "最终提示词在没有可压缩历史明细后仍超出模型上下文预算，"
+                        f"tokens={token_count}, budget={prompt_budget_tokens}"
+                    ),
+                )
+
+            precomputed_summary = await self._turn_finalizer.generate_updated_summary(
+                session_id=session_id,
+                messages_compress_candidates=compress_block,
+                existing_summary=session_summary,
+            )
+            if not precomputed_summary:
+                raise ServiceException(
+                    ChatErrorCode.CONTEXT_LIMIT_EXCEEDED,
+                    custom_msg=(
+                        "最终提示词超出模型上下文预算，且同步摘要生成失败，"
+                        f"tokens={token_count}, budget={prompt_budget_tokens}"
+                    ),
+                )
+            summary_updated_at = max(m.created_at for m in compress_block)
 
     # -------------------------------------------------------------------------
     # 公共入口
@@ -110,6 +238,7 @@ class ChatTurnCoordinator:
         tool_context: dict[str, Any] = {
             "session_id": session_id,
             "user_id": user_id,
+            "turn_loaded_files": set(),
         } 
 
         # [Skill Discovery] 注入当前会话可用 Skill 的轻量 metadata，由 LLM 决定是否调用 load_skill。
@@ -143,11 +272,20 @@ class ChatTurnCoordinator:
         )
 
         # [Context Construction] 将系统提示词、Mem0 检索到的事实、会话的历史摘要、前端上下文以及窗口内的明细消息组装成 LLM 所需的格式
-        messages_for_llm = self._context_assembler.assemble_prompt(
-            session_id, user_query, messages_keep+messages_compress_candidates, relevant_facts, session_summary,
+        prompt_assembly = await self._assemble_prompt_with_final_budget(
+            session_id=session_id,
+            user_query=user_query,
+            messages_keep=messages_keep,
+            messages_compress_candidates=messages_compress_candidates,
+            relevant_facts=relevant_facts,
+            session_summary=session_summary,
             states=states,
-            available_skills=available_skills or None,
+            available_skills=available_skills,
+            tool_scope=tool_scope,
+            model_name=resolved.model_name,
+            prompt_budget_tokens=prompt_budget_tokens,
         )
+        messages_for_llm = prompt_assembly.messages_for_llm
 
         # 记录进入 Agent 循环前的列表长度
         original_msg_count = len(messages_for_llm)
@@ -170,6 +308,7 @@ class ChatTurnCoordinator:
                 model_id=resolved.model_id,
                 api_base=resolved.api_base_url,
                 api_key=resolved.api_key,
+                prompt_budget_tokens=prompt_budget_tokens,
             ):
                 # QueryLoopRuntime 只产出领域事件；这里按需累加纯文本，并把事件翻译为 Vercel SSE 字符串
                 if isinstance(event, StepStartEvent):
@@ -200,20 +339,31 @@ class ChatTurnCoordinator:
 
             messages_to_persist = [user_msg] + intermediate_messages + [assistant_msg]
 
-            background_tasks.add_task(
-                self._turn_finalizer.persist_all,
-                user_id, session_id, resolved,
-                messages_to_persist
-            )
+            if prompt_assembly.precomputed_summary and prompt_assembly.summary_updated_at:
+                background_tasks.add_task(
+                    self._turn_finalizer.persist_then_apply_compression_result,
+                    user_id, session_id, resolved,
+                    messages_to_persist,
+                    prompt_assembly.precomputed_summary,
+                    prompt_assembly.summary_updated_at,
+                    prompt_assembly.messages_keep_for_hot_context,
+                )
+            elif needs_compression:
+                background_tasks.add_task(
+                    self._turn_finalizer.persist_then_summarize_and_compress,
+                    user_id, session_id, resolved,
+                    messages_to_persist,
+                    messages_keep,
+                    messages_compress_candidates,
+                    session_summary,
+                )
+            else:
+                background_tasks.add_task(
+                    self._turn_finalizer.persist_all,
+                    user_id, session_id, resolved,
+                    messages_to_persist
+                )
             background_tasks.add_task(
                 self._turn_finalizer.auto_generate_title,
                 session_id, user_id, user_query
             )
-            if needs_compression:
-                background_tasks.add_task(
-                    self._turn_finalizer.summarize_and_compress,
-                    session_id,
-                    messages_keep + messages_to_persist,
-                    messages_compress_candidates,
-                    session_summary
-                )

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -113,6 +113,7 @@ class ChatTurnCoordinator:
 
         # [Skill Match] 预筛当前 query 可能相关的 Skill，命中才暴露 schema + 注入 Available Skills
         candidate_skills = self._skill_matcher.match(user_query)
+        print(candidate_skills)
         expose_tool_name_set = None
         if candidate_skills:
             # 解禁 Registry 里默认隐藏的 skill 脚手架工具（reserved=True）

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
@@ -96,7 +96,9 @@ class ChatTurnFinalizer:
         """
         Per-message 粒度的 ephemeral 处理，须在任何持久化动作之前调用一次
         - ASSISTANT 消息标 ephemeral=True：整条丢弃。
-        - TOOL 消息标 ephemeral=True：保留消息结构（tool_call_id / name 齐全）但 content 置换为占位符。
+        - SYSTEM 消息标 ephemeral=True：整条丢弃，避免临时控制指令进入 durable 历史。
+        - TOOL 消息标 ephemeral=True：默认保留消息结构（tool_call_id / name 齐全）但 content 置换为占位符。
+          若工具显式标记 preserve_ephemeral_content=True，则保留短 ack。
         
         以确保 SKILL 中 SKILL.md / asset 正文不会进入 durable 历史，后续回合也不会从 Redis / Mongo 读回污染上下文
         """
@@ -107,7 +109,12 @@ class ChatTurnFinalizer:
                 continue
             if msg.role == Role.ASSISTANT:
                 continue  # 整条丢弃
+            if msg.role == Role.SYSTEM:
+                continue  # 临时 SYSTEM 注入只服务当前 turn，不进入持久历史
             if msg.role == Role.TOOL:
+                if msg.metadata.get("preserve_ephemeral_content"):
+                    redacted.append(msg)
+                    continue
                 msg.content = (
                     f"[Redacted: ephemeral tool '{msg.name or 'unknown'}' scaffolding output]"
                 )

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
@@ -95,7 +95,6 @@ class ChatTurnFinalizer:
     def _redact_ephemeral(new_messages: List[ChatMessage]) -> List[ChatMessage]:
         """
         Per-message 粒度的 ephemeral 处理，须在任何持久化动作之前调用一次
-        - ASSISTANT 消息标 ephemeral=True：整条丢弃。
         - SYSTEM 消息标 ephemeral=True：整条丢弃，避免临时控制指令进入 durable 历史。
         - TOOL 消息标 ephemeral=True：默认保留消息结构（tool_call_id / name 齐全）但 content 置换为占位符。
           若工具显式标记 preserve_ephemeral_content=True，则保留短 ack。
@@ -132,7 +131,7 @@ class ChatTurnFinalizer:
         resolved_model: ModelRequestInfo,
         new_messages: List[ChatMessage],
         group_id: Optional[str] = None,
-    ) -> None:
+    ) -> List[ChatMessage]:
         """后台统一处理所有存储逻辑: ephemeral 裁剪 → Redis 追加 → MongoDB 落盘 → Memory 摄入 → Token 计费"""
         # 先裁剪 ephemeral，下游所有持久化都看这份结果
         persistable = self._redact_ephemeral(new_messages)
@@ -165,6 +164,7 @@ class ChatTurnFinalizer:
                                         resolved_model=resolved_model,
                                         messages=persistable,
                                         group_id=group_id)
+        return persistable
 
 
 
@@ -204,16 +204,16 @@ class ChatTurnFinalizer:
         except Exception as e:
             log_error("自动生成标题", e, session=session_id)
 
-    async def summarize_and_compress(
+    async def generate_updated_summary(
         self,
         session_id: str,
-        messages_keep: List[ChatMessage],
         messages_compress_candidates: List[ChatMessage],
         existing_summary: Optional[str],
-    ) -> None:
-        """
-        增量摘要压缩
-        """
+    ) -> Optional[str]:
+        """生成增量摘要文本；只负责调用摘要模型，不做持久化。"""
+        if not messages_compress_candidates:
+            return None
+
         # 构建摘要输入，将 existing_summary（上一轮摘要，如有）作为前缀，拼接 messages_compress_candidates 明细，让轻量模型生成覆盖范围更广的全局摘要
         oldest_text = "\n".join(
             [f"{m.role.value}: {m.content}" for m in messages_compress_candidates]
@@ -260,15 +260,31 @@ class ChatTurnFinalizer:
             new_summary = message_response.content or ""
         except Exception as e:
             log_error("摘要生成", e, session=session_id)
-            return
+            return None
 
         if not new_summary.strip():
+            return None
+
+        return new_summary
+
+    async def apply_compression_result(
+        self,
+        session_id: str,
+        current_summary: str,
+        summary_updated_at: datetime,
+        messages_keep: List[ChatMessage],
+    ) -> None:
+        """应用已生成的摘要：更新 session summary，并用保留明细重载 Redis。"""
+        if not current_summary.strip():
             return
 
         # 持久化新摘要到 MongoDB，同时写入压缩时间戳
         try:
-            await self.session_repo.update_session_summary(session_id=session_id, current_summary=new_summary,
-                                                           summary_updated_at=datetime.now(timezone.utc))
+            await self.session_repo.update_session_summary(
+                session_id=session_id,
+                current_summary=current_summary,
+                summary_updated_at=summary_updated_at,
+            )
         except Exception as e:
             log_error("摘要持久化", e, session=session_id)
 
@@ -280,3 +296,82 @@ class ChatTurnFinalizer:
             )
         except Exception as e:
             log_error("Redis 上下文重载", e, session=session_id)
+
+    async def summarize_and_compress(
+        self,
+        session_id: str,
+        messages_keep: List[ChatMessage],
+        messages_compress_candidates: List[ChatMessage],
+        existing_summary: Optional[str],
+    ) -> None:
+        """
+        增量摘要压缩
+        """
+        new_summary = await self.generate_updated_summary(
+            session_id=session_id,
+            messages_compress_candidates=messages_compress_candidates,
+            existing_summary=existing_summary,
+        )
+        if not new_summary:
+            return
+
+        summary_updated_at = max(
+            (m.created_at for m in messages_compress_candidates),
+            default=datetime.now(timezone.utc),
+        )
+        await self.apply_compression_result(
+            session_id=session_id,
+            current_summary=new_summary,
+            summary_updated_at=summary_updated_at,
+            messages_keep=messages_keep,
+        )
+
+    async def persist_then_apply_compression_result(
+        self,
+        user_id: str,
+        session_id: str,
+        resolved_model: ModelRequestInfo,
+        new_messages: List[ChatMessage],
+        current_summary: str,
+        summary_updated_at: datetime,
+        messages_keep: List[ChatMessage],
+        group_id: Optional[str] = None,
+    ) -> None:
+        persistable = await self.persist_all(
+            user_id=user_id,
+            session_id=session_id,
+            resolved_model=resolved_model,
+            new_messages=new_messages,
+            group_id=group_id,
+        )
+        await self.apply_compression_result(
+            session_id=session_id,
+            current_summary=current_summary,
+            summary_updated_at=summary_updated_at,
+            messages_keep=messages_keep + persistable,
+        )
+
+    async def persist_then_summarize_and_compress(
+        self,
+        user_id: str,
+        session_id: str,
+        resolved_model: ModelRequestInfo,
+        new_messages: List[ChatMessage],
+        messages_keep: List[ChatMessage],
+        messages_compress_candidates: List[ChatMessage],
+        existing_summary: Optional[str],
+        group_id: Optional[str] = None,
+    ) -> None:
+        persistable = await self.persist_all(
+            user_id=user_id,
+            session_id=session_id,
+            resolved_model=resolved_model,
+            new_messages=new_messages,
+            group_id=group_id,
+        )
+        await self.summarize_and_compress(
+            session_id=session_id,
+            messages_keep=messages_keep + persistable,
+            messages_compress_candidates=messages_compress_candidates,
+            existing_summary=existing_summary,
+        )

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
@@ -9,6 +9,7 @@ from chat.domain.entities import ChatMessage, Role
 from chat.domain.entities.model import ModelScope
 from chat.domain.interfaces.llm import LLMProvider
 from chat.domain.interfaces.memory import MemoryProvider
+from chat.domain.message_lifecycle import MessageLifecycle, PersistenceMode
 from chat.domain.repositories import MessageRepository, HotContextRepository, SessionRepository, ProviderRepository
 from chat.domain.repositories.model_repo import ModelRequestInfo
 from common.kafka.producer import KafkaProducerClient
@@ -92,37 +93,34 @@ class ChatTurnFinalizer:
         await self.kafka_producer.send(topic=settings.KAFKA_TOKEN_CONSUMPTION_TOPIC, value=value)
 
     @staticmethod
-    def _redact_ephemeral(new_messages: List[ChatMessage]) -> List[ChatMessage]:
+    def _apply_persistence_policy(new_messages: List[ChatMessage]) -> List[ChatMessage]:
         """
-        Per-message 粒度的 ephemeral 处理，须在任何持久化动作之前调用一次
-        - SYSTEM 消息标 ephemeral=True：整条丢弃，避免临时控制指令进入 durable 历史。
-        - TOOL 消息标 ephemeral=True：默认保留消息结构（tool_call_id / name 齐全）但 content 置换为占位符。
-          若工具显式标记 preserve_ephemeral_content=True，则保留短 ack。
-        
-        以确保 SKILL 中 SKILL.md / asset 正文不会进入 durable 历史，后续回合也不会从 Redis / Mongo 读回污染上下文
+        Per-message 粒度的持久化策略处理，须在任何持久化动作之前调用一次。
+        - DROP：整条丢弃，避免临时控制指令进入 durable 历史。
+        - REDACT_CONTENT：保留消息结构但替换 content。
+        - PERSIST_FULL / PERSIST_CONTENT：原样保留。
+
+        restore_ref 会被落到 metadata 中，供后续上下文组装恢复临时注入。
+        进入 Redis / Mongo / Memory 的消息一律重置为默认 lifecycle。
         """
-        redacted: List[ChatMessage] = []
+        persistable: List[ChatMessage] = []
         for msg in new_messages:
-            if not msg.ephemeral:
-                redacted.append(msg)
+            mode = msg.lifecycle.persistence_mode
+            if mode == PersistenceMode.DROP:
                 continue
-            if msg.role == Role.SYSTEM:
-                continue  # 临时 SYSTEM 注入只服务当前 turn，不进入持久历史
-            if msg.role == Role.USER:
-                continue
-            if msg.role == Role.TOOL:
-                if msg.metadata.get("preserve_ephemeral_content"):
-                    redacted.append(msg)
-                    continue
+
+            restore_ref = msg.lifecycle.restore_ref
+            if restore_ref:
+                msg.metadata = dict(msg.metadata or {})
+                msg.metadata["restore_ref"] = restore_ref.model_dump(mode="json")
+
+            if mode == PersistenceMode.REDACT_CONTENT:
                 msg.content = (
-                    f"[Redacted: ephemeral tool '{msg.name or 'unknown'}' scaffolding output]"
+                    f"[Redacted: tool '{msg.name or 'unknown'}' scaffolding output]"
                 )
-                redacted.append(msg)
-                continue
-            # 其他 role 不该被标 ephemeral；保守保留并去 ephemeral 标记
-            msg.ephemeral = False
-            redacted.append(msg)
-        return redacted
+            msg.lifecycle = MessageLifecycle()
+            persistable.append(msg)
+        return persistable
 
     async def persist_all(
         self,
@@ -132,9 +130,9 @@ class ChatTurnFinalizer:
         new_messages: List[ChatMessage],
         group_id: Optional[str] = None,
     ) -> List[ChatMessage]:
-        """后台统一处理所有存储逻辑: ephemeral 裁剪 → Redis 追加 → MongoDB 落盘 → Memory 摄入 → Token 计费"""
-        # 先裁剪 ephemeral，下游所有持久化都看这份结果
-        persistable = self._redact_ephemeral(new_messages)
+        """后台统一处理所有存储逻辑: 生命周期策略裁剪 → Redis 追加 → MongoDB 落盘 → Memory 摄入 → Token 计费"""
+        # 先应用生命周期持久化策略，下游所有持久化都看这份结果
+        persistable = self._apply_persistence_policy(new_messages)
 
         await self._fill_token_counts(persistable, resolved_model.model_name)
 

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
@@ -107,10 +107,10 @@ class ChatTurnFinalizer:
             if not msg.ephemeral:
                 redacted.append(msg)
                 continue
-            if msg.role == Role.ASSISTANT:
-                continue  # 整条丢弃
             if msg.role == Role.SYSTEM:
                 continue  # 临时 SYSTEM 注入只服务当前 turn，不进入持久历史
+            if msg.role == Role.USER:
+                continue
             if msg.role == Role.TOOL:
                 if msg.metadata.get("preserve_ephemeral_content"):
                     redacted.append(msg)

--- a/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
+++ b/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
@@ -291,12 +291,10 @@ class QueryLoopRuntime:
 
         # schema 已由 ToolScope 在构造期固化，这里零决策直读
         tool_schemas = tool_scope.schemas()
-        provider_messages = self._messages_for_provider(messages)
-
         try:
             # 调用模型流式接口
             async for chunk in self.llm.stream_chat_completion(
-                messages=provider_messages,
+                messages=messages,
                 model_name=model_name,
                 tools=tool_schemas or None,
                 api_base=api_base,
@@ -373,53 +371,6 @@ class QueryLoopRuntime:
         yield _StepTerminal(should_continue=True, new_messages=new_messages)
 
     @staticmethod
-    def _messages_for_provider(messages: List[ChatMessage]) -> List[ChatMessage]:
-        """
-        Build a provider-facing view of the current transcript.
-
-        Ephemeral SYSTEM messages are control-plane injections produced during
-        the current agent loop (for example loaded SKILL.md). Coalesce them
-        into the first provider-facing SYSTEM message so providers that only
-        honor one system prompt still receive the loaded skill instructions,
-        while leaving assistant(tool_calls) -> tool(...) pairs adjacent.
-        """
-        system_injections = [
-            m for m in messages if m.role == Role.SYSTEM and m.ephemeral
-        ]
-        if not system_injections:
-            return messages
-
-        remaining = [
-            m for m in messages if not (m.role == Role.SYSTEM and m.ephemeral)
-        ]
-        injection_content = "\n\n".join(
-            m.content for m in system_injections if m.content
-        )
-        if not injection_content:
-            return remaining
-
-        if remaining and remaining[0].role == Role.SYSTEM:
-            first_system = remaining[0]
-            copy_fn = getattr(first_system, "model_copy", None)
-            merged_system = (
-                copy_fn(deep=False)
-                if copy_fn is not None
-                else first_system.copy(deep=False)
-            )
-            merged_system.content = "\n\n".join(
-                part for part in (first_system.content, injection_content) if part
-            )
-            return [merged_system] + remaining[1:]
-
-        return [
-            ChatMessage(
-                session_id=system_injections[0].session_id,
-                role=Role.SYSTEM,
-                content=injection_content,
-            )
-        ] + remaining
-
-    @staticmethod
     def _coerce_tool_result(result: Any) -> ToolExecutionResult:
         if isinstance(result, ToolExecutionResult):
             return result
@@ -454,7 +405,7 @@ class QueryLoopRuntime:
         """
         并行执行所有工具。
         返回 tool_output_available 事件列表（按 parsed 顺序）和本轮新增消息。
-        新增消息通常是 Role.TOOL；结构化工具结果也可以附带 ephemeral Role.SYSTEM 注入。
+        新增消息通常是 Role.TOOL；结构化工具结果也可以附带 ephemeral Role.USER 注入。
         每条 TOOL 消息独立按对应 tool 的 is_ephemeral_output 打 ephemeral 标，
         让 Finalizer 在 per-message 粒度上决定是否 redact，避免混合轮次里 skill 正文通过"整轮保守落盘"漏进 durable 历史
         """
@@ -473,6 +424,7 @@ class QueryLoopRuntime:
         # 遍历结果做异常降级
         events: List[StreamEvent] = []
         tool_messages: List[ChatMessage] = []
+        injection_messages: List[ChatMessage] = []
         for tool_call, result, is_ephemeral in zip(parsed_tool_calls, raw_results, ephemeral_flags):
             # 如果某个结果是 Exception，转成字符串形式的 [Tool Execution Error]: ... 并记录日志，否则原样使用。
             # 防止原生 Exception 对象序列化进 API 请求导致异常
@@ -501,20 +453,20 @@ class QueryLoopRuntime:
                     content=tool_result.tool_content,
                     metadata={
                         "preserve_ephemeral_content": True
-                    } if tool_result.system_injection else {},
+                    } if tool_result.user_injection else {},
                     ephemeral=is_ephemeral,
                 )
             )
-            if tool_result.system_injection:
-                tool_messages.append(
+            if tool_result.user_injection:
+                injection_messages.append(
                     ChatMessage(
                         session_id=session_id,
-                        role=Role.SYSTEM,
-                        content=tool_result.system_injection,
+                        role=Role.USER,
+                        content=tool_result.user_injection,
                         ephemeral=True,
                     )
                 )
-        return events, tool_messages
+        return events, tool_messages + injection_messages
 
     async def _invoke_tool(
         self,

--- a/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
+++ b/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
@@ -221,6 +221,50 @@ class QueryLoopRuntime:
     def __init__(self, llm: LLMProvider) -> None:
         self.llm = llm
 
+    @staticmethod
+    def _serialize_prompt_for_counting(
+        messages: List[ChatMessage],
+        tool_schemas: List[Dict[str, Any]],
+    ) -> str:
+        serialized_messages: List[Dict[str, Any]] = []
+        for msg in messages:
+            item: Dict[str, Any] = {
+                "role": msg.role.value,
+                "content": msg.content or "",
+            }
+            if msg.tool_calls:
+                item["tool_calls"] = msg.tool_calls
+            if msg.tool_call_id:
+                item["tool_call_id"] = msg.tool_call_id
+            if msg.name:
+                item["name"] = msg.name
+            serialized_messages.append(item)
+        return json.dumps(
+            {"messages": serialized_messages, "tools": tool_schemas},
+            ensure_ascii=False,
+            default=str,
+        )
+
+    async def _ensure_prompt_budget(
+        self,
+        messages: List[ChatMessage],
+        tool_schemas: List[Dict[str, Any]],
+        model_name: str,
+        prompt_budget_tokens: Optional[int],
+    ) -> None:
+        if prompt_budget_tokens is None:
+            return
+        text = self._serialize_prompt_for_counting(messages, tool_schemas)
+        token_count = await self.llm.count_tokens(text, model_name)
+        if token_count > prompt_budget_tokens:
+            raise ServiceException(
+                ChatErrorCode.CONTEXT_LIMIT_EXCEEDED,
+                custom_msg=(
+                    "最终提示词超出模型上下文预算，"
+                    f"tokens={token_count}, budget={prompt_budget_tokens}"
+                ),
+            )
+
     """
     ReAct 循环主入口 (QueryLoop)
     """
@@ -233,6 +277,7 @@ class QueryLoopRuntime:
         model_id: Optional[PydanticObjectId] = None,
         api_base: Optional[str] = None,
         api_key: Optional[str] = None,
+        prompt_budget_tokens: Optional[int] = None,
     ) -> AsyncIterator[StreamEvent]:
         # 进入多轮循环
         for iteration in range(settings.AGENT_MAX_ITERATIONS):
@@ -248,6 +293,7 @@ class QueryLoopRuntime:
                 api_key=api_key,
                 iteration=iteration,
                 tool_scope=tool_scope,
+                prompt_budget_tokens=prompt_budget_tokens,
             ):
                 # 如果拿到的是 _StepTerminal 就存到 terminal；否则直接 yield
                 if isinstance(item, _StepTerminal):
@@ -278,6 +324,7 @@ class QueryLoopRuntime:
         api_key: Optional[str],
         iteration: int,
         tool_scope: ToolScope,
+        prompt_budget_tokens: Optional[int],
     ) -> AsyncIterator[Union[StreamEvent, _StepTerminal]]:
         # 发 step 开始事件
         yield StepStartEvent()
@@ -291,6 +338,12 @@ class QueryLoopRuntime:
 
         # schema 已由 ToolScope 在构造期固化，这里零决策直读
         tool_schemas = tool_scope.schemas()
+        await self._ensure_prompt_budget(
+            messages,
+            tool_schemas,
+            model_name,
+            prompt_budget_tokens,
+        )
         try:
             # 调用模型流式接口
             async for chunk in self.llm.stream_chat_completion(
@@ -420,12 +473,18 @@ class QueryLoopRuntime:
         ephemeral_flags: List[bool] = [
             tool_scope.is_ephemeral(tool_call.name) for tool_call in parsed_tool_calls
         ]
+        restore_flags: List[bool] = [
+            tool_scope.should_restore_ephemeral_in_context(tool_call.name)
+            for tool_call in parsed_tool_calls
+        ]
 
         # 遍历结果做异常降级
         events: List[StreamEvent] = []
         tool_messages: List[ChatMessage] = []
         injection_messages: List[ChatMessage] = []
-        for tool_call, result, is_ephemeral in zip(parsed_tool_calls, raw_results, ephemeral_flags):
+        for tool_call, result, is_ephemeral, should_restore in zip(
+            parsed_tool_calls, raw_results, ephemeral_flags, restore_flags
+        ):
             # 如果某个结果是 Exception，转成字符串形式的 [Tool Execution Error]: ... 并记录日志，否则原样使用。
             # 防止原生 Exception 对象序列化进 API 请求导致异常
             if isinstance(result, Exception):
@@ -441,6 +500,12 @@ class QueryLoopRuntime:
                 else tool_result.tool_content
             )
 
+            should_restore_message = bool(should_restore and tool_result.user_injection)
+            metadata = dict(tool_result.metadata or {})
+            metadata["restore_ephemeral_in_context"] = should_restore_message
+            if tool_result.user_injection:
+                metadata["preserve_ephemeral_content"] = True
+
             # 发 ToolOutputAvailableEvent
             events.append(ToolOutputAvailableEvent(call_id=tool_call.id, output=event_output))
             # 构造对话历史中的 Tool 消息
@@ -451,9 +516,7 @@ class QueryLoopRuntime:
                     tool_call_id=tool_call.id,
                     name=tool_call.name,
                     content=tool_result.tool_content,
-                    metadata={
-                        "preserve_ephemeral_content": True
-                    } if tool_result.user_injection else {},
+                    metadata=metadata,
                     ephemeral=is_ephemeral,
                 )
             )

--- a/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
+++ b/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
@@ -10,6 +10,7 @@ from common.logger import log_fail
 from chat.core.config.app_settings import settings
 from chat.domain.entities import ChatMessage, Role
 from chat.domain.interfaces import LLMProvider
+from chat.domain.interfaces.tool import ToolExecutionResult
 from chat.domain.error_codes import ChatErrorCode
 from common.core.exceptions import ServiceException
 from chat.application.tools.tool_scope import ToolScope
@@ -290,11 +291,12 @@ class QueryLoopRuntime:
 
         # schema 已由 ToolScope 在构造期固化，这里零决策直读
         tool_schemas = tool_scope.schemas()
+        provider_messages = self._messages_for_provider(messages)
 
         try:
             # 调用模型流式接口
             async for chunk in self.llm.stream_chat_completion(
-                messages=messages,
+                messages=provider_messages,
                 model_name=model_name,
                 tools=tool_schemas or None,
                 api_base=api_base,
@@ -371,6 +373,59 @@ class QueryLoopRuntime:
         yield _StepTerminal(should_continue=True, new_messages=new_messages)
 
     @staticmethod
+    def _messages_for_provider(messages: List[ChatMessage]) -> List[ChatMessage]:
+        """
+        Build a provider-facing view of the current transcript.
+
+        Ephemeral SYSTEM messages are control-plane injections produced during
+        the current agent loop (for example loaded SKILL.md). Coalesce them
+        into the first provider-facing SYSTEM message so providers that only
+        honor one system prompt still receive the loaded skill instructions,
+        while leaving assistant(tool_calls) -> tool(...) pairs adjacent.
+        """
+        system_injections = [
+            m for m in messages if m.role == Role.SYSTEM and m.ephemeral
+        ]
+        if not system_injections:
+            return messages
+
+        remaining = [
+            m for m in messages if not (m.role == Role.SYSTEM and m.ephemeral)
+        ]
+        injection_content = "\n\n".join(
+            m.content for m in system_injections if m.content
+        )
+        if not injection_content:
+            return remaining
+
+        if remaining and remaining[0].role == Role.SYSTEM:
+            first_system = remaining[0]
+            copy_fn = getattr(first_system, "model_copy", None)
+            merged_system = (
+                copy_fn(deep=False)
+                if copy_fn is not None
+                else first_system.copy(deep=False)
+            )
+            merged_system.content = "\n\n".join(
+                part for part in (first_system.content, injection_content) if part
+            )
+            return [merged_system] + remaining[1:]
+
+        return [
+            ChatMessage(
+                session_id=system_injections[0].session_id,
+                role=Role.SYSTEM,
+                content=injection_content,
+            )
+        ] + remaining
+
+    @staticmethod
+    def _coerce_tool_result(result: Any) -> ToolExecutionResult:
+        if isinstance(result, ToolExecutionResult):
+            return result
+        return ToolExecutionResult(tool_content=str(result))
+
+    @staticmethod
     def _parse_tool_calls(
         accumulators: Dict[int, _ToolCallAccumulator],
     ) -> List[_ParsedToolCall]:
@@ -398,7 +453,8 @@ class QueryLoopRuntime:
     ) -> Tuple[List[StreamEvent], List[ChatMessage]]:
         """
         并行执行所有工具。
-        返回 tool_output_available 事件列表（按 parsed 顺序）和对应的 Role.TOOL 消息列表（按 parsed 顺序）。
+        返回 tool_output_available 事件列表（按 parsed 顺序）和本轮新增消息。
+        新增消息通常是 Role.TOOL；结构化工具结果也可以附带 ephemeral Role.SYSTEM 注入。
         每条 TOOL 消息独立按对应 tool 的 is_ephemeral_output 打 ephemeral 标，
         让 Finalizer 在 per-message 粒度上决定是否 redact，避免混合轮次里 skill 正文通过"整轮保守落盘"漏进 durable 历史
         """
@@ -423,11 +479,18 @@ class QueryLoopRuntime:
             if isinstance(result, Exception):
                 safe_result = f"[Tool Execution Error]: {type(result).__name__}: {result}"
                 log_fail("工具调用", result, name=tool_call.name, session=session_id)
+                tool_result = ToolExecutionResult(tool_content=safe_result)
             else:
-                safe_result = result
+                tool_result = self._coerce_tool_result(result)
+
+            event_output = (
+                tool_result.frontend_output
+                if tool_result.frontend_output is not None
+                else tool_result.tool_content
+            )
 
             # 发 ToolOutputAvailableEvent
-            events.append(ToolOutputAvailableEvent(call_id=tool_call.id, output=safe_result))
+            events.append(ToolOutputAvailableEvent(call_id=tool_call.id, output=event_output))
             # 构造对话历史中的 Tool 消息
             tool_messages.append(
                 ChatMessage(
@@ -435,10 +498,22 @@ class QueryLoopRuntime:
                     role=Role.TOOL,
                     tool_call_id=tool_call.id,
                     name=tool_call.name,
-                    content=safe_result,
+                    content=tool_result.tool_content,
+                    metadata={
+                        "preserve_ephemeral_content": True
+                    } if tool_result.system_injection else {},
                     ephemeral=is_ephemeral,
                 )
             )
+            if tool_result.system_injection:
+                tool_messages.append(
+                    ChatMessage(
+                        session_id=session_id,
+                        role=Role.SYSTEM,
+                        content=tool_result.system_injection,
+                        ephemeral=True,
+                    )
+                )
         return events, tool_messages
 
     async def _invoke_tool(
@@ -446,7 +521,7 @@ class QueryLoopRuntime:
         name: str,
         tool_scope: ToolScope,
         args: Dict[str, Any],
-    ) -> str:
+    ) -> Union[str, ToolExecutionResult]:
         """按 tool_scope 视图查工具并执行；未在视图内（被 deny 掉或未注册）时降级文本"""
         tool = tool_scope.get(name)
         if tool is None:

--- a/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
+++ b/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
@@ -11,6 +11,7 @@ from chat.core.config.app_settings import settings
 from chat.domain.entities import ChatMessage, Role
 from chat.domain.interfaces import LLMProvider
 from chat.domain.interfaces.tool import ToolExecutionResult
+from chat.domain.message_lifecycle import LLMVisibility, MessageLifecycle, PersistenceMode
 from chat.domain.error_codes import ChatErrorCode
 from common.core.exceptions import ServiceException
 from chat.application.tools.tool_scope import ToolScope
@@ -227,7 +228,7 @@ class QueryLoopRuntime:
         tool_schemas: List[Dict[str, Any]],
     ) -> str:
         serialized_messages: List[Dict[str, Any]] = []
-        for msg in messages:
+        for msg in QueryLoopRuntime._messages_visible_to_llm(messages):
             item: Dict[str, Any] = {
                 "role": msg.role.value,
                 "content": msg.content or "",
@@ -244,6 +245,13 @@ class QueryLoopRuntime:
             ensure_ascii=False,
             default=str,
         )
+
+    @staticmethod
+    def _messages_visible_to_llm(messages: List[ChatMessage]) -> List[ChatMessage]:
+        return [
+            msg for msg in messages
+            if msg.lifecycle.llm_visibility == LLMVisibility.INCLUDE
+        ]
 
     async def _ensure_prompt_budget(
         self,
@@ -347,7 +355,7 @@ class QueryLoopRuntime:
         try:
             # 调用模型流式接口
             async for chunk in self.llm.stream_chat_completion(
-                messages=messages,
+                messages=self._messages_visible_to_llm(messages),
                 model_name=model_name,
                 tools=tool_schemas or None,
                 api_base=api_base,
@@ -398,7 +406,6 @@ class QueryLoopRuntime:
                 }
                 for tool_call in parsed_tool_calls
             ],
-            ephemeral=False,
         )
         new_messages: List[ChatMessage] = [assistant_msg]
 
@@ -458,9 +465,9 @@ class QueryLoopRuntime:
         """
         并行执行所有工具。
         返回 tool_output_available 事件列表（按 parsed 顺序）和本轮新增消息。
-        新增消息通常是 Role.TOOL；结构化工具结果也可以附带 ephemeral Role.USER 注入。
-        每条 TOOL 消息独立按对应 tool 的 is_ephemeral_output 打 ephemeral 标，
-        让 Finalizer 在 per-message 粒度上决定是否 redact，避免混合轮次里 skill 正文通过"整轮保守落盘"漏进 durable 历史
+        新增消息通常是 Role.TOOL；结构化工具结果也可以附带仅本轮使用的 Role.USER 注入。
+        每条消息携带 lifecycle，让 Finalizer 在 per-message 粒度上决定是否 drop/redact/persist，
+        避免 skill 正文或 asset 正文漏进 durable 历史。
         """
 
         # 并发执行所有工具，return_exceptions=True 保证单工具失败不中断整轮
@@ -469,22 +476,11 @@ class QueryLoopRuntime:
             return_exceptions=True,
         )
 
-        # 查出每个 tool call 对应 tool 的 is_ephemeral_output
-        ephemeral_flags: List[bool] = [
-            tool_scope.is_ephemeral(tool_call.name) for tool_call in parsed_tool_calls
-        ]
-        restore_flags: List[bool] = [
-            tool_scope.should_restore_ephemeral_in_context(tool_call.name)
-            for tool_call in parsed_tool_calls
-        ]
-
         # 遍历结果做异常降级
         events: List[StreamEvent] = []
         tool_messages: List[ChatMessage] = []
         injection_messages: List[ChatMessage] = []
-        for tool_call, result, is_ephemeral, should_restore in zip(
-            parsed_tool_calls, raw_results, ephemeral_flags, restore_flags
-        ):
+        for tool_call, result in zip(parsed_tool_calls, raw_results):
             # 如果某个结果是 Exception，转成字符串形式的 [Tool Execution Error]: ... 并记录日志，否则原样使用。
             # 防止原生 Exception 对象序列化进 API 请求导致异常
             if isinstance(result, Exception):
@@ -500,11 +496,9 @@ class QueryLoopRuntime:
                 else tool_result.tool_content
             )
 
-            should_restore_message = bool(should_restore and tool_result.user_injection)
             metadata = dict(tool_result.metadata or {})
-            metadata["restore_ephemeral_in_context"] = should_restore_message
-            if tool_result.user_injection:
-                metadata["preserve_ephemeral_content"] = True
+            if tool_result.lifecycle.restore_ref:
+                metadata["restore_ref"] = tool_result.lifecycle.restore_ref.model_dump(mode="json")
 
             # 发 ToolOutputAvailableEvent
             events.append(ToolOutputAvailableEvent(call_id=tool_call.id, output=event_output))
@@ -517,7 +511,7 @@ class QueryLoopRuntime:
                     name=tool_call.name,
                     content=tool_result.tool_content,
                     metadata=metadata,
-                    ephemeral=is_ephemeral,
+                    lifecycle=tool_result.lifecycle,
                 )
             )
             if tool_result.user_injection:
@@ -526,7 +520,9 @@ class QueryLoopRuntime:
                         session_id=session_id,
                         role=Role.USER,
                         content=tool_result.user_injection,
-                        ephemeral=True,
+                        lifecycle=MessageLifecycle(
+                            persistence_mode=PersistenceMode.DROP,
+                        ),
                     )
                 )
         return events, tool_messages + injection_messages

--- a/services/wisepen-chat-service/src/chat/application/skill_cache_refresher.py
+++ b/services/wisepen-chat-service/src/chat/application/skill_cache_refresher.py
@@ -8,7 +8,7 @@ from chat.application.skill_matcher import SkillMatcher
 
 class SkillCacheRefresher:
     """
-    Skill matcher 缓存的刷新调度器
+    Skill metadata 缓存的刷新调度器
     在启动阶段触发一次 eager warmup（作为"周期刷新的第 0 次"）
     之后每 ttl_seconds 调一次 matcher.warmup()，使得用户发布的 Skill 变化能在 TTL 内被当前副本感知
     """

--- a/services/wisepen-chat-service/src/chat/application/skill_matcher.py
+++ b/services/wisepen-chat-service/src/chat/application/skill_matcher.py
@@ -10,9 +10,10 @@ from chat.domain.repositories import SkillRepository
 
 class SkillMatcher(ABC):
     """
-    Skill 预筛选接口：根据用户 query 返回可能相关的 Skill 元信息 shortlist。
+    Skill 可用清单接口：返回当前会话可展示给 LLM 的 Skill 元信息。
 
-    实现可以换成 embedding / 语义相似度，接口保持不变。
+    当前策略不再用字符串匹配预筛，而是把轻量 metadata 交给 LLM 判断是否加载。
+    接口名暂时保持 match 以减少调用方改动。
     """
 
     @abstractmethod
@@ -24,7 +25,10 @@ class SkillMatcher(ABC):
 
 class KeywordSkillMatcher(SkillMatcher):
     """
-    最简关键词预筛：大小写无关 substring 匹配 triggers，按命中数排序取 top_k。
+    可用 Skill metadata 缓存。
+
+    历史类名暂时保留以兼容容器装配；行为已经不是关键词匹配。
+    match(query) 会忽略 query，返回所有 enabled Skill 的轻量信息，让 LLM 自行决定是否调用 load_skill。
     """
 
     def __init__(self, skill_repo: SkillRepository) -> None:
@@ -38,40 +42,21 @@ class KeywordSkillMatcher(SkillMatcher):
         except Exception as e:
             # 捕获所有异常，保证服务可启动 / 周期刷新不炸
             # 失败时不擦除 self._cache，已有 last-good 继续服务，防止被 Mongo 抖动打回"无 Skill 能力"
-            log_error("Skill matcher warmup", e, had_cache=bool(self._cache))
+            log_error("Skill metadata warmup", e, had_cache=bool(self._cache))
             self._warmed = True
             return
 
-        self._cache = metas
+        self._cache = sorted(metas, key=lambda m: m.skill_id)
         self._warmed = True
-        log_event("Skill matcher warmup 完成", count=len(metas))
+        log_event("Skill metadata warmup 完成", count=len(metas))
 
     def match(self, query: str) -> List[SkillMeta]:
         if not self._cache:
             log_fail(
-                "Skill matcher",
-                "cache 为空，本次 match 返回空列表",
+                "Skill metadata",
+                "cache 为空，本次返回空列表",
             )
             return []
 
-        if not query:
-            return []
-
-        lowered = query.lower()
-        scored: List[tuple[int, SkillMeta]] = []
-        for meta in self._cache:
-            # 大小写无关 substring：同一 trigger 命中只记 1 分（去重）；命中数越多排名越高
-            hits = 0
-            for trig in meta.triggers:
-                if trig and trig.lower() in lowered:
-                    hits += 1
-            if hits > 0:
-                scored.append((hits, meta))
-
-        if not scored:
-            return []
-
-        # 先按命中数降序；命中数相同时按 skill_id 字典序稳定
-        scored.sort(key=lambda x: (-x[0], x[1].skill_id))
-        top_k = max(1, settings.SKILL_MATCH_TOP_K)
-        return [m for _, m in scored[:top_k]]
+        max_count = max(1, settings.SKILL_DISCOVERY_MAX_COUNT)
+        return self._cache[:max_count]

--- a/services/wisepen-chat-service/src/chat/application/skill_prompt_builder.py
+++ b/services/wisepen-chat-service/src/chat/application/skill_prompt_builder.py
@@ -1,0 +1,22 @@
+from chat.domain.entities.skill import Skill
+
+
+class SkillPromptBuilder:
+    """
+    Centralized prompt snippets for skill loading.
+    """
+
+    @staticmethod
+    def build_loaded_skill_prompt(skill: Skill) -> str:
+        return (
+            "[Mandatory Loaded Skill]\n"
+            f"You have loaded skill id={skill.skill_id} version={skill.version}.\n\n"
+            "This SKILL.md is mandatory for the current turn.\n"
+            "Its Scope, Output Format, and Constraints override the general assistant formatting instructions.\n"
+            "Do not answer with a general explanation.\n"
+            "Do not add an introduction, summary, score, praise, or follow-up question unless the SKILL.md explicitly requires it.\n"
+            "Before final response, silently verify that the answer follows the SKILL.md Output Format exactly.\n\n"
+            "===== SKILL.md BEGIN =====\n"
+            f"{skill.skill_md.rstrip()}\n"
+            "===== SKILL.md END ====="
+        )

--- a/services/wisepen-chat-service/src/chat/application/skill_prompt_builder.py
+++ b/services/wisepen-chat-service/src/chat/application/skill_prompt_builder.py
@@ -20,3 +20,27 @@ class SkillPromptBuilder:
             f"{skill.skill_md.rstrip()}\n"
             "===== SKILL.md END ====="
         )
+
+    @staticmethod
+    def build_loaded_skill_injection(skill: Skill) -> str:
+        lines = [
+            "<system-reminder>",
+            f"[Loaded WisePen Skill] id={skill.skill_id} version={skill.version}",
+            "This content is injected by WisePen for the current task. "
+            "Use it as operational context, but do not answer or quote this reminder directly.",
+            "",
+            SkillPromptBuilder.build_loaded_skill_prompt(skill),
+        ]
+
+        if skill.assets_manifest:
+            lines.append("")
+            lines.append(
+                "[Assets Manifest] Use load_skill_asset only if the loaded SKILL.md explicitly requires supporting assets."
+            )
+            for asset in skill.assets_manifest:
+                lines.append(
+                    f"- path={asset.path} kind={asset.kind} size={asset.size_bytes} - {asset.description}"
+                )
+
+        lines.append("</system-reminder>")
+        return "\n".join(lines)

--- a/services/wisepen-chat-service/src/chat/application/tools/check_loaded_files.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/check_loaded_files.py
@@ -1,0 +1,106 @@
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+LoadedFileKey = tuple[str, str]
+
+
+def _already_loaded_response(
+    *,
+    message: str,
+    file_type: str,
+    file_id: str,
+    file_path: str,
+) -> str:
+    return json.dumps(
+        {
+            "message": message,
+            "file_type": file_type,
+            "file_id": file_id,
+            "file_path": file_path,
+        },
+        ensure_ascii=False,
+    )
+
+
+@dataclass(frozen=True)
+class LoadedFileCheckResult:
+    already_loaded: bool
+    response: str | None
+    file_type: str
+    file_id: str
+    file_path: str
+    _loaded_key: LoadedFileKey
+    _turn_loaded: set[LoadedFileKey]
+    _recorded_turn: bool
+
+    def rollback(self) -> None:
+        if self._recorded_turn:
+            self._turn_loaded.discard(self._loaded_key)
+
+
+def _check_and_record(
+    *,
+    turn_loaded: set[LoadedFileKey],
+    loaded_key: LoadedFileKey,
+    file_type: str,
+    file_id: str,
+    file_path: str,
+    message: str,
+) -> LoadedFileCheckResult:
+    already_loaded = loaded_key in turn_loaded
+    if already_loaded:
+        return LoadedFileCheckResult(
+            already_loaded=True,
+            response=_already_loaded_response(
+                message=message,
+                file_type=file_type,
+                file_id=file_id,
+                file_path=file_path,
+            ),
+            file_type=file_type,
+            file_id=file_id,
+            file_path=file_path,
+            _loaded_key=loaded_key,
+            _turn_loaded=turn_loaded,
+            _recorded_turn=False,
+        )
+
+    turn_loaded.add(loaded_key)
+    return LoadedFileCheckResult(
+        already_loaded=False,
+        response=None,
+        file_type=file_type,
+        file_id=file_id,
+        file_path=file_path,
+        _loaded_key=loaded_key,
+        _turn_loaded=turn_loaded,
+        _recorded_turn=True,
+    )
+
+
+def check_and_record_loaded_file(
+    *,
+    context: dict[str, Any],
+    file_type: str,
+    file_id: str,
+    file_path: str,
+    message: str,
+) -> LoadedFileCheckResult:
+    """
+    Check whether a file has already been loaded in the current turn, and record it
+    atomically when allowed. Cross-turn visibility is derived from the assembled
+    prompt, not from process-local session state.
+    """
+    loaded_key = (file_type, file_id)
+    turn_loaded = context.setdefault("turn_loaded_files", set())
+
+    return _check_and_record(
+        turn_loaded=turn_loaded,
+        loaded_key=loaded_key,
+        file_type=file_type,
+        file_id=file_id,
+        file_path=file_path,
+        message=message,
+    )

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_asset_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_asset_tool.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 from common.logger import log_error, log_fail
 
 from chat.core.config.app_settings import settings
+from chat.application.tools.check_loaded_files import check_and_record_loaded_file
 from chat.domain.interfaces.skill_asset_loader import SkillAssetLoader
 from chat.domain.interfaces.tool import BaseTool
 from chat.domain.repositories import SkillRepository
@@ -117,9 +118,21 @@ class LoadSkillAssetTool(BaseTool):
                 f"please contact the skill publisher."
             )
 
+        file_id = f"{skill.skill_id}@{skill.version}:{path}"
+        loaded_check = check_and_record_loaded_file(
+            context=context,
+            file_type="skill-asset",
+            file_id=file_id,
+            file_path=path,
+            message="skill asset has already loaded",
+        )
+        if loaded_check.already_loaded:
+            return loaded_check.response or ""
+
         try:
             raw = await self._skill_asset_loader.load_by_object_key(object_key)
         except Exception as e:
+            loaded_check.rollback()
             log_error(
                 "load_skill_asset 读取",
                 e,
@@ -135,6 +148,7 @@ class LoadSkillAssetTool(BaseTool):
         try:
             content = raw.decode("utf-8")
         except UnicodeDecodeError:
+            loaded_check.rollback()
             log_fail(
                 "load_skill_asset 解码",
                 "资产非 UTF-8 文本，无法直接返回给 LLM",

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_asset_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_asset_tool.py
@@ -5,7 +5,8 @@ from common.logger import log_error, log_fail
 from chat.core.config.app_settings import settings
 from chat.application.tools.check_loaded_files import check_and_record_loaded_file
 from chat.domain.interfaces.skill_asset_loader import SkillAssetLoader
-from chat.domain.interfaces.tool import BaseTool
+from chat.domain.interfaces.tool import BaseTool, ToolExecutionResult
+from chat.domain.message_lifecycle import MessageLifecycle, PersistenceMode
 from chat.domain.repositories import SkillRepository
 
 
@@ -53,10 +54,6 @@ class LoadSkillAssetTool(BaseTool):
             },
             "required": ["skill_id", "path"],
         }
-
-    @property
-    def is_ephemeral_output(self) -> bool:
-        return True
 
     @property
     def reserved(self) -> bool:
@@ -168,9 +165,14 @@ class LoadSkillAssetTool(BaseTool):
         if len(content) > settings.TOOL_RESULT_MAX_CHARS:
             content = content[: settings.TOOL_RESULT_MAX_CHARS] + "\n...[truncated]"
 
-        return (
-            f"[Loaded Asset] skill_id={skill_id} version={skill.version} path={path}\n"
-            f"===== ASSET BEGIN =====\n"
-            f"{content}\n"
-            f"===== ASSET END ====="
+        return ToolExecutionResult(
+            tool_content=(
+                f"[Loaded Asset] skill_id={skill_id} version={skill.version} path={path}\n"
+                f"===== ASSET BEGIN =====\n"
+                f"{content}\n"
+                f"===== ASSET END ====="
+            ),
+            lifecycle=MessageLifecycle(
+                persistence_mode=PersistenceMode.REDACT_CONTENT,
+            ),
         )

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
@@ -52,7 +52,7 @@ class LoadSkillTool(BaseTool):
         # 系统保留，不应被用户级 deny 屏蔽
         return True
 
-    async def execute(self, context: Dict[str, Any], **kwargs) -> str:
+    async def execute(self, context: Dict[str, Any], **kwargs) -> str | ToolExecutionResult:
         skill_id = (kwargs.get("skill_id") or "").strip()
         if not skill_id:
             return "[Tool Error] Missing required argument: skill_id."
@@ -80,8 +80,13 @@ class LoadSkillTool(BaseTool):
             return f"[Tool Error] Skill '{skill_id}' not found."
 
         # 拼接强约束 prompt + assets manifest 摘要。
-        # 完整 SKILL.md 作为本轮临时 SYSTEM 注入，不再作为 TOOL 正文返回。
+        # 完整 SKILL.md 作为本轮临时 USER reminder 注入，不再作为 TOOL 正文返回。
         lines = [
+            "<system-reminder>",
+            f"[Loaded WisePen Skill] id={skill.skill_id} version={skill.version}",
+            "This content is injected by WisePen for the current task. "
+            "Use it as operational context, but do not answer or quote this reminder directly.",
+            "",
             SkillPromptBuilder.build_loaded_skill_prompt(skill),
         ]
 
@@ -98,6 +103,6 @@ class LoadSkillTool(BaseTool):
         ack = f"[Skill loaded: {skill.skill_id} version={skill.version}]"
         return ToolExecutionResult(
             tool_content=ack,
-            system_injection="\n".join(lines),
+            user_injection="\n".join(lines) + "\n</system-reminder>",
             frontend_output=ack,
         )

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 from common.logger import log_error, log_fail
 
 from chat.application.skill_prompt_builder import SkillPromptBuilder
+from chat.application.tools.check_loaded_files import check_and_record_loaded_file
 from chat.domain.interfaces.tool import BaseTool, ToolExecutionResult
 from chat.domain.repositories import SkillRepository
 
@@ -48,6 +49,10 @@ class LoadSkillTool(BaseTool):
         return True
 
     @property
+    def restore_ephemeral_in_context(self) -> bool:
+        return True
+
+    @property
     def reserved(self) -> bool:
         # 系统保留，不应被用户级 deny 屏蔽
         return True
@@ -79,30 +84,25 @@ class LoadSkillTool(BaseTool):
         if skill is None:
             return f"[Tool Error] Skill '{skill_id}' not found."
 
-        # 拼接强约束 prompt + assets manifest 摘要。
-        # 完整 SKILL.md 作为本轮临时 USER reminder 注入，不再作为 TOOL 正文返回。
-        lines = [
-            "<system-reminder>",
-            f"[Loaded WisePen Skill] id={skill.skill_id} version={skill.version}",
-            "This content is injected by WisePen for the current task. "
-            "Use it as operational context, but do not answer or quote this reminder directly.",
-            "",
-            SkillPromptBuilder.build_loaded_skill_prompt(skill),
-        ]
-
-        if skill.assets_manifest:
-            lines.append("")
-            lines.append(
-                "[Assets Manifest] Use load_skill_asset only if the loaded SKILL.md explicitly requires supporting assets."
-            )
-            for asset in skill.assets_manifest:
-                lines.append(
-                    f"- path={asset.path} kind={asset.kind} size={asset.size_bytes} - {asset.description}"
-                )
+        file_id = f"{skill.skill_id}@{skill.version}"
+        loaded_check = check_and_record_loaded_file(
+            context=context,
+            file_type="skill",
+            file_id=file_id,
+            file_path="SKILL.md",
+            message="skill has already loaded",
+        )
+        if loaded_check.already_loaded:
+            return loaded_check.response or ""
 
         ack = f"[Skill loaded: {skill.skill_id} version={skill.version}]"
         return ToolExecutionResult(
             tool_content=ack,
-            user_injection="\n".join(lines) + "\n</system-reminder>",
+            user_injection=SkillPromptBuilder.build_loaded_skill_injection(skill),
             frontend_output=ack,
+            metadata={
+                "restore_kind": "skill",
+                "skill_id": skill.skill_id,
+                "version": skill.version,
+            },
         )

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
@@ -2,7 +2,8 @@ from typing import Any, Dict
 
 from common.logger import log_error, log_fail
 
-from chat.domain.interfaces.tool import BaseTool
+from chat.application.skill_prompt_builder import SkillPromptBuilder
+from chat.domain.interfaces.tool import BaseTool, ToolExecutionResult
 from chat.domain.repositories import SkillRepository
 
 
@@ -78,22 +79,25 @@ class LoadSkillTool(BaseTool):
         if skill is None:
             return f"[Tool Error] Skill '{skill_id}' not found."
 
-        # 拼接 header + SKILL.md + assets manifest 摘要
+        # 拼接强约束 prompt + assets manifest 摘要。
+        # 完整 SKILL.md 作为本轮临时 SYSTEM 注入，不再作为 TOOL 正文返回。
         lines = [
-            f"[Loaded Skill] id={skill.skill_id} version={skill.version}",
-            f"[Display Name] {skill.display_name}",
-            "",
-            "===== SKILL.md BEGIN =====",
-            skill.skill_md.rstrip(),
-            "===== SKILL.md END =====",
+            SkillPromptBuilder.build_loaded_skill_prompt(skill),
         ]
 
         if skill.assets_manifest:
             lines.append("")
-            lines.append("[Assets Manifest] (use load_skill_asset to open any of these)")
+            lines.append(
+                "[Assets Manifest] Use load_skill_asset only if the loaded SKILL.md explicitly requires supporting assets."
+            )
             for asset in skill.assets_manifest:
                 lines.append(
-                    f"- path={asset.path} kind={asset.kind} size={asset.size_bytes} — {asset.description}"
+                    f"- path={asset.path} kind={asset.kind} size={asset.size_bytes} - {asset.description}"
                 )
 
-        return "\n".join(lines)
+        ack = f"[Skill loaded: {skill.skill_id} version={skill.version}]"
+        return ToolExecutionResult(
+            tool_content=ack,
+            system_injection="\n".join(lines),
+            frontend_output=ack,
+        )

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
@@ -4,6 +4,7 @@ from common.logger import log_error, log_fail
 
 from chat.application.skill_prompt_builder import SkillPromptBuilder
 from chat.application.tools.check_loaded_files import check_and_record_loaded_file
+from chat.domain.message_lifecycle import MessageLifecycle, PersistenceMode, RestoreRef
 from chat.domain.interfaces.tool import BaseTool, ToolExecutionResult
 from chat.domain.repositories import SkillRepository
 
@@ -42,15 +43,6 @@ class LoadSkillTool(BaseTool):
             },
             "required": ["skill_id"],
         }
-
-    @property
-    def is_ephemeral_output(self) -> bool:
-        # 本工具返回的消息无需持久化
-        return True
-
-    @property
-    def restore_ephemeral_in_context(self) -> bool:
-        return True
 
     @property
     def reserved(self) -> bool:
@@ -101,8 +93,14 @@ class LoadSkillTool(BaseTool):
             user_injection=SkillPromptBuilder.build_loaded_skill_injection(skill),
             frontend_output=ack,
             metadata={
-                "restore_kind": "skill",
                 "skill_id": skill.skill_id,
                 "version": skill.version,
             },
+            lifecycle=MessageLifecycle(
+                persistence_mode=PersistenceMode.PERSIST_CONTENT,
+                restore_ref=RestoreRef(
+                    kind="skill",
+                    data={"skill_id": skill.skill_id, "version": skill.version},
+                ),
+            ),
         )

--- a/services/wisepen-chat-service/src/chat/application/tools/search_history_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/search_history_tool.py
@@ -23,11 +23,15 @@ class SearchHistoricalMessagesTool(BaseTool):
     @property
     def description(self) -> str:
         return (
-            "Search historical chat messages by keyword and optional time range. "
-            "Use this when you need to recall specific facts, events, or details "
-            "from earlier in the conversation that may not be in the current context window."
-            "NOTE that the search keyword's language should match the user's chat language; otherwise, the search may fail. If no results are found, consider switching the keyword's language."
+            "Search older messages in the current chat session only when the conversation "
+            "has been compressed and the user explicitly asks about prior conversation history. "
+            "Do not use for general answering, writing, translation, summarization, skill execution, "
+            "or when the needed information is already present in the current context."
         )
+
+    @property
+    def reserved(self) -> bool:
+        return True
 
     @property
     def parameters_schema(self) -> Dict[str, Any]:

--- a/services/wisepen-chat-service/src/chat/application/tools/tool_scope.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/tool_scope.py
@@ -39,5 +39,9 @@ class ToolScope:
         t = self.get(name)
         return bool(t and t.is_ephemeral_output) # 未在 Scope 视图内的视为 False
 
+    def should_restore_ephemeral_in_context(self, name: str) -> bool:
+        t = self.get(name)
+        return bool(t and t.restore_ephemeral_in_context) # 未在 Scope 视图内的视为 False
+
     def __len__(self) -> int:
         return len(self._tools)

--- a/services/wisepen-chat-service/src/chat/application/tools/tool_scope.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/tool_scope.py
@@ -35,13 +35,5 @@ class ToolScope:
     def context(self) -> Dict[str, Any]:
         return dict(self._context)
 
-    def is_ephemeral(self, name: str) -> bool:
-        t = self.get(name)
-        return bool(t and t.is_ephemeral_output) # 未在 Scope 视图内的视为 False
-
-    def should_restore_ephemeral_in_context(self, name: str) -> bool:
-        t = self.get(name)
-        return bool(t and t.restore_ephemeral_in_context) # 未在 Scope 视图内的视为 False
-
     def __len__(self) -> int:
         return len(self._tools)

--- a/services/wisepen-chat-service/src/chat/container.py
+++ b/services/wisepen-chat-service/src/chat/container.py
@@ -103,7 +103,7 @@ class Container(containers.DeclarativeContainer):
         )
     else:
         skill_asset_loader = oss_skill_asset_loader
-    # KeywordSkillMatcher
+    # Skill metadata cache：保留历史类名，当前不再做关键词匹配
     skill_matcher = providers.Singleton(
         KeywordSkillMatcher,
         skill_repo=skill_repo,

--- a/services/wisepen-chat-service/src/chat/container.py
+++ b/services/wisepen-chat-service/src/chat/container.py
@@ -161,6 +161,7 @@ class Container(containers.DeclarativeContainer):
         tool_registry=tool_registry,
         kafka_producer=kafka_producer,
         skill_matcher=skill_matcher,
+        skill_repo=skill_repo,
     )
 
 

--- a/services/wisepen-chat-service/src/chat/core/config/app_settings.py
+++ b/services/wisepen-chat-service/src/chat/core/config/app_settings.py
@@ -69,7 +69,7 @@ class AppSettings(BaseModel):
 
     # Agentic ReAct 循环
     # ReAct 最大推理迭代次数，防止工具调用产生无限循环
-    AGENT_MAX_ITERATIONS: int = 5
+    AGENT_MAX_ITERATIONS: int = 10
     # 工具返回内容的字符截断上限（约 ~1000 token），防止超长结果撑爆后续迭代的上下文水位
     TOOL_RESULT_MAX_CHARS: int = 4000
 

--- a/services/wisepen-chat-service/src/chat/core/config/app_settings.py
+++ b/services/wisepen-chat-service/src/chat/core/config/app_settings.py
@@ -89,7 +89,9 @@ class AppSettings(BaseModel):
     SKILL_OSS_CACHE_TTL_SECONDS: int = 6 * 3600
     # GC 扫描周期（秒）
     SKILL_OSS_CACHE_GC_INTERVAL_SECONDS: int = 30 * 60
-    # Matcher 每轮给 LLM 暴露的 skill 候选上限（受控披露，防 LLM 误加载）
+    # 每轮给 LLM 暴露的可用 Skill metadata 上限（只含 skill_id/display_name/description，不含 SKILL.md 正文）
+    SKILL_DISCOVERY_MAX_COUNT: int = 20
+    # 旧关键词 matcher 的候选上限；保留字段兼容现有 Nacos 配置，当前主链路不再使用字符串匹配。
     SKILL_MATCH_TOP_K: int = 2
     # Skill 元数据缓存 TTL（秒）。用户/Java 端发布的新 Skill 最坏需等 TTL 才被当前副本感知。
     # 过小会增加 Mongo 读压力；过大会让新 Skill 生效滞后。

--- a/services/wisepen-chat-service/src/chat/core/providers/llm/litellm_adapter.py
+++ b/services/wisepen-chat-service/src/chat/core/providers/llm/litellm_adapter.py
@@ -85,21 +85,6 @@ class LiteLLMAdapter(LLMProvider):
         formatted_msgs = self._convert_messages(messages)
         litellm_model = self._format_model_for_litellm(model_name)
 
-        import json
-        print(
-            "[LLM 请求 payload]",
-            json.dumps(
-                {
-                    "model": litellm_model,
-                    "messages": formatted_msgs,
-                    "tools": tools,
-                },
-                ensure_ascii=False,
-                default=str,
-                indent=2,
-            ),
-            flush=True,
-        )
         try:
             response = await litellm.acompletion(
                 model=litellm_model,

--- a/services/wisepen-chat-service/src/chat/core/providers/llm/litellm_adapter.py
+++ b/services/wisepen-chat-service/src/chat/core/providers/llm/litellm_adapter.py
@@ -85,6 +85,21 @@ class LiteLLMAdapter(LLMProvider):
         formatted_msgs = self._convert_messages(messages)
         litellm_model = self._format_model_for_litellm(model_name)
 
+        import json
+        print(
+            "[LLM 请求 payload]",
+            json.dumps(
+                {
+                    "model": litellm_model,
+                    "messages": formatted_msgs,
+                    "tools": tools,
+                },
+                ensure_ascii=False,
+                default=str,
+                indent=2,
+            ),
+            flush=True,
+        )
         try:
             response = await litellm.acompletion(
                 model=litellm_model,

--- a/services/wisepen-chat-service/src/chat/domain/entities/message.py
+++ b/services/wisepen-chat-service/src/chat/domain/entities/message.py
@@ -6,6 +6,8 @@ from beanie import Document, PydanticObjectId
 from pydantic import Field, ConfigDict
 from pymongo import IndexModel, ASCENDING
 
+from chat.domain.message_lifecycle import MessageLifecycle
+
 
 class Role(str, Enum):
     SYSTEM = "system"
@@ -30,10 +32,7 @@ class ChatMessage(Document):
     tool_call_id: Optional[str] = None
     name: Optional[str] = None
 
-    # 仅本轮工作内可见标识
-    # True 时可对 ASSISTANT 消息整条丢弃、对 TOOL 消息 content 置换为占位符
-    # 确保 Skill 等脚手架内容不污染 durable 历史
-    ephemeral: bool = False
+    lifecycle: MessageLifecycle = Field(default_factory=MessageLifecycle)
 
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 

--- a/services/wisepen-chat-service/src/chat/domain/entities/skill.py
+++ b/services/wisepen-chat-service/src/chat/domain/entities/skill.py
@@ -30,7 +30,7 @@ class Skill(Document):
     description: str = Field(..., description="一句话说明本 Skill 的场景与目的")
     triggers: List[str] = Field(default_factory=list, description="关键词列表，供 KeywordSkillMatcher 大小写无关 substring 匹配")
 
-    skill_md: str = Field(..., description="发布时 SKILL.md 正文快照（含 frontmatter 去掉 --- 后的 body）")
+    skill_md: str = Field(..., description="发布时 SKILL.md 完整正文快照（含 frontmatter）")
     skill_md_object_key: str = Field(..., description="SKILL.md 在 OSS 的权威副本 object_key")
     assets_manifest: List[SkillAssetMeta] = Field(default_factory=list, description="附件清单，LLM 看得到的只有这一层")
 

--- a/services/wisepen-chat-service/src/chat/domain/entities/skill.py
+++ b/services/wisepen-chat-service/src/chat/domain/entities/skill.py
@@ -28,7 +28,7 @@ class Skill(Document):
     skill_id: str = Field(..., description="唯一 slug，如 'paper-translation'；工具参数、日志、权限校验都只用这个")
     display_name: str = Field(..., description="展示名，如 'Paper Translation'，仅用于日志和可能的 UI 列表")
     description: str = Field(..., description="一句话说明本 Skill 的场景与目的")
-    triggers: List[str] = Field(default_factory=list, description="关键词列表，供 KeywordSkillMatcher 大小写无关 substring 匹配")
+    triggers: List[str] = Field(default_factory=list, description="历史关键词列表；当前主链路不再依赖字符串匹配激活 Skill")
 
     skill_md: str = Field(..., description="发布时 SKILL.md 完整正文快照（含 frontmatter）")
     skill_md_object_key: str = Field(..., description="SKILL.md 在 OSS 的权威副本 object_key")

--- a/services/wisepen-chat-service/src/chat/domain/interfaces/__init__.py
+++ b/services/wisepen-chat-service/src/chat/domain/interfaces/__init__.py
@@ -1,11 +1,12 @@
 from .llm import LLMProvider
 from .memory import MemoryProvider
-from .tool import BaseTool
+from .tool import BaseTool, ToolExecutionResult
 from .skill_asset_loader import SkillAssetLoader
 
 __all__ = [
     "LLMProvider",
     "MemoryProvider",
     "BaseTool",
+    "ToolExecutionResult",
     "SkillAssetLoader",
 ]

--- a/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
+++ b/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
@@ -1,7 +1,9 @@
 # src/chat/domain/interfaces/tool.py
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Any, Optional, Union
+
+from chat.domain.message_lifecycle import MessageLifecycle
 
 
 @dataclass(frozen=True)
@@ -14,6 +16,7 @@ class ToolExecutionResult:
     user_injection: Optional[str] = None
     frontend_output: Optional[Any] = None
     metadata: Optional[Dict[str, Any]] = None
+    lifecycle: MessageLifecycle = field(default_factory=MessageLifecycle)
 
 
 class BaseTool(ABC):
@@ -28,25 +31,6 @@ class BaseTool(ABC):
     @property
     @abstractmethod
     def parameters_schema(self) -> Dict[str, Any]: pass
-
-    @property
-    def is_ephemeral_output(self) -> bool:
-        """
-        True 表示本工具的输出属于"仅本轮工作内可见"的脚手架（如 Skill 正文加载）
-        QueryLoopRuntime 会把对应 TOOL 消息标 ephemeral=True
-        ChatTurnFinalizer 在持久化前会将其 content 置换为占位符以防上下文膨胀
-        False 表示本工具的输出属于对话事实，应进入 durable 历史
-        """
-        return False
-
-    @property
-    def restore_ephemeral_in_context(self) -> bool:
-        """
-        True 表示该工具的 ephemeral 注入内容在持久化时不会落库，
-        但后续拼接历史上下文时应根据持久化的 TOOL ack 恢复对应注入。
-        默认不恢复；例如 load_skill 需要恢复 SKILL.md，load_skill_asset 不需要恢复。
-        """
-        return False
 
     @property
     def reserved(self) -> bool:

--- a/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
+++ b/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
@@ -13,6 +13,7 @@ class ToolExecutionResult:
     tool_content: str
     user_injection: Optional[str] = None
     frontend_output: Optional[Any] = None
+    metadata: Optional[Dict[str, Any]] = None
 
 
 class BaseTool(ABC):
@@ -35,6 +36,15 @@ class BaseTool(ABC):
         QueryLoopRuntime 会把对应 TOOL 消息标 ephemeral=True
         ChatTurnFinalizer 在持久化前会将其 content 置换为占位符以防上下文膨胀
         False 表示本工具的输出属于对话事实，应进入 durable 历史
+        """
+        return False
+
+    @property
+    def restore_ephemeral_in_context(self) -> bool:
+        """
+        True 表示该工具的 ephemeral 注入内容在持久化时不会落库，
+        但后续拼接历史上下文时应根据持久化的 TOOL ack 恢复对应注入。
+        默认不恢复；例如 load_skill 需要恢复 SKILL.md，load_skill_asset 不需要恢复。
         """
         return False
 

--- a/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
+++ b/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
@@ -1,6 +1,18 @@
 # src/chat/domain/interfaces/tool.py
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from dataclasses import dataclass
+from typing import Dict, Any, Optional, Union
+
+
+@dataclass(frozen=True)
+class ToolExecutionResult:
+    """
+    Structured tool result used when a tool needs to separate protocol-facing
+    tool content from control-plane system instructions.
+    """
+    tool_content: str
+    system_injection: Optional[str] = None
+    frontend_output: Optional[Any] = None
 
 
 class BaseTool(ABC):
@@ -49,7 +61,7 @@ class BaseTool(ABC):
         }
 
     @abstractmethod
-    async def execute(self, context: Dict[str, Any], **kwargs) -> str:
+    async def execute(self, context: Dict[str, Any], **kwargs) -> Union[str, ToolExecutionResult]:
         """
         执行工具逻辑。
         :param context: 系统强注入的安全上下文（session_id、user_id 等），

--- a/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
+++ b/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
@@ -8,10 +8,10 @@ from typing import Dict, Any, Optional, Union
 class ToolExecutionResult:
     """
     Structured tool result used when a tool needs to separate protocol-facing
-    tool content from control-plane system instructions.
+    tool content from turn-local control-plane instructions.
     """
     tool_content: str
-    system_injection: Optional[str] = None
+    user_injection: Optional[str] = None
     frontend_output: Optional[Any] = None
 
 

--- a/services/wisepen-chat-service/src/chat/domain/message_lifecycle.py
+++ b/services/wisepen-chat-service/src/chat/domain/message_lifecycle.py
@@ -1,0 +1,27 @@
+from enum import Enum
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LLMVisibility(str, Enum):
+    INCLUDE = "include"
+    EXCLUDE = "exclude"
+
+
+class PersistenceMode(str, Enum):
+    PERSIST_FULL = "persist_full"
+    DROP = "drop"
+    REDACT_CONTENT = "redact_content"
+    PERSIST_CONTENT = "persist_content"
+
+
+class RestoreRef(BaseModel):
+    kind: str
+    data: Dict[str, str] = Field(default_factory=dict)
+
+
+class MessageLifecycle(BaseModel):
+    llm_visibility: LLMVisibility = LLMVisibility.INCLUDE
+    persistence_mode: PersistenceMode = PersistenceMode.PERSIST_FULL
+    restore_ref: Optional[RestoreRef] = None

--- a/services/wisepen-chat-service/src/chat/scripts/seed_demo_skills.py
+++ b/services/wisepen-chat-service/src/chat/scripts/seed_demo_skills.py
@@ -186,9 +186,10 @@ async def _main() -> None:
     mongo_url = os.environ.get(
         "SEED_MONGO_URL", "mongodb://root:root@localhost:27017/"
     )
+    mongo_db_name = os.environ.get("SEED_MONGO_DB_NAME", "wisepen_chat")
     mongo_client = AsyncMongoClient(mongo_url)
     await init_beanie(
-        database=mongo_client["wisepen_chat"],
+        database=mongo_client[mongo_db_name],
         document_models=[Skill],
     )
 
@@ -200,7 +201,7 @@ async def _main() -> None:
             await _seed_one_bundle(version_dir, skill_id=skill_id, version=version)
             seeded += 1
 
-    log_event("seed_demo_skills: 完成", bundles=seeded, root=str(root))
+    log_event("seed_demo_skills: 完成", bundles=seeded, root=str(root), db=mongo_db_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概述

本次 PR 主要优化 Chat Service 中 Skill 的加载、上下文注入、文件生命周期和前端消息转换逻辑，使 Skill 相关上下文更可控，并减少重复加载与无效持久化。

## 主要改动

- 新增多组学术写作诊断相关 Skills，包括 introduction、method、discussion、conclusion、reference use 和 academic format。
- 调整 Skill 加载机制，引入消息生命周期标签，区分临时上下文与需要持久化的对话消息。
- 新增 `message_lifecycle.py`，统一管理 ephemeral 等消息生命周期字段。
- 优化 Skill prompt 构建逻辑，约束 `references/` 和 `assets/` 的使用方式。
- 新增已加载文件检查工具，避免重复读取已经加载过的文件。
- 调整文件生命周期策略，不再持久化 Skill 和 Skill assets。
- 收紧历史搜索工具逻辑，仅在压缩上下文后存储。
- 新增 Markdown 和 LaTeX 输出相关系统提示词。
- 修复前端 UI message 转换中 tool call function 字段读取错误的问题。

## 影响范围

- Chat 上下文组装与消息持久化逻辑
- Skill 加载与 Skill assets 读取逻辑
- 前端 UIMessage 的 tool call 渲染数据
- Demo skills 初始化数据
