### PR TITLE
feat(chat): 优化 Skill 加载与消息生命周期管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ ENV/
 # 操作系统
 .DS_Store
 Thumbs.db
+
+# json
+origin_text.txt
+json_text.txt
+to_json.py

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,4 @@ ENV/
 Thumbs.db
 
 # json
-origin_text.txt
-json_text.txt
-to_json.py
+/zyq

--- a/services/wisepen-chat-service/src/chat/api/converters/ui_message_converter.py
+++ b/services/wisepen-chat-service/src/chat/api/converters/ui_message_converter.py
@@ -95,9 +95,10 @@ def _build_assistant_ui_message(group: List[ChatMessage]) -> Optional[Dict[str, 
 
             if msg.tool_calls:
                 for tc in msg.tool_calls:
-                    tool_name = tc.get("function", {}).get_published_skill("name")
+                    function = tc.get("function") or {}
+                    tool_name = function.get("name")
                     tool_call_id = tc.get("id", "")
-                    raw_args = tc.get("function", {}).get_published_skill("arguments")
+                    raw_args = function.get("arguments")
                     try:
                         parsed_input = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
                     except (json.JSONDecodeError, TypeError):

--- a/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
@@ -109,7 +109,7 @@ class ChatContextAssembler:
         2. Contextual Grounding: Base your answers ONLY on the `<retrieved_context>`. Do not introduce outside information or hallucinate facts. 
         3. Handling Unknowns: If the provided context does not contain the information needed to answer the question, clearly and politely state that you do not have enough information, rather than guessing.
         4. Tone: Maintain a professional, encouraging, and clear tone suitable for users of an advanced educational and productivity tool.
-        5. Formatting: Use Markdown (e.g., bullet points, bold text, code blocks) to structure your response for maximum readability.
+        5. Formatting: Use Markdown to structure your response for readability unless a loaded skill specifies a stricter output format. If a loaded skill specifies an Output Format or Constraints section, follow the loaded skill exactly.
         """ # 全局指令
 
         # 如果有从 Mem0 召回的相关事实，作为补充信息拼接到 System Prompt 中

--- a/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
@@ -1,10 +1,17 @@
+import re
 from typing import Any, Dict, List, Optional, Tuple
 from common.logger import log_fail, log_error
 
 from chat.core.config.app_settings import settings
+from chat.application.skill_prompt_builder import SkillPromptBuilder
 from chat.domain.entities import ChatMessage, Role, ChatSession
 from chat.domain.entities.skill import SkillMeta
-from chat.domain.repositories import MessageRepository, HotContextRepository, SessionRepository
+from chat.domain.repositories import MessageRepository, HotContextRepository, SessionRepository, SkillRepository
+
+
+_SKILL_LOADED_ACK_RE = re.compile(
+    r"^\[Skill loaded:\s*(?P<skill_id>[^\s\]]+)\s+version=(?P<version>[^\]]+)\]$"
+)
 
 
 class ChatContextAssembler:
@@ -15,10 +22,12 @@ class ChatContextAssembler:
         message_repo: MessageRepository,
         session_repo: SessionRepository,
         hot_context_repo: HotContextRepository,
+        skill_repo: SkillRepository,
     ):
         self.message_repo = message_repo
         self.session_repo = session_repo
         self.hot_context_repo = hot_context_repo
+        self.skill_repo = skill_repo
 
     async def get_or_repopulate_hot_context(self, session_id: str) -> List[ChatMessage]:
         """
@@ -85,6 +94,75 @@ class ChatContextAssembler:
         needs_compression = total_token >= high_budget # 由于高水位线（如 80%）预留了安全 Buffer，即便把它们全发给模型，也不会触发 Token 溢出报错
 
         return messages_keep, messages_compress_candidates, needs_compression
+
+    @staticmethod
+    def _extract_restorable_skill(msg: ChatMessage) -> Optional[Tuple[str, Optional[str]]]:
+        if msg.role != Role.TOOL:
+            return None
+
+        metadata = msg.metadata or {}
+        if metadata.get("restore_ephemeral_in_context"):
+            skill_id = metadata.get("skill_id")
+            version = metadata.get("version")
+            if skill_id:
+                return str(skill_id), str(version) if version else None
+
+        # 兼容旧数据：历史记录可能没有 metadata，甚至 name 写错，但保留了 load_skill ack。
+        content = (msg.content or "").strip()
+        match = _SKILL_LOADED_ACK_RE.match(content)
+        if match:
+            return match.group("skill_id"), match.group("version")
+
+        return None
+
+    async def restore_ephemeral_context_injections(
+        self,
+        session_id: str,
+        windowed_messages: List[ChatMessage],
+    ) -> List[ChatMessage]:
+        """
+        持久化历史只保存 load_skill 的短 ack，不保存 SKILL.md 正文。
+        每次组装上下文时，遇到需要恢复的 TOOL ack，就在其后补回正式 load_skill 同款 USER 注入。
+        """
+        restored: List[ChatMessage] = []
+        for msg in windowed_messages:
+            restored.append(msg)
+            skill_ref = self._extract_restorable_skill(msg)
+            if not skill_ref:
+                continue
+
+            skill_id, expected_version = skill_ref
+            try:
+                skill = await self.skill_repo.get_published_skill(skill_id)
+            except Exception as e:
+                log_error("恢复 Skill 上下文", e, session=session_id, skill_id=skill_id)
+                continue
+            if skill is None:
+                log_fail("恢复 Skill 上下文", "skill 不存在", session=session_id, skill_id=skill_id)
+                continue
+            if expected_version and skill.version != expected_version:
+                log_fail(
+                    "恢复 Skill 上下文",
+                    "skill 版本与历史 ack 不一致，使用当前发布版本恢复",
+                    session=session_id,
+                    skill_id=skill_id,
+                    expected_version=expected_version,
+                    actual_version=skill.version,
+                )
+
+            restored.append(ChatMessage(
+                session_id=session_id,
+                role=Role.USER,
+                content=SkillPromptBuilder.build_loaded_skill_injection(skill),
+                metadata={
+                    "restored_from_tool_call_id": msg.tool_call_id,
+                    "restored_skill_id": skill.skill_id,
+                    "restored_skill_version": skill.version,
+                },
+                ephemeral=True,
+            ))
+
+        return restored
 
     def assemble_prompt(
         self,

--- a/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
@@ -6,6 +6,7 @@ from chat.core.config.app_settings import settings
 from chat.application.skill_prompt_builder import SkillPromptBuilder
 from chat.domain.entities import ChatMessage, Role, ChatSession
 from chat.domain.entities.skill import SkillMeta
+from chat.domain.message_lifecycle import MessageLifecycle, PersistenceMode
 from chat.domain.repositories import MessageRepository, HotContextRepository, SessionRepository, SkillRepository
 
 
@@ -100,10 +101,11 @@ class ChatContextAssembler:
         if msg.role != Role.TOOL:
             return None
 
-        metadata = msg.metadata or {}
-        if metadata.get("restore_ephemeral_in_context"):
-            skill_id = metadata.get("skill_id")
-            version = metadata.get("version")
+        restore_ref = (msg.metadata or {}).get("restore_ref") or {}
+        if restore_ref.get("kind") == "skill":
+            data = restore_ref.get("data") or {}
+            skill_id = data.get("skill_id")
+            version = data.get("version")
             if skill_id:
                 return str(skill_id), str(version) if version else None
 
@@ -115,7 +117,7 @@ class ChatContextAssembler:
 
         return None
 
-    async def restore_ephemeral_context_injections(
+    async def restore_context_injections(
         self,
         session_id: str,
         windowed_messages: List[ChatMessage],
@@ -159,7 +161,9 @@ class ChatContextAssembler:
                     "restored_skill_id": skill.skill_id,
                     "restored_skill_version": skill.version,
                 },
-                ephemeral=True,
+                lifecycle=MessageLifecycle(
+                    persistence_mode=PersistenceMode.DROP,
+                ),
             ))
 
         return restored
@@ -237,7 +241,9 @@ class ChatContextAssembler:
                 session_id=session_id,
                 role=Role.USER,
                 content=skill_block,
-                ephemeral=True,
+                lifecycle=MessageLifecycle(
+                    persistence_mode=PersistenceMode.DROP,
+                ),
             ))
 
         # 经过滑动窗口裁剪后的近期对话明细

--- a/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
@@ -109,8 +109,9 @@ class ChatContextAssembler:
         2. Contextual Grounding: Base your answers ONLY on the `<retrieved_context>`. Do not introduce outside information or hallucinate facts. 
         3. Handling Unknowns: If the provided context does not contain the information needed to answer the question, clearly and politely state that you do not have enough information, rather than guessing.
         4. Tone: Maintain a professional, encouraging, and clear tone suitable for users of an advanced educational and productivity tool.
-        5. Formatting: Use Markdown to structure your response for readability unless a loaded skill specifies a stricter output format. If a loaded skill specifies an Output Format or Constraints section, follow the loaded skill exactly.
-        6. System Reminders: Messages wrapped in `<system-reminder>` are WisePen-injected operational context, not the user's request. Use them to guide the current task, but do not answer or quote them directly.
+        5. Formatting: All text you output outside of tool use is displayed to the user. Output text to communicate with the user. You can use Github-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification. Use Markdown to structure your response for readability unless a loaded skill specifies a stricter output format. If a loaded skill specifies an Output Format or Constraints section, follow the loaded skill exactly.
+        6. Formula Formatting: If your output contains formulas, format them in LaTeX and wrap them with $$.
+        7. System Reminders: Messages wrapped in `<system-reminder>` are WisePen-injected operational context, not the user's request. Use them to guide the current task, but do not answer or quote them directly.
         """ # 全局指令
 
         # 如果有从 Mem0 召回的相关事实，作为补充信息拼接到 System Prompt 中

--- a/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_context_assembler.py
@@ -94,7 +94,7 @@ class ChatContextAssembler:
         relevant_facts: List[str],
         session_summary: Optional[str],
         states: Optional[List[Dict[str, Any]]] = None,
-        candidate_skills: Optional[List[SkillMeta]] = None,
+        available_skills: Optional[List[SkillMeta]] = None,
     ) -> List[ChatMessage]:
         """组装最终发往 LLM 的消息列表。"""
         system_prompt = """
@@ -110,6 +110,7 @@ class ChatContextAssembler:
         3. Handling Unknowns: If the provided context does not contain the information needed to answer the question, clearly and politely state that you do not have enough information, rather than guessing.
         4. Tone: Maintain a professional, encouraging, and clear tone suitable for users of an advanced educational and productivity tool.
         5. Formatting: Use Markdown to structure your response for readability unless a loaded skill specifies a stricter output format. If a loaded skill specifies an Output Format or Constraints section, follow the loaded skill exactly.
+        6. System Reminders: Messages wrapped in `<system-reminder>` are WisePen-injected operational context, not the user's request. Use them to guide the current task, but do not answer or quote them directly.
         """ # 全局指令
 
         # 如果有从 Mem0 召回的相关事实，作为补充信息拼接到 System Prompt 中
@@ -129,29 +130,35 @@ class ChatContextAssembler:
                 content=f"[Conversation Summary so far]:\n{session_summary}",
             ))
 
-        # Skill 候选清单：受控披露，只在 matcher 命中时注入；明确限制"仅在直接相关时加载"
+        # Skill 可用清单：只披露轻量 metadata，由 LLM 判断是否需要加载完整 SKILL.md。
         # 用 skill_id 作机器标识，description 给 LLM 做相关性判断
-        if candidate_skills:
+        if available_skills:
             skill_lines = [
-                f"- id=\"{s.skill_id}\": {s.description}" for s in candidate_skills
+                f"- id=\"{s.skill_id}\" name=\"{s.display_name}\": {s.description}" for s in available_skills
             ]
             skill_block = (
-                "[Available Skills]\n"
-                "The following skills MAY be relevant to the user's current request. "
-                "Each skill contains detailed domain instructions (SKILL.md) and possibly supporting assets.\n"
+                "<system-reminder>\n"
+                "[Available WisePen Skills]\n"
+                "The following skills are available in this conversation as lightweight metadata. "
+                "Each skill contains detailed domain instructions (SKILL.md) and possibly supporting assets, "
+                "but the full content is not loaded yet.\n"
                 "Strict rules:\n"
-                "1. Load a skill ONLY when it is DIRECTLY required to fulfill the current request. Do not load speculatively.\n"
-                "2. To load, call the tool `load_skill` with `skill_id` exactly as listed below.\n"
-                "3. After loading, follow the SKILL.md instructions precisely. "
+                "1. If the user explicitly asks to use one of the listed skills by id or name, call `load_skill` for that skill.\n"
+                "2. Otherwise, decide from the user's request whether any listed skill is directly useful. "
+                "Load a skill only when it is needed to fulfill the current request; do not load speculatively.\n"
+                "3. To load, call the tool `load_skill` with `skill_id` exactly as listed below.\n"
+                "4. After loading, follow the SKILL.md instructions precisely. "
                 "Use `load_skill_asset` to open a specific reference/template only if SKILL.md explicitly says to.\n"
-                "4. If none of the skills apply, simply ignore this list and answer normally.\n\n"
+                "5. If none of the skills apply, ignore this list and answer normally.\n\n"
                 "Skills:\n"
                 + "\n".join(skill_lines)
+                + "\n</system-reminder>"
             )
             messages.append(ChatMessage(
                 session_id=session_id,
-                role=Role.SYSTEM,
+                role=Role.USER,
                 content=skill_block,
+                ephemeral=True,
             ))
 
         # 经过滑动窗口裁剪后的近期对话明细

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -129,7 +129,7 @@ class ChatTurnCoordinator:
             if precomputed_summary is None:
                 candidate_window = compress_block + candidate_window
 
-            restored_window_messages = await self._context_assembler.restore_ephemeral_context_injections(
+            restored_window_messages = await self._context_assembler.restore_context_injections(
                 session_id,
                 candidate_window,
             )

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -24,7 +24,7 @@ from common.kafka.producer import KafkaProducerClient
 
 
 # Skill 脚手架工具的名字集合：Registry 内部它们 reserved=True 默认隐藏
-# 只有 skill 命中时 Coordinator 把本集合作为 `expose` 传入 derive()，从而解禁 schema
+# 只有存在可用 skill 时 Coordinator 把本集合作为 `expose` 传入 derive()，从而解禁 schema
 _SKILL_TOOL_NAMES = frozenset({"load_skill", "load_skill_asset"})
 
 
@@ -111,17 +111,17 @@ class ChatTurnCoordinator:
             "user_id": user_id,
         } 
 
-        # [Skill Match] 预筛当前 query 可能相关的 Skill，命中才暴露 schema + 注入 Available Skills
-        candidate_skills = self._skill_matcher.match(user_query)
-        print(candidate_skills)
+        # [Skill Discovery] 注入当前会话可用 Skill 的轻量 metadata，由 LLM 决定是否调用 load_skill。
+        # 不再用字符串 triggers 预筛，避免关键词未命中导致 Skill 无法被模型看见。
+        available_skills = self._skill_matcher.match(user_query)
         expose_tool_name_set = None
-        if candidate_skills:
+        if available_skills:
             # 解禁 Registry 里默认隐藏的 skill 脚手架工具（reserved=True）
             expose_tool_name_set = set(_SKILL_TOOL_NAMES)
-            tool_context["allowed_skill_ids"] = [s.skill_id for s in candidate_skills]
+            tool_context["allowed_skill_ids"] = [s.skill_id for s in available_skills]
 
         # [Tool Scope] 派生本请求的工具视图快照
-        # expose_tool_name_set 仅在 skill 命中时解禁 load_skill 系列，未命中时它们保持隐藏
+        # expose_tool_name_set 仅在存在可用 skill 时解禁 load_skill 系列，否则它们保持隐藏
         # runtime_discovered_tools 预留给"运行时动态发现的工具"（如 Skill bundle 自带 tools），暂时留空
         # allow_tool_name_set/deny_tool_name_set 预留给未来"用户级工具偏好"接入，暂时留空
         tool_scope = self._tool_registry.derive(
@@ -137,7 +137,7 @@ class ChatTurnCoordinator:
         messages_for_llm = self._context_assembler.assemble_prompt(
             session_id, user_query, messages_keep+messages_compress_candidates, relevant_facts, session_summary,
             states=states,
-            candidate_skills=candidate_skills or None,
+            available_skills=available_skills or None,
         )
 
         # 记录进入 Agent 循环前的列表长度

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -26,6 +26,7 @@ from common.kafka.producer import KafkaProducerClient
 # Skill 脚手架工具的名字集合：Registry 内部它们 reserved=True 默认隐藏
 # 只有存在可用 skill 时 Coordinator 把本集合作为 `expose` 传入 derive()，从而解禁 schema
 _SKILL_TOOL_NAMES = frozenset({"load_skill", "load_skill_asset"})
+_HISTORY_SEARCH_TOOL_NAMES = frozenset({"search_historical_messages"})
 
 
 class ChatTurnCoordinator:
@@ -114,14 +115,22 @@ class ChatTurnCoordinator:
         # [Skill Discovery] 注入当前会话可用 Skill 的轻量 metadata，由 LLM 决定是否调用 load_skill。
         # 不再用字符串 triggers 预筛，避免关键词未命中导致 Skill 无法被模型看见。
         available_skills = self._skill_matcher.match(user_query)
-        expose_tool_name_set = None
+        expose_tool_name_set = set()
         if available_skills:
             # 解禁 Registry 里默认隐藏的 skill 脚手架工具（reserved=True）
-            expose_tool_name_set = set(_SKILL_TOOL_NAMES)
+            expose_tool_name_set.update(_SKILL_TOOL_NAMES)
             tool_context["allowed_skill_ids"] = [s.skill_id for s in available_skills]
 
+        # 历史搜索工具默认隐藏。只有当前会话已经有摘要（说明早期明细发生过压缩）时，
+        # 才解禁给模型，避免短会话/未压缩会话里频繁冗余检索。
+        history_search_disabled = not bool(session_summary)
+        if not history_search_disabled:
+            expose_tool_name_set.update(_HISTORY_SEARCH_TOOL_NAMES)
+
+        expose_tool_name_set = expose_tool_name_set or None
+
         # [Tool Scope] 派生本请求的工具视图快照
-        # expose_tool_name_set 仅在存在可用 skill 时解禁 load_skill 系列，否则它们保持隐藏
+        # expose_tool_name_set 仅在满足系统条件时解禁 reserved 工具，否则它们保持隐藏
         # runtime_discovered_tools 预留给"运行时动态发现的工具"（如 Skill bundle 自带 tools），暂时留空
         # allow_tool_name_set/deny_tool_name_set 预留给未来"用户级工具偏好"接入，暂时留空
         tool_scope = self._tool_registry.derive(

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional, List, Dict, Any
 from beanie import PydanticObjectId
 from fastapi import BackgroundTasks
@@ -5,9 +7,10 @@ from common.logger import log_error, log_ok
 
 from chat.core.config.app_settings import settings
 from chat.domain.entities import ChatMessage, Role
+from chat.domain.error_codes import ChatErrorCode
 from chat.domain.interfaces.llm import LLMProvider
 from chat.domain.interfaces.memory import MemoryProvider
-from chat.domain.repositories import SessionRepository, MessageRepository, HotContextRepository, ModelRepository, ProviderRepository
+from chat.domain.repositories import SessionRepository, MessageRepository, HotContextRepository, ModelRepository, ProviderRepository, SkillRepository
 from common.core.exceptions import ServiceException
 from chat.application.chat_context_assembler import ChatContextAssembler
 from chat.application.query_loop_runtime import (
@@ -29,6 +32,14 @@ _SKILL_TOOL_NAMES = frozenset({"load_skill", "load_skill_asset"})
 _HISTORY_SEARCH_TOOL_NAMES = frozenset({"search_historical_messages"})
 
 
+@dataclass(frozen=True)
+class PromptAssemblyResult:
+    messages_for_llm: List[ChatMessage]
+    messages_keep_for_hot_context: List[ChatMessage]
+    precomputed_summary: Optional[str]
+    summary_updated_at: Optional[datetime]
+
+
 class ChatTurnCoordinator:
     """
     Chat协调器：负责编排聊天流程中的各个环节，包含上下文管理、LLM ReAct、记忆更新等。
@@ -47,13 +58,18 @@ class ChatTurnCoordinator:
             tool_registry: ToolRegistry,
             kafka_producer: KafkaProducerClient,
             skill_matcher: SkillMatcher,
+            skill_repo: SkillRepository,
     ):
         self._memory = memory
         self._model_repo = model_repo
         self._context_assembler = ChatContextAssembler(
-            message_repo=message_repo, session_repo=session_repo, hot_context_repo=hot_context_repo
+            message_repo=message_repo,
+            session_repo=session_repo,
+            hot_context_repo=hot_context_repo,
+            skill_repo=skill_repo,
         )
         self._tool_registry = tool_registry
+        self._llm = llm
         self._query_loop_runtime = QueryLoopRuntime(llm=llm)
         self._turn_finalizer = ChatTurnFinalizer(
             llm=llm, memory=memory,
@@ -62,6 +78,118 @@ class ChatTurnCoordinator:
             kafka_producer=kafka_producer
         )
         self._skill_matcher = skill_matcher
+
+    @staticmethod
+    def _group_history_messages(messages: List[ChatMessage]) -> List[List[ChatMessage]]:
+        groups: List[List[ChatMessage]] = []
+        current: List[ChatMessage] = []
+        for msg in sorted(messages, key=lambda m: m.created_at):
+            if msg.role == Role.USER and current:
+                groups.append(current)
+                current = [msg]
+            else:
+                current.append(msg)
+        if current:
+            groups.append(current)
+        return groups
+
+    async def _count_final_prompt_tokens(
+        self,
+        messages: List[ChatMessage],
+        tool_schemas: List[Dict[str, Any]],
+        model_name: str,
+    ) -> int:
+        text = QueryLoopRuntime._serialize_prompt_for_counting(messages, tool_schemas)
+        return await self._llm.count_tokens(text, model_name)
+
+    async def _assemble_prompt_with_final_budget(
+        self,
+        *,
+        session_id: str,
+        user_query: str,
+        messages_keep: List[ChatMessage],
+        messages_compress_candidates: List[ChatMessage],
+        relevant_facts: List[str],
+        session_summary: Optional[str],
+        states: Optional[List[Dict[str, Any]]],
+        available_skills,
+        tool_scope,
+        model_name: str,
+        prompt_budget_tokens: int,
+    ) -> PromptAssemblyResult:
+        keep_groups = self._group_history_messages(messages_keep)
+        compress_block = sorted(messages_compress_candidates, key=lambda m: m.created_at)
+        precomputed_summary: Optional[str] = None
+        summary_updated_at: Optional[datetime] = None
+        tool_schemas = tool_scope.schemas()
+
+        while True:
+            candidate_window = [msg for group in keep_groups for msg in group]
+            summary_for_prompt = precomputed_summary or session_summary
+            if precomputed_summary is None:
+                candidate_window = compress_block + candidate_window
+
+            restored_window_messages = await self._context_assembler.restore_ephemeral_context_injections(
+                session_id,
+                candidate_window,
+            )
+            messages_for_llm = self._context_assembler.assemble_prompt(
+                session_id,
+                user_query,
+                restored_window_messages,
+                relevant_facts,
+                summary_for_prompt,
+                states=states,
+                available_skills=available_skills or None,
+            )
+            token_count = await self._count_final_prompt_tokens(
+                messages_for_llm,
+                tool_schemas,
+                model_name,
+            )
+            if token_count <= prompt_budget_tokens:
+                return PromptAssemblyResult(
+                    messages_for_llm=messages_for_llm,
+                    messages_keep_for_hot_context=candidate_window,
+                    precomputed_summary=precomputed_summary,
+                    summary_updated_at=summary_updated_at,
+                )
+
+            if not compress_block and keep_groups:
+                compress_block.extend(keep_groups.pop(0))
+            elif precomputed_summary is not None and keep_groups:
+                compress_block.extend(keep_groups.pop(0))
+            elif precomputed_summary is not None:
+                raise ServiceException(
+                    ChatErrorCode.CONTEXT_LIMIT_EXCEEDED,
+                    custom_msg=(
+                        "最终提示词在压缩全部可压缩历史后仍超出模型上下文预算，"
+                        f"tokens={token_count}, budget={prompt_budget_tokens}"
+                    ),
+                )
+            elif not compress_block:
+                raise ServiceException(
+                    ChatErrorCode.CONTEXT_LIMIT_EXCEEDED,
+                    custom_msg=(
+                        "最终提示词在没有可压缩历史明细后仍超出模型上下文预算，"
+                        f"tokens={token_count}, budget={prompt_budget_tokens}"
+                    ),
+                )
+
+            precomputed_summary = await self._turn_finalizer.generate_updated_summary(
+                session_id=session_id,
+                messages_compress_candidates=compress_block,
+                existing_summary=session_summary,
+            )
+            if not precomputed_summary:
+                raise ServiceException(
+                    ChatErrorCode.CONTEXT_LIMIT_EXCEEDED,
+                    custom_msg=(
+                        "最终提示词超出模型上下文预算，且同步摘要生成失败，"
+                        f"tokens={token_count}, budget={prompt_budget_tokens}"
+                    ),
+                )
+            summary_updated_at = max(m.created_at for m in compress_block)
 
     # -------------------------------------------------------------------------
     # 公共入口
@@ -110,6 +238,7 @@ class ChatTurnCoordinator:
         tool_context: dict[str, Any] = {
             "session_id": session_id,
             "user_id": user_id,
+            "turn_loaded_files": set(),
         } 
 
         # [Skill Discovery] 注入当前会话可用 Skill 的轻量 metadata，由 LLM 决定是否调用 load_skill。
@@ -143,11 +272,20 @@ class ChatTurnCoordinator:
         )
 
         # [Context Construction] 将系统提示词、Mem0 检索到的事实、会话的历史摘要、前端上下文以及窗口内的明细消息组装成 LLM 所需的格式
-        messages_for_llm = self._context_assembler.assemble_prompt(
-            session_id, user_query, messages_keep+messages_compress_candidates, relevant_facts, session_summary,
+        prompt_assembly = await self._assemble_prompt_with_final_budget(
+            session_id=session_id,
+            user_query=user_query,
+            messages_keep=messages_keep,
+            messages_compress_candidates=messages_compress_candidates,
+            relevant_facts=relevant_facts,
+            session_summary=session_summary,
             states=states,
-            available_skills=available_skills or None,
+            available_skills=available_skills,
+            tool_scope=tool_scope,
+            model_name=resolved.model_name,
+            prompt_budget_tokens=prompt_budget_tokens,
         )
+        messages_for_llm = prompt_assembly.messages_for_llm
 
         # 记录进入 Agent 循环前的列表长度
         original_msg_count = len(messages_for_llm)
@@ -170,6 +308,7 @@ class ChatTurnCoordinator:
                 model_id=resolved.model_id,
                 api_base=resolved.api_base_url,
                 api_key=resolved.api_key,
+                prompt_budget_tokens=prompt_budget_tokens,
             ):
                 # QueryLoopRuntime 只产出领域事件；这里按需累加纯文本，并把事件翻译为 Vercel SSE 字符串
                 if isinstance(event, StepStartEvent):
@@ -200,20 +339,31 @@ class ChatTurnCoordinator:
 
             messages_to_persist = [user_msg] + intermediate_messages + [assistant_msg]
 
-            background_tasks.add_task(
-                self._turn_finalizer.persist_all,
-                user_id, session_id, resolved,
-                messages_to_persist
-            )
+            if prompt_assembly.precomputed_summary and prompt_assembly.summary_updated_at:
+                background_tasks.add_task(
+                    self._turn_finalizer.persist_then_apply_compression_result,
+                    user_id, session_id, resolved,
+                    messages_to_persist,
+                    prompt_assembly.precomputed_summary,
+                    prompt_assembly.summary_updated_at,
+                    prompt_assembly.messages_keep_for_hot_context,
+                )
+            elif needs_compression:
+                background_tasks.add_task(
+                    self._turn_finalizer.persist_then_summarize_and_compress,
+                    user_id, session_id, resolved,
+                    messages_to_persist,
+                    messages_keep,
+                    messages_compress_candidates,
+                    session_summary,
+                )
+            else:
+                background_tasks.add_task(
+                    self._turn_finalizer.persist_all,
+                    user_id, session_id, resolved,
+                    messages_to_persist
+                )
             background_tasks.add_task(
                 self._turn_finalizer.auto_generate_title,
                 session_id, user_id, user_query
             )
-            if needs_compression:
-                background_tasks.add_task(
-                    self._turn_finalizer.summarize_and_compress,
-                    session_id,
-                    messages_keep + messages_to_persist,
-                    messages_compress_candidates,
-                    session_summary
-                )

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -113,6 +113,7 @@ class ChatTurnCoordinator:
 
         # [Skill Match] 预筛当前 query 可能相关的 Skill，命中才暴露 schema + 注入 Available Skills
         candidate_skills = self._skill_matcher.match(user_query)
+        print(candidate_skills)
         expose_tool_name_set = None
         if candidate_skills:
             # 解禁 Registry 里默认隐藏的 skill 脚手架工具（reserved=True）

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
@@ -96,7 +96,9 @@ class ChatTurnFinalizer:
         """
         Per-message 粒度的 ephemeral 处理，须在任何持久化动作之前调用一次
         - ASSISTANT 消息标 ephemeral=True：整条丢弃。
-        - TOOL 消息标 ephemeral=True：保留消息结构（tool_call_id / name 齐全）但 content 置换为占位符。
+        - SYSTEM 消息标 ephemeral=True：整条丢弃，避免临时控制指令进入 durable 历史。
+        - TOOL 消息标 ephemeral=True：默认保留消息结构（tool_call_id / name 齐全）但 content 置换为占位符。
+          若工具显式标记 preserve_ephemeral_content=True，则保留短 ack。
         
         以确保 SKILL 中 SKILL.md / asset 正文不会进入 durable 历史，后续回合也不会从 Redis / Mongo 读回污染上下文
         """
@@ -107,7 +109,12 @@ class ChatTurnFinalizer:
                 continue
             if msg.role == Role.ASSISTANT:
                 continue  # 整条丢弃
+            if msg.role == Role.SYSTEM:
+                continue  # 临时 SYSTEM 注入只服务当前 turn，不进入持久历史
             if msg.role == Role.TOOL:
+                if msg.metadata.get("preserve_ephemeral_content"):
+                    redacted.append(msg)
+                    continue
                 msg.content = (
                     f"[Redacted: ephemeral tool '{msg.name or 'unknown'}' scaffolding output]"
                 )

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
@@ -95,7 +95,6 @@ class ChatTurnFinalizer:
     def _redact_ephemeral(new_messages: List[ChatMessage]) -> List[ChatMessage]:
         """
         Per-message 粒度的 ephemeral 处理，须在任何持久化动作之前调用一次
-        - ASSISTANT 消息标 ephemeral=True：整条丢弃。
         - SYSTEM 消息标 ephemeral=True：整条丢弃，避免临时控制指令进入 durable 历史。
         - TOOL 消息标 ephemeral=True：默认保留消息结构（tool_call_id / name 齐全）但 content 置换为占位符。
           若工具显式标记 preserve_ephemeral_content=True，则保留短 ack。
@@ -132,7 +131,7 @@ class ChatTurnFinalizer:
         resolved_model: ModelRequestInfo,
         new_messages: List[ChatMessage],
         group_id: Optional[str] = None,
-    ) -> None:
+    ) -> List[ChatMessage]:
         """后台统一处理所有存储逻辑: ephemeral 裁剪 → Redis 追加 → MongoDB 落盘 → Memory 摄入 → Token 计费"""
         # 先裁剪 ephemeral，下游所有持久化都看这份结果
         persistable = self._redact_ephemeral(new_messages)
@@ -165,6 +164,7 @@ class ChatTurnFinalizer:
                                         resolved_model=resolved_model,
                                         messages=persistable,
                                         group_id=group_id)
+        return persistable
 
 
 
@@ -204,16 +204,16 @@ class ChatTurnFinalizer:
         except Exception as e:
             log_error("自动生成标题", e, session=session_id)
 
-    async def summarize_and_compress(
+    async def generate_updated_summary(
         self,
         session_id: str,
-        messages_keep: List[ChatMessage],
         messages_compress_candidates: List[ChatMessage],
         existing_summary: Optional[str],
-    ) -> None:
-        """
-        增量摘要压缩
-        """
+    ) -> Optional[str]:
+        """生成增量摘要文本；只负责调用摘要模型，不做持久化。"""
+        if not messages_compress_candidates:
+            return None
+
         # 构建摘要输入，将 existing_summary（上一轮摘要，如有）作为前缀，拼接 messages_compress_candidates 明细，让轻量模型生成覆盖范围更广的全局摘要
         oldest_text = "\n".join(
             [f"{m.role.value}: {m.content}" for m in messages_compress_candidates]
@@ -260,15 +260,31 @@ class ChatTurnFinalizer:
             new_summary = message_response.content or ""
         except Exception as e:
             log_error("摘要生成", e, session=session_id)
-            return
+            return None
 
         if not new_summary.strip():
+            return None
+
+        return new_summary
+
+    async def apply_compression_result(
+        self,
+        session_id: str,
+        current_summary: str,
+        summary_updated_at: datetime,
+        messages_keep: List[ChatMessage],
+    ) -> None:
+        """应用已生成的摘要：更新 session summary，并用保留明细重载 Redis。"""
+        if not current_summary.strip():
             return
 
         # 持久化新摘要到 MongoDB，同时写入压缩时间戳
         try:
-            await self.session_repo.update_session_summary(session_id=session_id, current_summary=new_summary,
-                                                           summary_updated_at=datetime.now(timezone.utc))
+            await self.session_repo.update_session_summary(
+                session_id=session_id,
+                current_summary=current_summary,
+                summary_updated_at=summary_updated_at,
+            )
         except Exception as e:
             log_error("摘要持久化", e, session=session_id)
 
@@ -280,3 +296,82 @@ class ChatTurnFinalizer:
             )
         except Exception as e:
             log_error("Redis 上下文重载", e, session=session_id)
+
+    async def summarize_and_compress(
+        self,
+        session_id: str,
+        messages_keep: List[ChatMessage],
+        messages_compress_candidates: List[ChatMessage],
+        existing_summary: Optional[str],
+    ) -> None:
+        """
+        增量摘要压缩
+        """
+        new_summary = await self.generate_updated_summary(
+            session_id=session_id,
+            messages_compress_candidates=messages_compress_candidates,
+            existing_summary=existing_summary,
+        )
+        if not new_summary:
+            return
+
+        summary_updated_at = max(
+            (m.created_at for m in messages_compress_candidates),
+            default=datetime.now(timezone.utc),
+        )
+        await self.apply_compression_result(
+            session_id=session_id,
+            current_summary=new_summary,
+            summary_updated_at=summary_updated_at,
+            messages_keep=messages_keep,
+        )
+
+    async def persist_then_apply_compression_result(
+        self,
+        user_id: str,
+        session_id: str,
+        resolved_model: ModelRequestInfo,
+        new_messages: List[ChatMessage],
+        current_summary: str,
+        summary_updated_at: datetime,
+        messages_keep: List[ChatMessage],
+        group_id: Optional[str] = None,
+    ) -> None:
+        persistable = await self.persist_all(
+            user_id=user_id,
+            session_id=session_id,
+            resolved_model=resolved_model,
+            new_messages=new_messages,
+            group_id=group_id,
+        )
+        await self.apply_compression_result(
+            session_id=session_id,
+            current_summary=current_summary,
+            summary_updated_at=summary_updated_at,
+            messages_keep=messages_keep + persistable,
+        )
+
+    async def persist_then_summarize_and_compress(
+        self,
+        user_id: str,
+        session_id: str,
+        resolved_model: ModelRequestInfo,
+        new_messages: List[ChatMessage],
+        messages_keep: List[ChatMessage],
+        messages_compress_candidates: List[ChatMessage],
+        existing_summary: Optional[str],
+        group_id: Optional[str] = None,
+    ) -> None:
+        persistable = await self.persist_all(
+            user_id=user_id,
+            session_id=session_id,
+            resolved_model=resolved_model,
+            new_messages=new_messages,
+            group_id=group_id,
+        )
+        await self.summarize_and_compress(
+            session_id=session_id,
+            messages_keep=messages_keep + persistable,
+            messages_compress_candidates=messages_compress_candidates,
+            existing_summary=existing_summary,
+        )

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
@@ -9,6 +9,7 @@ from chat.domain.entities import ChatMessage, Role
 from chat.domain.entities.model import ModelScope
 from chat.domain.interfaces.llm import LLMProvider
 from chat.domain.interfaces.memory import MemoryProvider
+from chat.domain.message_lifecycle import MessageLifecycle, PersistenceMode
 from chat.domain.repositories import MessageRepository, HotContextRepository, SessionRepository, ProviderRepository
 from chat.domain.repositories.model_repo import ModelRequestInfo
 from common.kafka.producer import KafkaProducerClient
@@ -92,37 +93,34 @@ class ChatTurnFinalizer:
         await self.kafka_producer.send(topic=settings.KAFKA_TOKEN_CONSUMPTION_TOPIC, value=value)
 
     @staticmethod
-    def _redact_ephemeral(new_messages: List[ChatMessage]) -> List[ChatMessage]:
+    def _apply_persistence_policy(new_messages: List[ChatMessage]) -> List[ChatMessage]:
         """
-        Per-message 粒度的 ephemeral 处理，须在任何持久化动作之前调用一次
-        - SYSTEM 消息标 ephemeral=True：整条丢弃，避免临时控制指令进入 durable 历史。
-        - TOOL 消息标 ephemeral=True：默认保留消息结构（tool_call_id / name 齐全）但 content 置换为占位符。
-          若工具显式标记 preserve_ephemeral_content=True，则保留短 ack。
-        
-        以确保 SKILL 中 SKILL.md / asset 正文不会进入 durable 历史，后续回合也不会从 Redis / Mongo 读回污染上下文
+        Per-message 粒度的持久化策略处理，须在任何持久化动作之前调用一次。
+        - DROP：整条丢弃，避免临时控制指令进入 durable 历史。
+        - REDACT_CONTENT：保留消息结构但替换 content。
+        - PERSIST_FULL / PERSIST_CONTENT：原样保留。
+
+        restore_ref 会被落到 metadata 中，供后续上下文组装恢复临时注入。
+        进入 Redis / Mongo / Memory 的消息一律重置为默认 lifecycle。
         """
-        redacted: List[ChatMessage] = []
+        persistable: List[ChatMessage] = []
         for msg in new_messages:
-            if not msg.ephemeral:
-                redacted.append(msg)
+            mode = msg.lifecycle.persistence_mode
+            if mode == PersistenceMode.DROP:
                 continue
-            if msg.role == Role.SYSTEM:
-                continue  # 临时 SYSTEM 注入只服务当前 turn，不进入持久历史
-            if msg.role == Role.USER:
-                continue
-            if msg.role == Role.TOOL:
-                if msg.metadata.get("preserve_ephemeral_content"):
-                    redacted.append(msg)
-                    continue
+
+            restore_ref = msg.lifecycle.restore_ref
+            if restore_ref:
+                msg.metadata = dict(msg.metadata or {})
+                msg.metadata["restore_ref"] = restore_ref.model_dump(mode="json")
+
+            if mode == PersistenceMode.REDACT_CONTENT:
                 msg.content = (
-                    f"[Redacted: ephemeral tool '{msg.name or 'unknown'}' scaffolding output]"
+                    f"[Redacted: tool '{msg.name or 'unknown'}' scaffolding output]"
                 )
-                redacted.append(msg)
-                continue
-            # 其他 role 不该被标 ephemeral；保守保留并去 ephemeral 标记
-            msg.ephemeral = False
-            redacted.append(msg)
-        return redacted
+            msg.lifecycle = MessageLifecycle()
+            persistable.append(msg)
+        return persistable
 
     async def persist_all(
         self,
@@ -132,9 +130,9 @@ class ChatTurnFinalizer:
         new_messages: List[ChatMessage],
         group_id: Optional[str] = None,
     ) -> List[ChatMessage]:
-        """后台统一处理所有存储逻辑: ephemeral 裁剪 → Redis 追加 → MongoDB 落盘 → Memory 摄入 → Token 计费"""
-        # 先裁剪 ephemeral，下游所有持久化都看这份结果
-        persistable = self._redact_ephemeral(new_messages)
+        """后台统一处理所有存储逻辑: 生命周期策略裁剪 → Redis 追加 → MongoDB 落盘 → Memory 摄入 → Token 计费"""
+        # 先应用生命周期持久化策略，下游所有持久化都看这份结果
+        persistable = self._apply_persistence_policy(new_messages)
 
         await self._fill_token_counts(persistable, resolved_model.model_name)
 

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_finalizer.py
@@ -107,10 +107,10 @@ class ChatTurnFinalizer:
             if not msg.ephemeral:
                 redacted.append(msg)
                 continue
-            if msg.role == Role.ASSISTANT:
-                continue  # 整条丢弃
             if msg.role == Role.SYSTEM:
                 continue  # 临时 SYSTEM 注入只服务当前 turn，不进入持久历史
+            if msg.role == Role.USER:
+                continue
             if msg.role == Role.TOOL:
                 if msg.metadata.get("preserve_ephemeral_content"):
                     redacted.append(msg)

--- a/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
+++ b/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
@@ -291,12 +291,10 @@ class QueryLoopRuntime:
 
         # schema 已由 ToolScope 在构造期固化，这里零决策直读
         tool_schemas = tool_scope.schemas()
-        provider_messages = self._messages_for_provider(messages)
-
         try:
             # 调用模型流式接口
             async for chunk in self.llm.stream_chat_completion(
-                messages=provider_messages,
+                messages=messages,
                 model_name=model_name,
                 tools=tool_schemas or None,
                 api_base=api_base,
@@ -373,53 +371,6 @@ class QueryLoopRuntime:
         yield _StepTerminal(should_continue=True, new_messages=new_messages)
 
     @staticmethod
-    def _messages_for_provider(messages: List[ChatMessage]) -> List[ChatMessage]:
-        """
-        Build a provider-facing view of the current transcript.
-
-        Ephemeral SYSTEM messages are control-plane injections produced during
-        the current agent loop (for example loaded SKILL.md). Coalesce them
-        into the first provider-facing SYSTEM message so providers that only
-        honor one system prompt still receive the loaded skill instructions,
-        while leaving assistant(tool_calls) -> tool(...) pairs adjacent.
-        """
-        system_injections = [
-            m for m in messages if m.role == Role.SYSTEM and m.ephemeral
-        ]
-        if not system_injections:
-            return messages
-
-        remaining = [
-            m for m in messages if not (m.role == Role.SYSTEM and m.ephemeral)
-        ]
-        injection_content = "\n\n".join(
-            m.content for m in system_injections if m.content
-        )
-        if not injection_content:
-            return remaining
-
-        if remaining and remaining[0].role == Role.SYSTEM:
-            first_system = remaining[0]
-            copy_fn = getattr(first_system, "model_copy", None)
-            merged_system = (
-                copy_fn(deep=False)
-                if copy_fn is not None
-                else first_system.copy(deep=False)
-            )
-            merged_system.content = "\n\n".join(
-                part for part in (first_system.content, injection_content) if part
-            )
-            return [merged_system] + remaining[1:]
-
-        return [
-            ChatMessage(
-                session_id=system_injections[0].session_id,
-                role=Role.SYSTEM,
-                content=injection_content,
-            )
-        ] + remaining
-
-    @staticmethod
     def _coerce_tool_result(result: Any) -> ToolExecutionResult:
         if isinstance(result, ToolExecutionResult):
             return result
@@ -454,7 +405,7 @@ class QueryLoopRuntime:
         """
         并行执行所有工具。
         返回 tool_output_available 事件列表（按 parsed 顺序）和本轮新增消息。
-        新增消息通常是 Role.TOOL；结构化工具结果也可以附带 ephemeral Role.SYSTEM 注入。
+        新增消息通常是 Role.TOOL；结构化工具结果也可以附带 ephemeral Role.USER 注入。
         每条 TOOL 消息独立按对应 tool 的 is_ephemeral_output 打 ephemeral 标，
         让 Finalizer 在 per-message 粒度上决定是否 redact，避免混合轮次里 skill 正文通过"整轮保守落盘"漏进 durable 历史
         """
@@ -473,6 +424,7 @@ class QueryLoopRuntime:
         # 遍历结果做异常降级
         events: List[StreamEvent] = []
         tool_messages: List[ChatMessage] = []
+        injection_messages: List[ChatMessage] = []
         for tool_call, result, is_ephemeral in zip(parsed_tool_calls, raw_results, ephemeral_flags):
             # 如果某个结果是 Exception，转成字符串形式的 [Tool Execution Error]: ... 并记录日志，否则原样使用。
             # 防止原生 Exception 对象序列化进 API 请求导致异常
@@ -501,20 +453,20 @@ class QueryLoopRuntime:
                     content=tool_result.tool_content,
                     metadata={
                         "preserve_ephemeral_content": True
-                    } if tool_result.system_injection else {},
+                    } if tool_result.user_injection else {},
                     ephemeral=is_ephemeral,
                 )
             )
-            if tool_result.system_injection:
-                tool_messages.append(
+            if tool_result.user_injection:
+                injection_messages.append(
                     ChatMessage(
                         session_id=session_id,
-                        role=Role.SYSTEM,
-                        content=tool_result.system_injection,
+                        role=Role.USER,
+                        content=tool_result.user_injection,
                         ephemeral=True,
                     )
                 )
-        return events, tool_messages
+        return events, tool_messages + injection_messages
 
     async def _invoke_tool(
         self,

--- a/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
+++ b/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
@@ -221,6 +221,50 @@ class QueryLoopRuntime:
     def __init__(self, llm: LLMProvider) -> None:
         self.llm = llm
 
+    @staticmethod
+    def _serialize_prompt_for_counting(
+        messages: List[ChatMessage],
+        tool_schemas: List[Dict[str, Any]],
+    ) -> str:
+        serialized_messages: List[Dict[str, Any]] = []
+        for msg in messages:
+            item: Dict[str, Any] = {
+                "role": msg.role.value,
+                "content": msg.content or "",
+            }
+            if msg.tool_calls:
+                item["tool_calls"] = msg.tool_calls
+            if msg.tool_call_id:
+                item["tool_call_id"] = msg.tool_call_id
+            if msg.name:
+                item["name"] = msg.name
+            serialized_messages.append(item)
+        return json.dumps(
+            {"messages": serialized_messages, "tools": tool_schemas},
+            ensure_ascii=False,
+            default=str,
+        )
+
+    async def _ensure_prompt_budget(
+        self,
+        messages: List[ChatMessage],
+        tool_schemas: List[Dict[str, Any]],
+        model_name: str,
+        prompt_budget_tokens: Optional[int],
+    ) -> None:
+        if prompt_budget_tokens is None:
+            return
+        text = self._serialize_prompt_for_counting(messages, tool_schemas)
+        token_count = await self.llm.count_tokens(text, model_name)
+        if token_count > prompt_budget_tokens:
+            raise ServiceException(
+                ChatErrorCode.CONTEXT_LIMIT_EXCEEDED,
+                custom_msg=(
+                    "最终提示词超出模型上下文预算，"
+                    f"tokens={token_count}, budget={prompt_budget_tokens}"
+                ),
+            )
+
     """
     ReAct 循环主入口 (QueryLoop)
     """
@@ -233,6 +277,7 @@ class QueryLoopRuntime:
         model_id: Optional[PydanticObjectId] = None,
         api_base: Optional[str] = None,
         api_key: Optional[str] = None,
+        prompt_budget_tokens: Optional[int] = None,
     ) -> AsyncIterator[StreamEvent]:
         # 进入多轮循环
         for iteration in range(settings.AGENT_MAX_ITERATIONS):
@@ -248,6 +293,7 @@ class QueryLoopRuntime:
                 api_key=api_key,
                 iteration=iteration,
                 tool_scope=tool_scope,
+                prompt_budget_tokens=prompt_budget_tokens,
             ):
                 # 如果拿到的是 _StepTerminal 就存到 terminal；否则直接 yield
                 if isinstance(item, _StepTerminal):
@@ -278,6 +324,7 @@ class QueryLoopRuntime:
         api_key: Optional[str],
         iteration: int,
         tool_scope: ToolScope,
+        prompt_budget_tokens: Optional[int],
     ) -> AsyncIterator[Union[StreamEvent, _StepTerminal]]:
         # 发 step 开始事件
         yield StepStartEvent()
@@ -291,6 +338,12 @@ class QueryLoopRuntime:
 
         # schema 已由 ToolScope 在构造期固化，这里零决策直读
         tool_schemas = tool_scope.schemas()
+        await self._ensure_prompt_budget(
+            messages,
+            tool_schemas,
+            model_name,
+            prompt_budget_tokens,
+        )
         try:
             # 调用模型流式接口
             async for chunk in self.llm.stream_chat_completion(
@@ -420,12 +473,18 @@ class QueryLoopRuntime:
         ephemeral_flags: List[bool] = [
             tool_scope.is_ephemeral(tool_call.name) for tool_call in parsed_tool_calls
         ]
+        restore_flags: List[bool] = [
+            tool_scope.should_restore_ephemeral_in_context(tool_call.name)
+            for tool_call in parsed_tool_calls
+        ]
 
         # 遍历结果做异常降级
         events: List[StreamEvent] = []
         tool_messages: List[ChatMessage] = []
         injection_messages: List[ChatMessage] = []
-        for tool_call, result, is_ephemeral in zip(parsed_tool_calls, raw_results, ephemeral_flags):
+        for tool_call, result, is_ephemeral, should_restore in zip(
+            parsed_tool_calls, raw_results, ephemeral_flags, restore_flags
+        ):
             # 如果某个结果是 Exception，转成字符串形式的 [Tool Execution Error]: ... 并记录日志，否则原样使用。
             # 防止原生 Exception 对象序列化进 API 请求导致异常
             if isinstance(result, Exception):
@@ -441,6 +500,12 @@ class QueryLoopRuntime:
                 else tool_result.tool_content
             )
 
+            should_restore_message = bool(should_restore and tool_result.user_injection)
+            metadata = dict(tool_result.metadata or {})
+            metadata["restore_ephemeral_in_context"] = should_restore_message
+            if tool_result.user_injection:
+                metadata["preserve_ephemeral_content"] = True
+
             # 发 ToolOutputAvailableEvent
             events.append(ToolOutputAvailableEvent(call_id=tool_call.id, output=event_output))
             # 构造对话历史中的 Tool 消息
@@ -451,9 +516,7 @@ class QueryLoopRuntime:
                     tool_call_id=tool_call.id,
                     name=tool_call.name,
                     content=tool_result.tool_content,
-                    metadata={
-                        "preserve_ephemeral_content": True
-                    } if tool_result.user_injection else {},
+                    metadata=metadata,
                     ephemeral=is_ephemeral,
                 )
             )

--- a/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
+++ b/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
@@ -10,6 +10,7 @@ from common.logger import log_fail
 from chat.core.config.app_settings import settings
 from chat.domain.entities import ChatMessage, Role
 from chat.domain.interfaces import LLMProvider
+from chat.domain.interfaces.tool import ToolExecutionResult
 from chat.domain.error_codes import ChatErrorCode
 from common.core.exceptions import ServiceException
 from chat.application.tools.tool_scope import ToolScope
@@ -290,11 +291,12 @@ class QueryLoopRuntime:
 
         # schema 已由 ToolScope 在构造期固化，这里零决策直读
         tool_schemas = tool_scope.schemas()
+        provider_messages = self._messages_for_provider(messages)
 
         try:
             # 调用模型流式接口
             async for chunk in self.llm.stream_chat_completion(
-                messages=messages,
+                messages=provider_messages,
                 model_name=model_name,
                 tools=tool_schemas or None,
                 api_base=api_base,
@@ -371,6 +373,59 @@ class QueryLoopRuntime:
         yield _StepTerminal(should_continue=True, new_messages=new_messages)
 
     @staticmethod
+    def _messages_for_provider(messages: List[ChatMessage]) -> List[ChatMessage]:
+        """
+        Build a provider-facing view of the current transcript.
+
+        Ephemeral SYSTEM messages are control-plane injections produced during
+        the current agent loop (for example loaded SKILL.md). Coalesce them
+        into the first provider-facing SYSTEM message so providers that only
+        honor one system prompt still receive the loaded skill instructions,
+        while leaving assistant(tool_calls) -> tool(...) pairs adjacent.
+        """
+        system_injections = [
+            m for m in messages if m.role == Role.SYSTEM and m.ephemeral
+        ]
+        if not system_injections:
+            return messages
+
+        remaining = [
+            m for m in messages if not (m.role == Role.SYSTEM and m.ephemeral)
+        ]
+        injection_content = "\n\n".join(
+            m.content for m in system_injections if m.content
+        )
+        if not injection_content:
+            return remaining
+
+        if remaining and remaining[0].role == Role.SYSTEM:
+            first_system = remaining[0]
+            copy_fn = getattr(first_system, "model_copy", None)
+            merged_system = (
+                copy_fn(deep=False)
+                if copy_fn is not None
+                else first_system.copy(deep=False)
+            )
+            merged_system.content = "\n\n".join(
+                part for part in (first_system.content, injection_content) if part
+            )
+            return [merged_system] + remaining[1:]
+
+        return [
+            ChatMessage(
+                session_id=system_injections[0].session_id,
+                role=Role.SYSTEM,
+                content=injection_content,
+            )
+        ] + remaining
+
+    @staticmethod
+    def _coerce_tool_result(result: Any) -> ToolExecutionResult:
+        if isinstance(result, ToolExecutionResult):
+            return result
+        return ToolExecutionResult(tool_content=str(result))
+
+    @staticmethod
     def _parse_tool_calls(
         accumulators: Dict[int, _ToolCallAccumulator],
     ) -> List[_ParsedToolCall]:
@@ -398,7 +453,8 @@ class QueryLoopRuntime:
     ) -> Tuple[List[StreamEvent], List[ChatMessage]]:
         """
         并行执行所有工具。
-        返回 tool_output_available 事件列表（按 parsed 顺序）和对应的 Role.TOOL 消息列表（按 parsed 顺序）。
+        返回 tool_output_available 事件列表（按 parsed 顺序）和本轮新增消息。
+        新增消息通常是 Role.TOOL；结构化工具结果也可以附带 ephemeral Role.SYSTEM 注入。
         每条 TOOL 消息独立按对应 tool 的 is_ephemeral_output 打 ephemeral 标，
         让 Finalizer 在 per-message 粒度上决定是否 redact，避免混合轮次里 skill 正文通过"整轮保守落盘"漏进 durable 历史
         """
@@ -423,11 +479,18 @@ class QueryLoopRuntime:
             if isinstance(result, Exception):
                 safe_result = f"[Tool Execution Error]: {type(result).__name__}: {result}"
                 log_fail("工具调用", result, name=tool_call.name, session=session_id)
+                tool_result = ToolExecutionResult(tool_content=safe_result)
             else:
-                safe_result = result
+                tool_result = self._coerce_tool_result(result)
+
+            event_output = (
+                tool_result.frontend_output
+                if tool_result.frontend_output is not None
+                else tool_result.tool_content
+            )
 
             # 发 ToolOutputAvailableEvent
-            events.append(ToolOutputAvailableEvent(call_id=tool_call.id, output=safe_result))
+            events.append(ToolOutputAvailableEvent(call_id=tool_call.id, output=event_output))
             # 构造对话历史中的 Tool 消息
             tool_messages.append(
                 ChatMessage(
@@ -435,10 +498,22 @@ class QueryLoopRuntime:
                     role=Role.TOOL,
                     tool_call_id=tool_call.id,
                     name=tool_call.name,
-                    content=safe_result,
+                    content=tool_result.tool_content,
+                    metadata={
+                        "preserve_ephemeral_content": True
+                    } if tool_result.system_injection else {},
                     ephemeral=is_ephemeral,
                 )
             )
+            if tool_result.system_injection:
+                tool_messages.append(
+                    ChatMessage(
+                        session_id=session_id,
+                        role=Role.SYSTEM,
+                        content=tool_result.system_injection,
+                        ephemeral=True,
+                    )
+                )
         return events, tool_messages
 
     async def _invoke_tool(
@@ -446,7 +521,7 @@ class QueryLoopRuntime:
         name: str,
         tool_scope: ToolScope,
         args: Dict[str, Any],
-    ) -> str:
+    ) -> Union[str, ToolExecutionResult]:
         """按 tool_scope 视图查工具并执行；未在视图内（被 deny 掉或未注册）时降级文本"""
         tool = tool_scope.get(name)
         if tool is None:

--- a/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
+++ b/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
@@ -11,6 +11,7 @@ from chat.core.config.app_settings import settings
 from chat.domain.entities import ChatMessage, Role
 from chat.domain.interfaces import LLMProvider
 from chat.domain.interfaces.tool import ToolExecutionResult
+from chat.domain.message_lifecycle import LLMVisibility, MessageLifecycle, PersistenceMode
 from chat.domain.error_codes import ChatErrorCode
 from common.core.exceptions import ServiceException
 from chat.application.tools.tool_scope import ToolScope
@@ -227,7 +228,7 @@ class QueryLoopRuntime:
         tool_schemas: List[Dict[str, Any]],
     ) -> str:
         serialized_messages: List[Dict[str, Any]] = []
-        for msg in messages:
+        for msg in QueryLoopRuntime._messages_visible_to_llm(messages):
             item: Dict[str, Any] = {
                 "role": msg.role.value,
                 "content": msg.content or "",
@@ -244,6 +245,13 @@ class QueryLoopRuntime:
             ensure_ascii=False,
             default=str,
         )
+
+    @staticmethod
+    def _messages_visible_to_llm(messages: List[ChatMessage]) -> List[ChatMessage]:
+        return [
+            msg for msg in messages
+            if msg.lifecycle.llm_visibility == LLMVisibility.INCLUDE
+        ]
 
     async def _ensure_prompt_budget(
         self,
@@ -347,7 +355,7 @@ class QueryLoopRuntime:
         try:
             # 调用模型流式接口
             async for chunk in self.llm.stream_chat_completion(
-                messages=messages,
+                messages=self._messages_visible_to_llm(messages),
                 model_name=model_name,
                 tools=tool_schemas or None,
                 api_base=api_base,
@@ -398,7 +406,6 @@ class QueryLoopRuntime:
                 }
                 for tool_call in parsed_tool_calls
             ],
-            ephemeral=False,
         )
         new_messages: List[ChatMessage] = [assistant_msg]
 
@@ -458,9 +465,9 @@ class QueryLoopRuntime:
         """
         并行执行所有工具。
         返回 tool_output_available 事件列表（按 parsed 顺序）和本轮新增消息。
-        新增消息通常是 Role.TOOL；结构化工具结果也可以附带 ephemeral Role.USER 注入。
-        每条 TOOL 消息独立按对应 tool 的 is_ephemeral_output 打 ephemeral 标，
-        让 Finalizer 在 per-message 粒度上决定是否 redact，避免混合轮次里 skill 正文通过"整轮保守落盘"漏进 durable 历史
+        新增消息通常是 Role.TOOL；结构化工具结果也可以附带仅本轮使用的 Role.USER 注入。
+        每条消息携带 lifecycle，让 Finalizer 在 per-message 粒度上决定是否 drop/redact/persist，
+        避免 skill 正文或 asset 正文漏进 durable 历史。
         """
 
         # 并发执行所有工具，return_exceptions=True 保证单工具失败不中断整轮
@@ -469,22 +476,11 @@ class QueryLoopRuntime:
             return_exceptions=True,
         )
 
-        # 查出每个 tool call 对应 tool 的 is_ephemeral_output
-        ephemeral_flags: List[bool] = [
-            tool_scope.is_ephemeral(tool_call.name) for tool_call in parsed_tool_calls
-        ]
-        restore_flags: List[bool] = [
-            tool_scope.should_restore_ephemeral_in_context(tool_call.name)
-            for tool_call in parsed_tool_calls
-        ]
-
         # 遍历结果做异常降级
         events: List[StreamEvent] = []
         tool_messages: List[ChatMessage] = []
         injection_messages: List[ChatMessage] = []
-        for tool_call, result, is_ephemeral, should_restore in zip(
-            parsed_tool_calls, raw_results, ephemeral_flags, restore_flags
-        ):
+        for tool_call, result in zip(parsed_tool_calls, raw_results):
             # 如果某个结果是 Exception，转成字符串形式的 [Tool Execution Error]: ... 并记录日志，否则原样使用。
             # 防止原生 Exception 对象序列化进 API 请求导致异常
             if isinstance(result, Exception):
@@ -500,11 +496,9 @@ class QueryLoopRuntime:
                 else tool_result.tool_content
             )
 
-            should_restore_message = bool(should_restore and tool_result.user_injection)
             metadata = dict(tool_result.metadata or {})
-            metadata["restore_ephemeral_in_context"] = should_restore_message
-            if tool_result.user_injection:
-                metadata["preserve_ephemeral_content"] = True
+            if tool_result.lifecycle.restore_ref:
+                metadata["restore_ref"] = tool_result.lifecycle.restore_ref.model_dump(mode="json")
 
             # 发 ToolOutputAvailableEvent
             events.append(ToolOutputAvailableEvent(call_id=tool_call.id, output=event_output))
@@ -517,7 +511,7 @@ class QueryLoopRuntime:
                     name=tool_call.name,
                     content=tool_result.tool_content,
                     metadata=metadata,
-                    ephemeral=is_ephemeral,
+                    lifecycle=tool_result.lifecycle,
                 )
             )
             if tool_result.user_injection:
@@ -526,7 +520,9 @@ class QueryLoopRuntime:
                         session_id=session_id,
                         role=Role.USER,
                         content=tool_result.user_injection,
-                        ephemeral=True,
+                        lifecycle=MessageLifecycle(
+                            persistence_mode=PersistenceMode.DROP,
+                        ),
                     )
                 )
         return events, tool_messages + injection_messages

--- a/services/wisepen-chat-service/src/chat/application/skill_cache_refresher.py
+++ b/services/wisepen-chat-service/src/chat/application/skill_cache_refresher.py
@@ -8,7 +8,7 @@ from chat.application.skill_matcher import SkillMatcher
 
 class SkillCacheRefresher:
     """
-    Skill matcher 缓存的刷新调度器
+    Skill metadata 缓存的刷新调度器
     在启动阶段触发一次 eager warmup（作为"周期刷新的第 0 次"）
     之后每 ttl_seconds 调一次 matcher.warmup()，使得用户发布的 Skill 变化能在 TTL 内被当前副本感知
     """

--- a/services/wisepen-chat-service/src/chat/application/skill_matcher.py
+++ b/services/wisepen-chat-service/src/chat/application/skill_matcher.py
@@ -10,9 +10,10 @@ from chat.domain.repositories import SkillRepository
 
 class SkillMatcher(ABC):
     """
-    Skill 预筛选接口：根据用户 query 返回可能相关的 Skill 元信息 shortlist。
+    Skill 可用清单接口：返回当前会话可展示给 LLM 的 Skill 元信息。
 
-    实现可以换成 embedding / 语义相似度，接口保持不变。
+    当前策略不再用字符串匹配预筛，而是把轻量 metadata 交给 LLM 判断是否加载。
+    接口名暂时保持 match 以减少调用方改动。
     """
 
     @abstractmethod
@@ -24,7 +25,10 @@ class SkillMatcher(ABC):
 
 class KeywordSkillMatcher(SkillMatcher):
     """
-    最简关键词预筛：大小写无关 substring 匹配 triggers，按命中数排序取 top_k。
+    可用 Skill metadata 缓存。
+
+    历史类名暂时保留以兼容容器装配；行为已经不是关键词匹配。
+    match(query) 会忽略 query，返回所有 enabled Skill 的轻量信息，让 LLM 自行决定是否调用 load_skill。
     """
 
     def __init__(self, skill_repo: SkillRepository) -> None:
@@ -38,40 +42,21 @@ class KeywordSkillMatcher(SkillMatcher):
         except Exception as e:
             # 捕获所有异常，保证服务可启动 / 周期刷新不炸
             # 失败时不擦除 self._cache，已有 last-good 继续服务，防止被 Mongo 抖动打回"无 Skill 能力"
-            log_error("Skill matcher warmup", e, had_cache=bool(self._cache))
+            log_error("Skill metadata warmup", e, had_cache=bool(self._cache))
             self._warmed = True
             return
 
-        self._cache = metas
+        self._cache = sorted(metas, key=lambda m: m.skill_id)
         self._warmed = True
-        log_event("Skill matcher warmup 完成", count=len(metas))
+        log_event("Skill metadata warmup 完成", count=len(metas))
 
     def match(self, query: str) -> List[SkillMeta]:
         if not self._cache:
             log_fail(
-                "Skill matcher",
-                "cache 为空，本次 match 返回空列表",
+                "Skill metadata",
+                "cache 为空，本次返回空列表",
             )
             return []
 
-        if not query:
-            return []
-
-        lowered = query.lower()
-        scored: List[tuple[int, SkillMeta]] = []
-        for meta in self._cache:
-            # 大小写无关 substring：同一 trigger 命中只记 1 分（去重）；命中数越多排名越高
-            hits = 0
-            for trig in meta.triggers:
-                if trig and trig.lower() in lowered:
-                    hits += 1
-            if hits > 0:
-                scored.append((hits, meta))
-
-        if not scored:
-            return []
-
-        # 先按命中数降序；命中数相同时按 skill_id 字典序稳定
-        scored.sort(key=lambda x: (-x[0], x[1].skill_id))
-        top_k = max(1, settings.SKILL_MATCH_TOP_K)
-        return [m for _, m in scored[:top_k]]
+        max_count = max(1, settings.SKILL_DISCOVERY_MAX_COUNT)
+        return self._cache[:max_count]

--- a/services/wisepen-chat-service/src/chat/application/skill_prompt_builder.py
+++ b/services/wisepen-chat-service/src/chat/application/skill_prompt_builder.py
@@ -1,0 +1,22 @@
+from chat.domain.entities.skill import Skill
+
+
+class SkillPromptBuilder:
+    """
+    Centralized prompt snippets for skill loading.
+    """
+
+    @staticmethod
+    def build_loaded_skill_prompt(skill: Skill) -> str:
+        return (
+            "[Mandatory Loaded Skill]\n"
+            f"You have loaded skill id={skill.skill_id} version={skill.version}.\n\n"
+            "This SKILL.md is mandatory for the current turn.\n"
+            "Its Scope, Output Format, and Constraints override the general assistant formatting instructions.\n"
+            "Do not answer with a general explanation.\n"
+            "Do not add an introduction, summary, score, praise, or follow-up question unless the SKILL.md explicitly requires it.\n"
+            "Before final response, silently verify that the answer follows the SKILL.md Output Format exactly.\n\n"
+            "===== SKILL.md BEGIN =====\n"
+            f"{skill.skill_md.rstrip()}\n"
+            "===== SKILL.md END ====="
+        )

--- a/services/wisepen-chat-service/src/chat/application/skill_prompt_builder.py
+++ b/services/wisepen-chat-service/src/chat/application/skill_prompt_builder.py
@@ -20,3 +20,27 @@ class SkillPromptBuilder:
             f"{skill.skill_md.rstrip()}\n"
             "===== SKILL.md END ====="
         )
+
+    @staticmethod
+    def build_loaded_skill_injection(skill: Skill) -> str:
+        lines = [
+            "<system-reminder>",
+            f"[Loaded WisePen Skill] id={skill.skill_id} version={skill.version}",
+            "This content is injected by WisePen for the current task. "
+            "Use it as operational context, but do not answer or quote this reminder directly.",
+            "",
+            SkillPromptBuilder.build_loaded_skill_prompt(skill),
+        ]
+
+        if skill.assets_manifest:
+            lines.append("")
+            lines.append(
+                "[Assets Manifest] Use load_skill_asset only if the loaded SKILL.md explicitly requires supporting assets."
+            )
+            for asset in skill.assets_manifest:
+                lines.append(
+                    f"- path={asset.path} kind={asset.kind} size={asset.size_bytes} - {asset.description}"
+                )
+
+        lines.append("</system-reminder>")
+        return "\n".join(lines)

--- a/services/wisepen-chat-service/src/chat/application/tools/check_loaded_files.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/check_loaded_files.py
@@ -1,0 +1,106 @@
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+LoadedFileKey = tuple[str, str]
+
+
+def _already_loaded_response(
+    *,
+    message: str,
+    file_type: str,
+    file_id: str,
+    file_path: str,
+) -> str:
+    return json.dumps(
+        {
+            "message": message,
+            "file_type": file_type,
+            "file_id": file_id,
+            "file_path": file_path,
+        },
+        ensure_ascii=False,
+    )
+
+
+@dataclass(frozen=True)
+class LoadedFileCheckResult:
+    already_loaded: bool
+    response: str | None
+    file_type: str
+    file_id: str
+    file_path: str
+    _loaded_key: LoadedFileKey
+    _turn_loaded: set[LoadedFileKey]
+    _recorded_turn: bool
+
+    def rollback(self) -> None:
+        if self._recorded_turn:
+            self._turn_loaded.discard(self._loaded_key)
+
+
+def _check_and_record(
+    *,
+    turn_loaded: set[LoadedFileKey],
+    loaded_key: LoadedFileKey,
+    file_type: str,
+    file_id: str,
+    file_path: str,
+    message: str,
+) -> LoadedFileCheckResult:
+    already_loaded = loaded_key in turn_loaded
+    if already_loaded:
+        return LoadedFileCheckResult(
+            already_loaded=True,
+            response=_already_loaded_response(
+                message=message,
+                file_type=file_type,
+                file_id=file_id,
+                file_path=file_path,
+            ),
+            file_type=file_type,
+            file_id=file_id,
+            file_path=file_path,
+            _loaded_key=loaded_key,
+            _turn_loaded=turn_loaded,
+            _recorded_turn=False,
+        )
+
+    turn_loaded.add(loaded_key)
+    return LoadedFileCheckResult(
+        already_loaded=False,
+        response=None,
+        file_type=file_type,
+        file_id=file_id,
+        file_path=file_path,
+        _loaded_key=loaded_key,
+        _turn_loaded=turn_loaded,
+        _recorded_turn=True,
+    )
+
+
+def check_and_record_loaded_file(
+    *,
+    context: dict[str, Any],
+    file_type: str,
+    file_id: str,
+    file_path: str,
+    message: str,
+) -> LoadedFileCheckResult:
+    """
+    Check whether a file has already been loaded in the current turn, and record it
+    atomically when allowed. Cross-turn visibility is derived from the assembled
+    prompt, not from process-local session state.
+    """
+    loaded_key = (file_type, file_id)
+    turn_loaded = context.setdefault("turn_loaded_files", set())
+
+    return _check_and_record(
+        turn_loaded=turn_loaded,
+        loaded_key=loaded_key,
+        file_type=file_type,
+        file_id=file_id,
+        file_path=file_path,
+        message=message,
+    )

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_asset_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_asset_tool.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 from common.logger import log_error, log_fail
 
 from chat.core.config.app_settings import settings
+from chat.application.tools.check_loaded_files import check_and_record_loaded_file
 from chat.domain.interfaces.skill_asset_loader import SkillAssetLoader
 from chat.domain.interfaces.tool import BaseTool
 from chat.domain.repositories import SkillRepository
@@ -117,9 +118,21 @@ class LoadSkillAssetTool(BaseTool):
                 f"please contact the skill publisher."
             )
 
+        file_id = f"{skill.skill_id}@{skill.version}:{path}"
+        loaded_check = check_and_record_loaded_file(
+            context=context,
+            file_type="skill-asset",
+            file_id=file_id,
+            file_path=path,
+            message="skill asset has already loaded",
+        )
+        if loaded_check.already_loaded:
+            return loaded_check.response or ""
+
         try:
             raw = await self._skill_asset_loader.load_by_object_key(object_key)
         except Exception as e:
+            loaded_check.rollback()
             log_error(
                 "load_skill_asset 读取",
                 e,
@@ -135,6 +148,7 @@ class LoadSkillAssetTool(BaseTool):
         try:
             content = raw.decode("utf-8")
         except UnicodeDecodeError:
+            loaded_check.rollback()
             log_fail(
                 "load_skill_asset 解码",
                 "资产非 UTF-8 文本，无法直接返回给 LLM",

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_asset_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_asset_tool.py
@@ -5,7 +5,8 @@ from common.logger import log_error, log_fail
 from chat.core.config.app_settings import settings
 from chat.application.tools.check_loaded_files import check_and_record_loaded_file
 from chat.domain.interfaces.skill_asset_loader import SkillAssetLoader
-from chat.domain.interfaces.tool import BaseTool
+from chat.domain.interfaces.tool import BaseTool, ToolExecutionResult
+from chat.domain.message_lifecycle import MessageLifecycle, PersistenceMode
 from chat.domain.repositories import SkillRepository
 
 
@@ -53,10 +54,6 @@ class LoadSkillAssetTool(BaseTool):
             },
             "required": ["skill_id", "path"],
         }
-
-    @property
-    def is_ephemeral_output(self) -> bool:
-        return True
 
     @property
     def reserved(self) -> bool:
@@ -168,9 +165,14 @@ class LoadSkillAssetTool(BaseTool):
         if len(content) > settings.TOOL_RESULT_MAX_CHARS:
             content = content[: settings.TOOL_RESULT_MAX_CHARS] + "\n...[truncated]"
 
-        return (
-            f"[Loaded Asset] skill_id={skill_id} version={skill.version} path={path}\n"
-            f"===== ASSET BEGIN =====\n"
-            f"{content}\n"
-            f"===== ASSET END ====="
+        return ToolExecutionResult(
+            tool_content=(
+                f"[Loaded Asset] skill_id={skill_id} version={skill.version} path={path}\n"
+                f"===== ASSET BEGIN =====\n"
+                f"{content}\n"
+                f"===== ASSET END ====="
+            ),
+            lifecycle=MessageLifecycle(
+                persistence_mode=PersistenceMode.REDACT_CONTENT,
+            ),
         )

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
@@ -52,7 +52,7 @@ class LoadSkillTool(BaseTool):
         # 系统保留，不应被用户级 deny 屏蔽
         return True
 
-    async def execute(self, context: Dict[str, Any], **kwargs) -> str:
+    async def execute(self, context: Dict[str, Any], **kwargs) -> str | ToolExecutionResult:
         skill_id = (kwargs.get("skill_id") or "").strip()
         if not skill_id:
             return "[Tool Error] Missing required argument: skill_id."
@@ -80,8 +80,13 @@ class LoadSkillTool(BaseTool):
             return f"[Tool Error] Skill '{skill_id}' not found."
 
         # 拼接强约束 prompt + assets manifest 摘要。
-        # 完整 SKILL.md 作为本轮临时 SYSTEM 注入，不再作为 TOOL 正文返回。
+        # 完整 SKILL.md 作为本轮临时 USER reminder 注入，不再作为 TOOL 正文返回。
         lines = [
+            "<system-reminder>",
+            f"[Loaded WisePen Skill] id={skill.skill_id} version={skill.version}",
+            "This content is injected by WisePen for the current task. "
+            "Use it as operational context, but do not answer or quote this reminder directly.",
+            "",
             SkillPromptBuilder.build_loaded_skill_prompt(skill),
         ]
 
@@ -98,6 +103,6 @@ class LoadSkillTool(BaseTool):
         ack = f"[Skill loaded: {skill.skill_id} version={skill.version}]"
         return ToolExecutionResult(
             tool_content=ack,
-            system_injection="\n".join(lines),
+            user_injection="\n".join(lines) + "\n</system-reminder>",
             frontend_output=ack,
         )

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 from common.logger import log_error, log_fail
 
 from chat.application.skill_prompt_builder import SkillPromptBuilder
+from chat.application.tools.check_loaded_files import check_and_record_loaded_file
 from chat.domain.interfaces.tool import BaseTool, ToolExecutionResult
 from chat.domain.repositories import SkillRepository
 
@@ -48,6 +49,10 @@ class LoadSkillTool(BaseTool):
         return True
 
     @property
+    def restore_ephemeral_in_context(self) -> bool:
+        return True
+
+    @property
     def reserved(self) -> bool:
         # 系统保留，不应被用户级 deny 屏蔽
         return True
@@ -79,30 +84,25 @@ class LoadSkillTool(BaseTool):
         if skill is None:
             return f"[Tool Error] Skill '{skill_id}' not found."
 
-        # 拼接强约束 prompt + assets manifest 摘要。
-        # 完整 SKILL.md 作为本轮临时 USER reminder 注入，不再作为 TOOL 正文返回。
-        lines = [
-            "<system-reminder>",
-            f"[Loaded WisePen Skill] id={skill.skill_id} version={skill.version}",
-            "This content is injected by WisePen for the current task. "
-            "Use it as operational context, but do not answer or quote this reminder directly.",
-            "",
-            SkillPromptBuilder.build_loaded_skill_prompt(skill),
-        ]
-
-        if skill.assets_manifest:
-            lines.append("")
-            lines.append(
-                "[Assets Manifest] Use load_skill_asset only if the loaded SKILL.md explicitly requires supporting assets."
-            )
-            for asset in skill.assets_manifest:
-                lines.append(
-                    f"- path={asset.path} kind={asset.kind} size={asset.size_bytes} - {asset.description}"
-                )
+        file_id = f"{skill.skill_id}@{skill.version}"
+        loaded_check = check_and_record_loaded_file(
+            context=context,
+            file_type="skill",
+            file_id=file_id,
+            file_path="SKILL.md",
+            message="skill has already loaded",
+        )
+        if loaded_check.already_loaded:
+            return loaded_check.response or ""
 
         ack = f"[Skill loaded: {skill.skill_id} version={skill.version}]"
         return ToolExecutionResult(
             tool_content=ack,
-            user_injection="\n".join(lines) + "\n</system-reminder>",
+            user_injection=SkillPromptBuilder.build_loaded_skill_injection(skill),
             frontend_output=ack,
+            metadata={
+                "restore_kind": "skill",
+                "skill_id": skill.skill_id,
+                "version": skill.version,
+            },
         )

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
@@ -2,7 +2,8 @@ from typing import Any, Dict
 
 from common.logger import log_error, log_fail
 
-from chat.domain.interfaces.tool import BaseTool
+from chat.application.skill_prompt_builder import SkillPromptBuilder
+from chat.domain.interfaces.tool import BaseTool, ToolExecutionResult
 from chat.domain.repositories import SkillRepository
 
 
@@ -78,22 +79,25 @@ class LoadSkillTool(BaseTool):
         if skill is None:
             return f"[Tool Error] Skill '{skill_id}' not found."
 
-        # 拼接 header + SKILL.md + assets manifest 摘要
+        # 拼接强约束 prompt + assets manifest 摘要。
+        # 完整 SKILL.md 作为本轮临时 SYSTEM 注入，不再作为 TOOL 正文返回。
         lines = [
-            f"[Loaded Skill] id={skill.skill_id} version={skill.version}",
-            f"[Display Name] {skill.display_name}",
-            "",
-            "===== SKILL.md BEGIN =====",
-            skill.skill_md.rstrip(),
-            "===== SKILL.md END =====",
+            SkillPromptBuilder.build_loaded_skill_prompt(skill),
         ]
 
         if skill.assets_manifest:
             lines.append("")
-            lines.append("[Assets Manifest] (use load_skill_asset to open any of these)")
+            lines.append(
+                "[Assets Manifest] Use load_skill_asset only if the loaded SKILL.md explicitly requires supporting assets."
+            )
             for asset in skill.assets_manifest:
                 lines.append(
-                    f"- path={asset.path} kind={asset.kind} size={asset.size_bytes} — {asset.description}"
+                    f"- path={asset.path} kind={asset.kind} size={asset.size_bytes} - {asset.description}"
                 )
 
-        return "\n".join(lines)
+        ack = f"[Skill loaded: {skill.skill_id} version={skill.version}]"
+        return ToolExecutionResult(
+            tool_content=ack,
+            system_injection="\n".join(lines),
+            frontend_output=ack,
+        )

--- a/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/load_skill_tool.py
@@ -4,6 +4,7 @@ from common.logger import log_error, log_fail
 
 from chat.application.skill_prompt_builder import SkillPromptBuilder
 from chat.application.tools.check_loaded_files import check_and_record_loaded_file
+from chat.domain.message_lifecycle import MessageLifecycle, PersistenceMode, RestoreRef
 from chat.domain.interfaces.tool import BaseTool, ToolExecutionResult
 from chat.domain.repositories import SkillRepository
 
@@ -42,15 +43,6 @@ class LoadSkillTool(BaseTool):
             },
             "required": ["skill_id"],
         }
-
-    @property
-    def is_ephemeral_output(self) -> bool:
-        # 本工具返回的消息无需持久化
-        return True
-
-    @property
-    def restore_ephemeral_in_context(self) -> bool:
-        return True
 
     @property
     def reserved(self) -> bool:
@@ -101,8 +93,14 @@ class LoadSkillTool(BaseTool):
             user_injection=SkillPromptBuilder.build_loaded_skill_injection(skill),
             frontend_output=ack,
             metadata={
-                "restore_kind": "skill",
                 "skill_id": skill.skill_id,
                 "version": skill.version,
             },
+            lifecycle=MessageLifecycle(
+                persistence_mode=PersistenceMode.PERSIST_CONTENT,
+                restore_ref=RestoreRef(
+                    kind="skill",
+                    data={"skill_id": skill.skill_id, "version": skill.version},
+                ),
+            ),
         )

--- a/services/wisepen-chat-service/src/chat/application/tools/search_history_tool.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/search_history_tool.py
@@ -23,11 +23,15 @@ class SearchHistoricalMessagesTool(BaseTool):
     @property
     def description(self) -> str:
         return (
-            "Search historical chat messages by keyword and optional time range. "
-            "Use this when you need to recall specific facts, events, or details "
-            "from earlier in the conversation that may not be in the current context window."
-            "NOTE that the search keyword's language should match the user's chat language; otherwise, the search may fail. If no results are found, consider switching the keyword's language."
+            "Search older messages in the current chat session only when the conversation "
+            "has been compressed and the user explicitly asks about prior conversation history. "
+            "Do not use for general answering, writing, translation, summarization, skill execution, "
+            "or when the needed information is already present in the current context."
         )
+
+    @property
+    def reserved(self) -> bool:
+        return True
 
     @property
     def parameters_schema(self) -> Dict[str, Any]:

--- a/services/wisepen-chat-service/src/chat/application/tools/tool_scope.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/tool_scope.py
@@ -39,5 +39,9 @@ class ToolScope:
         t = self.get(name)
         return bool(t and t.is_ephemeral_output) # 未在 Scope 视图内的视为 False
 
+    def should_restore_ephemeral_in_context(self, name: str) -> bool:
+        t = self.get(name)
+        return bool(t and t.restore_ephemeral_in_context) # 未在 Scope 视图内的视为 False
+
     def __len__(self) -> int:
         return len(self._tools)

--- a/services/wisepen-chat-service/src/chat/application/tools/tool_scope.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/tool_scope.py
@@ -35,13 +35,5 @@ class ToolScope:
     def context(self) -> Dict[str, Any]:
         return dict(self._context)
 
-    def is_ephemeral(self, name: str) -> bool:
-        t = self.get(name)
-        return bool(t and t.is_ephemeral_output) # 未在 Scope 视图内的视为 False
-
-    def should_restore_ephemeral_in_context(self, name: str) -> bool:
-        t = self.get(name)
-        return bool(t and t.restore_ephemeral_in_context) # 未在 Scope 视图内的视为 False
-
     def __len__(self) -> int:
         return len(self._tools)

--- a/services/wisepen-chat-service/src/chat/container.py
+++ b/services/wisepen-chat-service/src/chat/container.py
@@ -103,7 +103,7 @@ class Container(containers.DeclarativeContainer):
         )
     else:
         skill_asset_loader = oss_skill_asset_loader
-    # KeywordSkillMatcher
+    # Skill metadata cache：保留历史类名，当前不再做关键词匹配
     skill_matcher = providers.Singleton(
         KeywordSkillMatcher,
         skill_repo=skill_repo,

--- a/services/wisepen-chat-service/src/chat/container.py
+++ b/services/wisepen-chat-service/src/chat/container.py
@@ -161,6 +161,7 @@ class Container(containers.DeclarativeContainer):
         tool_registry=tool_registry,
         kafka_producer=kafka_producer,
         skill_matcher=skill_matcher,
+        skill_repo=skill_repo,
     )
 
 

--- a/services/wisepen-chat-service/src/chat/core/config/app_settings.py
+++ b/services/wisepen-chat-service/src/chat/core/config/app_settings.py
@@ -69,7 +69,7 @@ class AppSettings(BaseModel):
 
     # Agentic ReAct 循环
     # ReAct 最大推理迭代次数，防止工具调用产生无限循环
-    AGENT_MAX_ITERATIONS: int = 5
+    AGENT_MAX_ITERATIONS: int = 10
     # 工具返回内容的字符截断上限（约 ~1000 token），防止超长结果撑爆后续迭代的上下文水位
     TOOL_RESULT_MAX_CHARS: int = 4000
 

--- a/services/wisepen-chat-service/src/chat/core/config/app_settings.py
+++ b/services/wisepen-chat-service/src/chat/core/config/app_settings.py
@@ -89,7 +89,9 @@ class AppSettings(BaseModel):
     SKILL_OSS_CACHE_TTL_SECONDS: int = 6 * 3600
     # GC 扫描周期（秒）
     SKILL_OSS_CACHE_GC_INTERVAL_SECONDS: int = 30 * 60
-    # Matcher 每轮给 LLM 暴露的 skill 候选上限（受控披露，防 LLM 误加载）
+    # 每轮给 LLM 暴露的可用 Skill metadata 上限（只含 skill_id/display_name/description，不含 SKILL.md 正文）
+    SKILL_DISCOVERY_MAX_COUNT: int = 20
+    # 旧关键词 matcher 的候选上限；保留字段兼容现有 Nacos 配置，当前主链路不再使用字符串匹配。
     SKILL_MATCH_TOP_K: int = 2
     # Skill 元数据缓存 TTL（秒）。用户/Java 端发布的新 Skill 最坏需等 TTL 才被当前副本感知。
     # 过小会增加 Mongo 读压力；过大会让新 Skill 生效滞后。

--- a/services/wisepen-chat-service/src/chat/core/providers/llm/litellm_adapter.py
+++ b/services/wisepen-chat-service/src/chat/core/providers/llm/litellm_adapter.py
@@ -85,21 +85,6 @@ class LiteLLMAdapter(LLMProvider):
         formatted_msgs = self._convert_messages(messages)
         litellm_model = self._format_model_for_litellm(model_name)
 
-        import json
-        print(
-            "[LLM 请求 payload]",
-            json.dumps(
-                {
-                    "model": litellm_model,
-                    "messages": formatted_msgs,
-                    "tools": tools,
-                },
-                ensure_ascii=False,
-                default=str,
-                indent=2,
-            ),
-            flush=True,
-        )
         try:
             response = await litellm.acompletion(
                 model=litellm_model,

--- a/services/wisepen-chat-service/src/chat/core/providers/llm/litellm_adapter.py
+++ b/services/wisepen-chat-service/src/chat/core/providers/llm/litellm_adapter.py
@@ -85,6 +85,21 @@ class LiteLLMAdapter(LLMProvider):
         formatted_msgs = self._convert_messages(messages)
         litellm_model = self._format_model_for_litellm(model_name)
 
+        import json
+        print(
+            "[LLM 请求 payload]",
+            json.dumps(
+                {
+                    "model": litellm_model,
+                    "messages": formatted_msgs,
+                    "tools": tools,
+                },
+                ensure_ascii=False,
+                default=str,
+                indent=2,
+            ),
+            flush=True,
+        )
         try:
             response = await litellm.acompletion(
                 model=litellm_model,

--- a/services/wisepen-chat-service/src/chat/domain/entities/message.py
+++ b/services/wisepen-chat-service/src/chat/domain/entities/message.py
@@ -6,6 +6,8 @@ from beanie import Document, PydanticObjectId
 from pydantic import Field, ConfigDict
 from pymongo import IndexModel, ASCENDING
 
+from chat.domain.message_lifecycle import MessageLifecycle
+
 
 class Role(str, Enum):
     SYSTEM = "system"
@@ -30,10 +32,7 @@ class ChatMessage(Document):
     tool_call_id: Optional[str] = None
     name: Optional[str] = None
 
-    # 仅本轮工作内可见标识
-    # True 时可对 ASSISTANT 消息整条丢弃、对 TOOL 消息 content 置换为占位符
-    # 确保 Skill 等脚手架内容不污染 durable 历史
-    ephemeral: bool = False
+    lifecycle: MessageLifecycle = Field(default_factory=MessageLifecycle)
 
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 

--- a/services/wisepen-chat-service/src/chat/domain/entities/skill.py
+++ b/services/wisepen-chat-service/src/chat/domain/entities/skill.py
@@ -30,7 +30,7 @@ class Skill(Document):
     description: str = Field(..., description="一句话说明本 Skill 的场景与目的")
     triggers: List[str] = Field(default_factory=list, description="关键词列表，供 KeywordSkillMatcher 大小写无关 substring 匹配")
 
-    skill_md: str = Field(..., description="发布时 SKILL.md 正文快照（含 frontmatter 去掉 --- 后的 body）")
+    skill_md: str = Field(..., description="发布时 SKILL.md 完整正文快照（含 frontmatter）")
     skill_md_object_key: str = Field(..., description="SKILL.md 在 OSS 的权威副本 object_key")
     assets_manifest: List[SkillAssetMeta] = Field(default_factory=list, description="附件清单，LLM 看得到的只有这一层")
 

--- a/services/wisepen-chat-service/src/chat/domain/entities/skill.py
+++ b/services/wisepen-chat-service/src/chat/domain/entities/skill.py
@@ -28,7 +28,7 @@ class Skill(Document):
     skill_id: str = Field(..., description="唯一 slug，如 'paper-translation'；工具参数、日志、权限校验都只用这个")
     display_name: str = Field(..., description="展示名，如 'Paper Translation'，仅用于日志和可能的 UI 列表")
     description: str = Field(..., description="一句话说明本 Skill 的场景与目的")
-    triggers: List[str] = Field(default_factory=list, description="关键词列表，供 KeywordSkillMatcher 大小写无关 substring 匹配")
+    triggers: List[str] = Field(default_factory=list, description="历史关键词列表；当前主链路不再依赖字符串匹配激活 Skill")
 
     skill_md: str = Field(..., description="发布时 SKILL.md 完整正文快照（含 frontmatter）")
     skill_md_object_key: str = Field(..., description="SKILL.md 在 OSS 的权威副本 object_key")

--- a/services/wisepen-chat-service/src/chat/domain/interfaces/__init__.py
+++ b/services/wisepen-chat-service/src/chat/domain/interfaces/__init__.py
@@ -1,11 +1,12 @@
 from .llm import LLMProvider
 from .memory import MemoryProvider
-from .tool import BaseTool
+from .tool import BaseTool, ToolExecutionResult
 from .skill_asset_loader import SkillAssetLoader
 
 __all__ = [
     "LLMProvider",
     "MemoryProvider",
     "BaseTool",
+    "ToolExecutionResult",
     "SkillAssetLoader",
 ]

--- a/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
+++ b/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
@@ -1,7 +1,9 @@
 # src/chat/domain/interfaces/tool.py
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Any, Optional, Union
+
+from chat.domain.message_lifecycle import MessageLifecycle
 
 
 @dataclass(frozen=True)
@@ -14,6 +16,7 @@ class ToolExecutionResult:
     user_injection: Optional[str] = None
     frontend_output: Optional[Any] = None
     metadata: Optional[Dict[str, Any]] = None
+    lifecycle: MessageLifecycle = field(default_factory=MessageLifecycle)
 
 
 class BaseTool(ABC):
@@ -28,25 +31,6 @@ class BaseTool(ABC):
     @property
     @abstractmethod
     def parameters_schema(self) -> Dict[str, Any]: pass
-
-    @property
-    def is_ephemeral_output(self) -> bool:
-        """
-        True 表示本工具的输出属于"仅本轮工作内可见"的脚手架（如 Skill 正文加载）
-        QueryLoopRuntime 会把对应 TOOL 消息标 ephemeral=True
-        ChatTurnFinalizer 在持久化前会将其 content 置换为占位符以防上下文膨胀
-        False 表示本工具的输出属于对话事实，应进入 durable 历史
-        """
-        return False
-
-    @property
-    def restore_ephemeral_in_context(self) -> bool:
-        """
-        True 表示该工具的 ephemeral 注入内容在持久化时不会落库，
-        但后续拼接历史上下文时应根据持久化的 TOOL ack 恢复对应注入。
-        默认不恢复；例如 load_skill 需要恢复 SKILL.md，load_skill_asset 不需要恢复。
-        """
-        return False
 
     @property
     def reserved(self) -> bool:

--- a/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
+++ b/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
@@ -13,6 +13,7 @@ class ToolExecutionResult:
     tool_content: str
     user_injection: Optional[str] = None
     frontend_output: Optional[Any] = None
+    metadata: Optional[Dict[str, Any]] = None
 
 
 class BaseTool(ABC):
@@ -35,6 +36,15 @@ class BaseTool(ABC):
         QueryLoopRuntime 会把对应 TOOL 消息标 ephemeral=True
         ChatTurnFinalizer 在持久化前会将其 content 置换为占位符以防上下文膨胀
         False 表示本工具的输出属于对话事实，应进入 durable 历史
+        """
+        return False
+
+    @property
+    def restore_ephemeral_in_context(self) -> bool:
+        """
+        True 表示该工具的 ephemeral 注入内容在持久化时不会落库，
+        但后续拼接历史上下文时应根据持久化的 TOOL ack 恢复对应注入。
+        默认不恢复；例如 load_skill 需要恢复 SKILL.md，load_skill_asset 不需要恢复。
         """
         return False
 

--- a/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
+++ b/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
@@ -1,6 +1,18 @@
 # src/chat/domain/interfaces/tool.py
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from dataclasses import dataclass
+from typing import Dict, Any, Optional, Union
+
+
+@dataclass(frozen=True)
+class ToolExecutionResult:
+    """
+    Structured tool result used when a tool needs to separate protocol-facing
+    tool content from control-plane system instructions.
+    """
+    tool_content: str
+    system_injection: Optional[str] = None
+    frontend_output: Optional[Any] = None
 
 
 class BaseTool(ABC):
@@ -49,7 +61,7 @@ class BaseTool(ABC):
         }
 
     @abstractmethod
-    async def execute(self, context: Dict[str, Any], **kwargs) -> str:
+    async def execute(self, context: Dict[str, Any], **kwargs) -> Union[str, ToolExecutionResult]:
         """
         执行工具逻辑。
         :param context: 系统强注入的安全上下文（session_id、user_id 等），

--- a/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
+++ b/services/wisepen-chat-service/src/chat/domain/interfaces/tool.py
@@ -8,10 +8,10 @@ from typing import Dict, Any, Optional, Union
 class ToolExecutionResult:
     """
     Structured tool result used when a tool needs to separate protocol-facing
-    tool content from control-plane system instructions.
+    tool content from turn-local control-plane instructions.
     """
     tool_content: str
-    system_injection: Optional[str] = None
+    user_injection: Optional[str] = None
     frontend_output: Optional[Any] = None
 
 

--- a/services/wisepen-chat-service/src/chat/domain/message_lifecycle.py
+++ b/services/wisepen-chat-service/src/chat/domain/message_lifecycle.py
@@ -1,0 +1,27 @@
+from enum import Enum
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LLMVisibility(str, Enum):
+    INCLUDE = "include"
+    EXCLUDE = "exclude"
+
+
+class PersistenceMode(str, Enum):
+    PERSIST_FULL = "persist_full"
+    DROP = "drop"
+    REDACT_CONTENT = "redact_content"
+    PERSIST_CONTENT = "persist_content"
+
+
+class RestoreRef(BaseModel):
+    kind: str
+    data: Dict[str, str] = Field(default_factory=dict)
+
+
+class MessageLifecycle(BaseModel):
+    llm_visibility: LLMVisibility = LLMVisibility.INCLUDE
+    persistence_mode: PersistenceMode = PersistenceMode.PERSIST_FULL
+    restore_ref: Optional[RestoreRef] = None

--- a/services/wisepen-chat-service/src/chat/scripts/seed_demo_skills.py
+++ b/services/wisepen-chat-service/src/chat/scripts/seed_demo_skills.py
@@ -186,9 +186,10 @@ async def _main() -> None:
     mongo_url = os.environ.get(
         "SEED_MONGO_URL", "mongodb://root:root@localhost:27017/"
     )
+    mongo_db_name = os.environ.get("SEED_MONGO_DB_NAME", "wisepen_chat")
     mongo_client = AsyncMongoClient(mongo_url)
     await init_beanie(
-        database=mongo_client["wisepen_chat"],
+        database=mongo_client[mongo_db_name],
         document_models=[Skill],
     )
 
@@ -200,7 +201,7 @@ async def _main() -> None:
             await _seed_one_bundle(version_dir, skill_id=skill_id, version=version)
             seeded += 1
 
-    log_event("seed_demo_skills: 完成", bundles=seeded, root=str(root))
+    log_event("seed_demo_skills: 完成", bundles=seeded, root=str(root), db=mongo_db_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
概述
* 本次 PR 主要优化 Chat Service 中 Skill 的加载、上下文注入、文件生命周期和前端消息转换逻辑，使 Skill 相关上下文更可控，并减少重复加载与无效持久化。

主要改动
* 调整 Skill 加载机制，引入消息生命周期标签，区分临时上下文与需要持久化的对话消息。
* 新增 message_lifecycle.py，统一管理 ephemeral 等消息生命周期字段。
* 优化 Skill prompt 构建逻辑，约束 references/ 和 assets/ 的使用方式。
* 新增已加载文件检查工具，避免重复读取已经加载过的文件。
* 调整文件生命周期策略，不再持久化 Skill 和 Skill assets。
* 收紧历史搜索工具逻辑，仅在压缩上下文后存储。
* 新增 Markdown 和 LaTeX 输出相关系统提示词。
* 修复前端 UI message 转换中 tool call function 字段读取错误的问题。

影响范围
* Chat 上下文组装与消息持久化逻辑
* Skill 加载与 Skill assets 读取逻辑
* 前端 UIMessage 的 tool call 渲染数据
* Demo skills 初始化数据
