### PR TITLE
fix(chat): 修复持久化历史上下文回填顺序错误与 prompt 组装时的窗口消息顺序。

### DIFF
--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -109,7 +109,7 @@ class ChatTurnCoordinator:
         tool_context: dict[str, Any] = {
             "session_id": session_id,
             "user_id": user_id,
-        } 
+        }
 
         # [Skill Discovery] 返回本轮可展示给 LLM 的 Skill metadata，由 LLM 判断是否加载。
         available_skills = self._skill_matcher.match(user_query)
@@ -124,7 +124,7 @@ class ChatTurnCoordinator:
         # runtime_discovered_tools 预留给"运行时动态发现的工具"（如 Skill bundle 自带 tools），暂时留空
         # allow_tool_name_set/deny_tool_name_set 预留给未来"用户级工具偏好"接入，暂时留空
         tool_scope = self._tool_registry.derive(
-            tool_context=tool_context, 
+            tool_context=tool_context,
             runtime_discovered_tools=None,
             expose_tool_name_set=expose_tool_name_set,
             allow_tool_name_set=None,
@@ -133,7 +133,7 @@ class ChatTurnCoordinator:
 
         # [Context Construction] 将系统提示词、Mem0 检索到的事实、会话的历史摘要、前端上下文以及窗口内的明细消息组装成 LLM 所需的格式
         messages_for_llm = self._context_assembler.assemble_prompt(
-            session_id, user_query, messages_keep+messages_compress_candidates, relevant_facts, session_summary,
+            session_id, user_query, messages_compress_candidates+messages_keep, relevant_facts, session_summary,
             states=states,
             available_skills=available_skills or None,
         )

--- a/services/wisepen-chat-service/src/chat/core/persistence/mongo/message_repository.py
+++ b/services/wisepen-chat-service/src/chat/core/persistence/mongo/message_repository.py
@@ -18,7 +18,8 @@ class MongoMessageRepository(MessageRepository):
         conditions = [ChatMessage.session_id == session_id]
         if after:
             conditions.append(ChatMessage.created_at > after)
-        return await ChatMessage.find(*conditions).sort("+created_at").limit(limit).to_list()
+        messages = await ChatMessage.find(*conditions).sort("-created_at").limit(limit).to_list()
+        return list(reversed(messages))
 
     async def list_session_message_turns_page(
         self,


### PR DESCRIPTION
## 问题

Redis 热上下文清空后，MongoDB 回填历史消息时原逻辑取到的是摘要时间之后最早的 N 条，而不是最新 N 条，导致较新的对话没有进入 LLM 上下文。

同时，token window 构造后传入 prompt 的拼接顺序存在问题，可能让较新的消息排在较旧消息之前。

## 修改内容

- Mongo 回填时按 `created_at` 倒序取最新 N 条
- 返回前反转为由旧到新，保证 Redis 与 LLM prompt 顺序一致
- 调整 prompt 组装时窗口消息顺序为 `messages_compress_candidates + messages_keep` 