### PR TITLE
fix()：阻断问题修复

### DIFF
--- a/services/wisepen-chat-service/src/chat/api/endpoints/session.py
+++ b/services/wisepen-chat-service/src/chat/api/endpoints/session.py
@@ -157,12 +157,15 @@ async def get_session_messages(
     tool_states = {}
     if page == 1:
         pending = await suspended_chat_repo.find_suspended_by_session(session_id, user_id)
-        pending_messages = list(pending.context.chat_record_messages)
-        for item in pending.context.turn_suspension.classified_tool_invocation_plan.approval_required_tools:
-            tool_states[item.tool_call_id] = "approval-requested"
-        for item in pending.context.turn_suspension.classified_tool_invocation_plan.client_tools:
-            tool_states[item.tool_call_id] = "input-available"
-        messages_for_ui.extend(pending_messages)
+        # 普通、空白或已完成会话没有 SuspendedChat；仅在存在挂起记录时读取 context，
+        # 避免历史首页对 None 解引用并返回 HTTP 500。
+        if pending is not None:
+            pending_messages = list(pending.context.chat_record_messages)
+            for item in pending.context.turn_suspension.classified_tool_invocation_plan.approval_required_tools:
+                tool_states[item.tool_call_id] = "approval-requested"
+            for item in pending.context.turn_suspension.classified_tool_invocation_plan.client_tools:
+                tool_states[item.tool_call_id] = "input-available"
+            messages_for_ui.extend(pending_messages)
 
     ui_messages = convert_to_ui_messages(messages_for_ui, tool_states=tool_states)
 

--- a/services/wisepen-chat-service/src/chat/api/endpoints/session.py
+++ b/services/wisepen-chat-service/src/chat/api/endpoints/session.py
@@ -157,8 +157,6 @@ async def get_session_messages(
     tool_states = {}
     if page == 1:
         pending = await suspended_chat_repo.find_suspended_by_session(session_id, user_id)
-        # 普通、空白或已完成会话没有 SuspendedChat；仅在存在挂起记录时读取 context，
-        # 避免历史首页对 None 解引用并返回 HTTP 500。
         if pending is not None:
             pending_messages = list(pending.context.chat_record_messages)
             for item in pending.context.turn_suspension.classified_tool_invocation_plan.approval_required_tools:

--- a/services/wisepen-chat-service/src/chat/api/vercel_sse_mapper.py
+++ b/services/wisepen-chat-service/src/chat/api/vercel_sse_mapper.py
@@ -7,7 +7,8 @@ from chat.api.vercel_formats import (
     text_start, text_delta, text_end,
     reasoning_start, reasoning_delta, reasoning_end,
     tool_input_start, tool_input_available, tool_output_available,
-    tool_output_error, tool_output_denied, tool_approval_request, error,
+    # 名称必须与 vercel_formats 的实际导出一致，否则 Chat API 会在启动导入阶段失败。
+    tool_error, tool_denied, tool_approval_request, error,
 )
 from chat.application.events import (
     StreamEvent, ErrorEvent,
@@ -52,9 +53,9 @@ def to_vercel_sse(event: StreamEvent) -> str:
     if isinstance(event, ToolOutputAvailableEvent):
         return tool_output_available(tool_call_id=event.call_id, output=event.output)
     if isinstance(event, ToolErrorEvent):
-        return tool_output_error(tool_call_id=event.call_id, error_text=event.error_text)
+        return tool_error(tool_call_id=event.call_id, error_text=event.error_text)
     if isinstance(event, ToolDeniedEvent):
-        return tool_output_denied(tool_call_id=event.call_id)
+        return tool_denied(tool_call_id=event.call_id)
     if isinstance(event, ToolApprovalRequiredEvent):
         return tool_approval_request(
             approval_id=event.call_id,

--- a/services/wisepen-chat-service/src/chat/api/vercel_sse_mapper.py
+++ b/services/wisepen-chat-service/src/chat/api/vercel_sse_mapper.py
@@ -7,7 +7,6 @@ from chat.api.vercel_formats import (
     text_start, text_delta, text_end,
     reasoning_start, reasoning_delta, reasoning_end,
     tool_input_start, tool_input_available, tool_output_available,
-    # 名称必须与 vercel_formats 的实际导出一致，否则 Chat API 会在启动导入阶段失败。
     tool_error, tool_denied, tool_approval_request, error,
 )
 from chat.application.events import (

--- a/services/wisepen-chat-service/src/chat/application/tools/core/definition.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/core/definition.py
@@ -3,9 +3,10 @@ from enum import StrEnum
 from typing import Any, Protocol, Dict, Callable, TYPE_CHECKING
 
 from chat.application.events import StreamEvent
-from chat.application.tools.core.llm.invocation import ToolInvocation
 from chat.domain.entities import ChatMessage
 
+# definition 是 invocation 的下层依赖，且本模块不使用 ToolInvocation；反向导入会让
+# invocation 在这些枚举尚未定义完成时回读 definition，从而触发循环导入。
 if TYPE_CHECKING:
     from chat.application.tools.core.execution.hooks.base import ToolPreflightHook
 

--- a/services/wisepen-chat-service/src/chat/application/tools/core/definition.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/core/definition.py
@@ -5,8 +5,6 @@ from typing import Any, Protocol, Dict, Callable, TYPE_CHECKING
 from chat.application.events import StreamEvent
 from chat.domain.entities import ChatMessage
 
-# definition 是 invocation 的下层依赖，且本模块不使用 ToolInvocation；反向导入会让
-# invocation 在这些枚举尚未定义完成时回读 definition，从而触发循环导入。
 if TYPE_CHECKING:
     from chat.application.tools.core.execution.hooks.base import ToolPreflightHook
 

--- a/services/wisepen-chat-service/src/chat/core/persistence/redis/chat_turn_stream.py
+++ b/services/wisepen-chat-service/src/chat/core/persistence/redis/chat_turn_stream.py
@@ -109,8 +109,9 @@ class RedisChatTurnStream:
 
         # 如果已有事件重放完了，但还没结束，就进入循环
         while True:
-            # 从 last_id 之后继续读，如果暂时没有新事件，最多等 15 秒，一次最多读 50 条
-            result = await self.redis.xread({stream_key: last_id}, block=15000, count=50)
+            # redis-py 8 默认 socket_timeout 为 5 秒；BLOCK 留 1 秒余量，避免客户端
+            # 在 Redis 返回空结果前先读超时并关闭 SSE 连接。
+            result = await self.redis.xread({stream_key: last_id}, block=4000, count=50)
             if not result:
                 continue # 继续循环
 

--- a/services/wisepen-chat-service/src/chat/core/persistence/redis/chat_turn_stream.py
+++ b/services/wisepen-chat-service/src/chat/core/persistence/redis/chat_turn_stream.py
@@ -109,8 +109,7 @@ class RedisChatTurnStream:
 
         # 如果已有事件重放完了，但还没结束，就进入循环
         while True:
-            # redis-py 8 默认 socket_timeout 为 5 秒；BLOCK 留 1 秒余量，避免客户端
-            # 在 Redis 返回空结果前先读超时并关闭 SSE 连接。
+            # 从 last_id 之后继续读，如果暂时没有新事件，最多等 4 秒，一次最多读 50 条
             result = await self.redis.xread({stream_key: last_id}, block=4000, count=50)
             if not result:
                 continue # 继续循环

--- a/services/wisepen-chat-service/src/chat/domain/repositories/suspended_chat_repo.py
+++ b/services/wisepen-chat-service/src/chat/domain/repositories/suspended_chat_repo.py
@@ -1,6 +1,12 @@
-from abc import ABC, abstractmethod
+from __future__ import annotations
 
-from chat.domain.entities import SuspendedChat
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+# 仓储接口仅用 SuspendedChat 做类型标注；运行时导入会在实体初始化期间
+# 经 repositories.__init__ 回指尚未定义完成的 SuspendedChat，形成循环导入。
+if TYPE_CHECKING:
+    from chat.domain.entities.suspended_chat import SuspendedChat
 
 
 class SuspendedChatRepository(ABC):

--- a/services/wisepen-chat-service/src/chat/domain/repositories/suspended_chat_repo.py
+++ b/services/wisepen-chat-service/src/chat/domain/repositories/suspended_chat_repo.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-# 仓储接口仅用 SuspendedChat 做类型标注；运行时导入会在实体初始化期间
-# 经 repositories.__init__ 回指尚未定义完成的 SuspendedChat，形成循环导入。
 if TYPE_CHECKING:
     from chat.domain.entities.suspended_chat import SuspendedChat
 


### PR DESCRIPTION
fix(Chat): 修复启动阻断与 Redis SSE 读取超时

修复 Chat 服务启动阶段的循环依赖和 SSE 事件映射问题，并将 Redis XREAD BLOCK 调整为 4 秒，避免默认 5 秒 socket timeout 导致 SSE 在 DONE 前断开。
