### PR TITLE
fix()：上一次挂起时的工具调用恢复成可继续执行的 step

### DIFF
--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -24,7 +24,7 @@ from chat.application.agents import (
     AgentResolver,
     DefaultAgentResolver, AgentSpec,
 )
-from chat.application.events import StepFinishEvent, ErrorEvent
+from chat.application.events import ErrorEvent, StepFinishEvent, TurnSuspension
 from chat.api.vercel_sse_mapper import to_vercel_sse
 from chat.application.chat_turn_finalizer import ChatTurnFinalizer
 from chat.application.tools.skill_tools.utils.skill_matcher import SkillMatcher
@@ -112,6 +112,7 @@ class ChatTurnCoordinator:
         if suspended_chat is None:
             raise ServiceException(ChatErrorCode.SUSPENDED_CHAT_NOT_FOUND)
         suspended_chat_id = str(suspended_chat.id)
+        turn_suspension = suspended_chat.context.turn_suspension
         tool_scope = await self._tool_registry.recover_derived(suspended_chat.context.tool_scope_data, user_id)
 
         chat_turn_context = ChatTurnContext(
@@ -122,20 +123,37 @@ class ChatTurnCoordinator:
             session_summary=suspended_chat.context.session_summary,
             windowed_history_messages=suspended_chat.context.windowed_history_messages,
             tool_scope=tool_scope,
-            messages_for_llm=suspended_chat.context.messages_for_llm,
-            chat_record_messages=suspended_chat.context.chat_record_messages,
-            token_usage=suspended_chat.context.token_usage
+            messages_for_llm=list(suspended_chat.context.messages_for_llm),
+            # 首次挂起批次已经落库和计费；恢复批次只记录新增的工具结果和后续回复。
+            chat_record_messages=[],
+            token_usage=0,
         )
 
         async for event in self.query_llm(
             chat_turn_context=chat_turn_context,
             client_tool_results=client_tool_results,
             tool_approval_status=tool_approval_status,
+            resumed_turn_suspension=turn_suspension,
             cancel_requested=cancel_requested,
         ):
             yield event
-        self.set_background_task(background_tasks, chat_turn_context)
-
+        # 恢复在执行保存的工具计划前被取消时不会产生新增消息；此时必须保留挂起记录，
+        # 否则下一轮历史只剩 assistant function_call，缺少对应的 Role.TOOL。
+        if not chat_turn_context.chat_record_messages:
+            return
+        # 恢复批次必须先完成消息持久化，再删除挂起记录；否则后台任务失败时，
+        # assistant function_call 可能已经随挂起记录一起丢失对应的 Role.TOOL 结果，
+        # 下一轮回放会把不完整的工具调用历史提交给 provider。
+        await self._turn_finalizer.persist_message_and_token_bill(
+            user_id=chat_turn_context.user_id,
+            session_id=chat_turn_context.session_id,
+            chat_record_messages=chat_turn_context.chat_record_messages,
+            memory_policy=chat_turn_context.agent_spec.memory_policy,
+            model_info=chat_turn_context.model_info,
+            token_usage=chat_turn_context.token_usage,
+            billing_group_id=chat_turn_context.agent_spec.billing_group_id,
+        )
+        # 只有上面的持久化成功后才删除挂起记录，失败时保留它以便重试或由下一轮关闭。
         await self._suspended_chat_repo.delete_by_id(suspended_chat_id)
 
     # -------------------------------------------------------------------------
@@ -331,6 +349,7 @@ class ChatTurnCoordinator:
             chat_turn_context: ChatTurnContext,
             client_tool_results: list[ClientToolResult] | None,
             tool_approval_status: List[ToolApprovalStatus] | None,
+            resumed_turn_suspension: TurnSuspension | None = None,
             cancel_requested: Callable[[], Awaitable[bool]] | None = None,
     ):
         # 流式推理
@@ -343,6 +362,7 @@ class ChatTurnCoordinator:
                 model_info=chat_turn_context.model_info,
                 client_tool_results=client_tool_results,
                 tool_approval_status=tool_approval_status,
+                resumed_turn_suspension=resumed_turn_suspension,
                 cancel_requested=cancel_requested,
             ):
                 # QueryLoopRuntime 产出的事件如果是 StepFinishEvent 额外处理消息累积
@@ -383,6 +403,8 @@ class ChatTurnCoordinator:
                     return
         except ServiceException as e:
             error("chat stream generation failed.", session_id=chat_turn_context.session_id, exc=e)
+            if resumed_turn_suspension is not None and not chat_turn_context.chat_record_messages:
+                raise
             yield to_vercel_sse(ErrorEvent(error_text=str(e)))
             return
 
@@ -442,8 +464,11 @@ class ChatTurnCoordinator:
             for invocation in unfinished_chat.context.turn_suspension.classified_tool_invocation_plan.server_tools
         )
 
+        # 首次挂起批次的 user/assistant（含 function_call）已经落库；这里只构造
+        # 本次关闭新增的工具结果和结束 assistant，避免下一轮历史出现重复消息/重复计费。
+        close_messages = []
         for invocation, message in pending_messages:
-            unfinished_chat.context.chat_record_messages.append(
+            close_messages.append(
                 ChatMessage(
                     session_id=session_id, role=Role.TOOL,
                     tool_call_id=invocation.tool_call_id, tool_name=invocation.tool_name,
@@ -451,7 +476,7 @@ class ChatTurnCoordinator:
                 )
             )
 
-        unfinished_chat.context.chat_record_messages.append(
+        close_messages.append(
             ChatMessage(
                 session_id=session_id, role=Role.ASSISTANT,
                 content="本轮对话已中断，未能生成完整回复",
@@ -462,10 +487,11 @@ class ChatTurnCoordinator:
         await self._turn_finalizer.persist_message_and_token_bill(
             user_id=unfinished_chat.user_id,
             session_id=unfinished_chat.session_id,
-            chat_record_messages=unfinished_chat.context.chat_record_messages,
+            chat_record_messages=close_messages,
             memory_policy=unfinished_chat.context.agent_spec.memory_policy,
             model_info=unfinished_chat.context.model_info,
-            token_usage=unfinished_chat.context.token_usage,
+            # 原始模型调用已在首次挂起批次计费，关闭动作只补写状态消息，不应重复计费。
+            token_usage=0,
             billing_group_id=unfinished_chat.context.agent_spec.billing_group_id,
         )
         # 调用轻量级模型生成并更新会话的全局摘要
@@ -473,10 +499,12 @@ class ChatTurnCoordinator:
                 and unfinished_chat.context.agent_spec.memory_policy.enable_chat_memory_summary
                 and unfinished_chat.context.windowed_history_messages is not None
                 and unfinished_chat.context.windowed_history_messages.needs_compression):
+            # 摘要输入可以包含首次挂起批次的完整上下文，但正式持久化仍只写 close_messages，
+            # 这样既不遗漏当前用户问题，又不会重复落库 user/assistant/function_call。
             await self._turn_finalizer.summarize_and_compress(
                 session_id=unfinished_chat.session_id,
                 windowed_history_messages=unfinished_chat.context.windowed_history_messages,
-                chat_record_messages=unfinished_chat.context.chat_record_messages,
+                chat_record_messages=[*unfinished_chat.context.chat_record_messages, *close_messages],
                 existing_summary=unfinished_chat.context.session_summary,
                 memory_policy=unfinished_chat.context.agent_spec.memory_policy,
             )

--- a/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
+++ b/services/wisepen-chat-service/src/chat/application/query_loop_runtime.py
@@ -27,7 +27,11 @@ from chat.application.tools.core.definition import ClientToolResult, ToolApprova
 from chat.application.tools import ToolScope
 from chat.application.tools.core.execution.dispatcher import ToolDispatcher
 from chat.application.tools.core.execution.result import ToolExecutionResult
-from chat.application.tools.core.llm.invocation import ToolInvocation, classify_tools
+from chat.application.tools.core.llm.invocation import (
+    ClassifiedToolInvocationPlan,
+    ToolInvocation,
+    classify_tools,
+)
 from chat.application.tools.core.llm.renderer import tool_result_renderer
 from chat.core.config.app_settings import settings
 from chat.domain.entities import ChatMessage, Role
@@ -154,6 +158,7 @@ class QueryLoopRuntime:
         start_iteration: int = 0,
         client_tool_results: list[ClientToolResult] = None,
         tool_approval_status: List[ToolApprovalStatus] = None,
+        resumed_turn_suspension: TurnSuspension | None = None,
         cancel_requested: Callable[[], Awaitable[bool]] | None = None,
     ) -> AsyncIterator[StreamEvent]:
         # 解析获取当前模型的 LLMProvider
@@ -173,8 +178,15 @@ class QueryLoopRuntime:
         # 进入多轮循环
         _client_tool_results = client_tool_results
         _tool_approval_status = tool_approval_status
+        _resumed_tool_invocation_plan = (
+            resumed_turn_suspension.classified_tool_invocation_plan
+            if resumed_turn_suspension is not None
+            else None
+        )
 
         max_iterations = agent_max_iterations or settings.AGENT_MAX_ITERATIONS
+        if resumed_turn_suspension is not None:
+            start_iteration = resumed_turn_suspension.iteration
         for iteration in range(start_iteration, max_iterations):
             # 请求取消检查点
             if cancel_requested is not None and await cancel_requested():
@@ -193,6 +205,7 @@ class QueryLoopRuntime:
                 tool_scope=tool_scope,
                 client_tool_results=_client_tool_results,
                 tool_approval_status=_tool_approval_status,
+                resumed_tool_invocation_plan=_resumed_tool_invocation_plan,
                 cancel_requested=cancel_requested,
             ):
                 # 如果拿到的是 StepFinishEvent 就存到 step_finish_event；否则直接 yield
@@ -203,6 +216,7 @@ class QueryLoopRuntime:
             # 清空客户端工具调用结果和工具批准状态，以推进正常循环
             _client_tool_results = None
             _tool_approval_status = None
+            _resumed_tool_invocation_plan = None
 
             assert step_finish_event is not None
             if step_finish_event.aborted:
@@ -235,10 +249,30 @@ class QueryLoopRuntime:
         tool_scope: ToolScope,
         client_tool_results: list[ClientToolResult] | None = None,
         tool_approval_status: List[ToolApprovalStatus] | None = None,
+        resumed_tool_invocation_plan: ClassifiedToolInvocationPlan | None = None,
         cancel_requested: Callable[[], Awaitable[bool]] | None = None,
     ) -> AsyncIterator[Union[StreamEvent, StepFinishEvent]]:
         # 发 step 开始事件
         yield StepStartEvent()
+
+        # 恢复不是一次新的模型推理。assistant 工具调用消息已在挂起前写入 messages，
+        # 此处只消费持久化的调用计划并补齐 Role.TOOL 消息。
+        if resumed_tool_invocation_plan is not None:
+            async for event in self._run_resumed_tool_step(
+                session_id=session_id,
+                tool_scope=tool_scope,
+                tool_invocation_plan=resumed_tool_invocation_plan,
+                client_tool_results=client_tool_results or [],
+                tool_approval_status=tool_approval_status or [],
+                cancel_requested=cancel_requested,
+            ):
+                yield event
+            return
+        if client_tool_results is not None or tool_approval_status is not None:
+            raise ServiceException(
+                ChatErrorCode.SUSPENDED_CHAT_STATE_INVALID,
+                custom_msg="恢复工具结果时缺少挂起工具计划",
+            )
 
         # 创建本轮推理的事件解释器
         event_interpreter = _StepEventInterpreter()
@@ -475,6 +509,106 @@ class QueryLoopRuntime:
                 aborted=True,
             )
             return
+
+    async def _run_resumed_tool_step(
+        self,
+        *,
+        session_id: str,
+        tool_scope: ToolScope,
+        tool_invocation_plan: ClassifiedToolInvocationPlan,
+        client_tool_results: list[ClientToolResult],
+        tool_approval_status: list[ToolApprovalStatus],
+        cancel_requested: Callable[[], Awaitable[bool]] | None,
+    ) -> AsyncIterator[Union[StreamEvent, StepFinishEvent]]:
+        """完成挂起 step 的工具阶段，不重复创建已持久化的 assistant 消息。"""
+        new_messages: list[ChatMessage] = []
+        tool_outputs: list[ToolExecutionResult] = []
+        invocations = [
+            *tool_invocation_plan.server_tools,
+            *tool_invocation_plan.approval_required_tools,
+            *tool_invocation_plan.client_tools,
+        ]
+
+        try:
+            if cancel_requested is not None and await cancel_requested():
+                raise asyncio.CancelledError
+
+            approval_by_call_id = {
+                status.tool_call_id: status.approved
+                for status in tool_approval_status
+            }
+            for invocation in tool_invocation_plan.approval_required_tools:
+                invocation.is_approved = approval_by_call_id[invocation.tool_call_id]
+
+            # 首次 step 因外部动作整体挂起，混合计划中的 server tools 尚未执行，
+            # 因此恢复时必须完成三类工具。
+            if tool_invocation_plan.server_tools:
+                output = await self._tool_dispatcher.dispatch(
+                    tool_invocation_plan.server_tools,
+                    tool_scope,
+                )
+                tool_outputs.extend(output.results)
+
+            if tool_invocation_plan.approval_required_tools:
+                if cancel_requested is not None and await cancel_requested():
+                    raise asyncio.CancelledError
+                output = await self._tool_dispatcher.dispatch(
+                    tool_invocation_plan.approval_required_tools,
+                    tool_scope,
+                )
+                tool_outputs.extend(output.results)
+
+            if tool_invocation_plan.client_tools:
+                if cancel_requested is not None and await cancel_requested():
+                    raise asyncio.CancelledError
+                output = await self._tool_dispatcher.client_dispatch(
+                    tool_invocation_plan.client_tools,
+                    client_tool_results,
+                    tool_scope,
+                )
+                tool_outputs.extend(output.results)
+
+            for result in tool_outputs:
+                tool = tool_scope.get(result.tool_invocation.tool_name)
+                rendered = tool_result_renderer(result, tool.definition if tool else None)
+                tool_message_content = rendered.tool_output
+                if not isinstance(tool_message_content, str):
+                    tool_message_content = (
+                        ""
+                        if tool_message_content is None
+                        else json.dumps(tool_message_content, ensure_ascii=False, default=str)
+                    )
+
+                yield ToolOutputAvailableEvent(
+                    call_id=rendered.tool_call_id,
+                    output=rendered.tool_output,
+                )
+                new_messages.append(
+                    ChatMessage(
+                        session_id=session_id,
+                        role=Role.TOOL,
+                        tool_call_id=rendered.tool_call_id,
+                        tool_name=rendered.tool_name,
+                        content=tool_message_content,
+                        persisted_output_placeholder=rendered.persisted_output_placeholder,
+                    )
+                )
+
+            yield StepFinishEvent(
+                is_finished=False,
+                intermediate_messages=new_messages,
+                token_usage=0,
+            )
+        except asyncio.CancelledError:
+            yield StepFinishEvent(
+                is_finished=False,
+                intermediate_messages=self._build_aborted_tool_messages(
+                    session_id=session_id,
+                    invocations=invocations,
+                ),
+                token_usage=0,
+                aborted=True,
+            )
 
     def _build_aborted_tool_messages(
         self,

--- a/services/wisepen-chat-service/src/chat/domain/entities/suspended_chat.py
+++ b/services/wisepen-chat-service/src/chat/domain/entities/suspended_chat.py
@@ -27,6 +27,12 @@ class SuspendedTurnContext:
     turn_suspension: TurnSuspension
 
 
+def _encode_context(value: SuspendedTurnContext) -> str:
+    return base64.b64encode(
+        pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+    ).decode("ascii")
+
+
 class SuspendedChat(Document):
     """未完成 Chat Turn 的临时恢复缓存"""
     session_id: str
@@ -46,10 +52,12 @@ class SuspendedChat(Document):
 
     @field_serializer("context")
     def encode_context(self, value: SuspendedTurnContext):
-        return base64.b64encode(pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)).decode("ascii")
+        return _encode_context(value)
 
     class Settings:
         name = "wisepen_suspended_chat"
+        # Beanie 的 Document BSON 编码不会调用 Pydantic field_serializer。
+        bson_encoders = {SuspendedTurnContext: _encode_context}
         indexes = [
             IndexModel([
                 ("session_id", ASCENDING),


### PR DESCRIPTION
当前修复中，为了避免后台异步持久化和理解删除 SuspendedChat 的会有回放失败风险，采用先同步持久化
再删除 Suspendedchat 的改动，因此存在明确延迟才能恢复工具产生 SSE