### PR TITLE
Agent 配置注入与集成

### DIFF
--- a/services/wisepen-chat-service/src/chat/application/agents/__init__.py
+++ b/services/wisepen-chat-service/src/chat/application/agents/__init__.py
@@ -1,4 +1,10 @@
 from chat.application.agents.default_agent import DEFAULT_AGENT_ID, build_default_agent
+from chat.application.agents.agent_assets import AgentAssetMeta
+from chat.application.agents.asset_loader import (
+    AgentAssetLoader,
+    AgentAssetNotFoundError,
+    AgentAssetUnavailableError,
+)
 from chat.application.agents.models import (
     Agent,
     AgentMemoryPolicy,
@@ -6,12 +12,16 @@ from chat.application.agents.models import (
     AgentToolAndSkillPolicy,
     AgentSpec,
 )
-from chat.application.agents.resolver import AgentResolver, CompositeAgentResolver, DefaultAgentResolver
+from chat.application.agents.resolver import AgentResolver, CompositeAgentResolver, DefaultAgentResolver, RemoteAgentResolver
 
 __all__ = [
     "DEFAULT_AGENT_ID",
     "build_default_agent",
     "Agent",
+    "AgentAssetMeta",
+    "AgentAssetLoader",
+    "AgentAssetNotFoundError",
+    "AgentAssetUnavailableError",
     "AgentMemoryPolicy",
     "AgentModelPolicy",
     "AgentToolAndSkillPolicy",
@@ -19,4 +29,5 @@ __all__ = [
     "AgentResolver",
     "CompositeAgentResolver",
     "DefaultAgentResolver",
+    "RemoteAgentResolver",
 ]

--- a/services/wisepen-chat-service/src/chat/application/agents/agent_assets.py
+++ b/services/wisepen-chat-service/src/chat/application/agents/agent_assets.py
@@ -1,0 +1,27 @@
+from typing import Any, Mapping
+
+from pydantic import BaseModel, Field
+
+
+class AgentAssetMeta(BaseModel):
+    """Agent version bundle asset metadata returned by Java AI Asset service."""
+
+    id: str = Field(...)
+    path: str = Field(...)
+    object_key: str = Field(...)
+    kind: str = Field(...)
+    upload_status: str = Field(...)
+    description: str | None = None
+    size_bytes: int = Field(default=0)
+
+    @classmethod
+    def from_response(cls, payload: Mapping[str, Any]) -> "AgentAssetMeta":
+        return cls(
+            id=str(payload.get("id")),
+            path=str(f"{payload.get('path').rstrip('/')}/{payload.get('name')}"),
+            object_key=str(payload.get("objectKey")),
+            kind=str(payload.get("assetResourceType")),
+            upload_status=str(payload.get("uploadStatus")),
+            description=str(payload.get("description") or ""),
+            size_bytes=int(payload.get("size") or 0),
+        )

--- a/services/wisepen-chat-service/src/chat/application/agents/agent_assets.py
+++ b/services/wisepen-chat-service/src/chat/application/agents/agent_assets.py
@@ -3,6 +3,7 @@ from typing import Any, Mapping
 from pydantic import BaseModel, Field
 
 
+# 预留：Agent 资产元数据目前仅映射 Java 版本包，尚未进入 Chat 使用链路。
 class AgentAssetMeta(BaseModel):
     """Agent version bundle asset metadata returned by Java AI Asset service."""
 

--- a/services/wisepen-chat-service/src/chat/application/agents/asset_loader.py
+++ b/services/wisepen-chat-service/src/chat/application/agents/asset_loader.py
@@ -1,0 +1,27 @@
+from chat.application.agents.models import Agent
+from chat.domain.interfaces.file_loader import FileLoader
+
+
+class AgentAssetNotFoundError(LookupError):
+    pass
+
+
+class AgentAssetUnavailableError(ValueError):
+    pass
+
+
+class AgentAssetLoader:
+    """Read a declared asset from an already resolved Agent version snapshot."""
+
+    def __init__(self, file_loader: FileLoader) -> None:
+        self._file_loader = file_loader
+
+    async def load_by_path(self, agent: Agent, path: str) -> bytes:
+        asset = next((asset for asset in agent.assets_manifest if asset.path == path), None)
+        if asset is None:
+            raise AgentAssetNotFoundError(f"Agent asset is not declared: {path}")
+        if asset.upload_status.upper() != "AVAILABLE":
+            raise AgentAssetUnavailableError(f"Agent asset is not ready: {path}")
+        if not asset.object_key:
+            raise AgentAssetUnavailableError(f"Agent asset has no object key: {path}")
+        return await self._file_loader.load_by_object_key(asset.object_key)

--- a/services/wisepen-chat-service/src/chat/application/agents/asset_loader.py
+++ b/services/wisepen-chat-service/src/chat/application/agents/asset_loader.py
@@ -10,6 +10,7 @@ class AgentAssetUnavailableError(ValueError):
     pass
 
 
+# 预留：等待 Agent 资产按需读取能力接入 Chat Tool。
 class AgentAssetLoader:
     """Read a declared asset from an already resolved Agent version snapshot."""
 

--- a/services/wisepen-chat-service/src/chat/application/agents/models.py
+++ b/services/wisepen-chat-service/src/chat/application/agents/models.py
@@ -150,6 +150,7 @@ class Agent(BaseModel):
     source_type: str = ""
     version: int = 0
     version_status: str = ""
+    # 预留：Agent 资产清单尚未进入 Chat 使用链路。
     assets_manifest: List[AgentAssetMeta] = Field(default_factory=list)
     spec: AgentSpec
 

--- a/services/wisepen-chat-service/src/chat/application/agents/models.py
+++ b/services/wisepen-chat-service/src/chat/application/agents/models.py
@@ -1,5 +1,7 @@
-from typing import Optional, Set
+from typing import Any, List, Mapping, Optional, Set
 from pydantic import BaseModel, Field, model_validator
+
+from chat.application.agents.agent_assets import AgentAssetMeta
 
 
 # 模型策略
@@ -7,6 +9,15 @@ class AgentModelPolicy(BaseModel):
     default_model_id: Optional[str] = None
     default_provider_id: Optional[str] = None
     allow_request_override: bool = True
+
+    @classmethod
+    def from_response(cls, payload: Mapping[str, Any] | None) -> "AgentModelPolicy":
+        payload = payload or {}
+        return cls(
+            default_model_id=payload.get("defaultModelId"),
+            default_provider_id=payload.get("defaultProviderId"),
+            allow_request_override=_value_or_default(payload, "allowRequestOverride", True),
+        )
 
 # 工具与skill策略
 class AgentToolAndSkillPolicy(BaseModel):
@@ -23,6 +34,18 @@ class AgentToolAndSkillPolicy(BaseModel):
     force_enabled_skill_ids: Optional[Set[str]] = None
     # 匹配前Top-K
     skill_match_top_k: Optional[int] = Field(default=20, ge=0, lt=30)
+
+    @classmethod
+    def from_response(cls, payload: Mapping[str, Any] | None) -> "AgentToolAndSkillPolicy":
+        payload = payload or {}
+        return cls(
+            enable_use_tool=_value_or_default(payload, "enableUseTool", True),
+            allow_tool_names=_string_set(payload.get("allowToolNames")),
+            deny_tool_names=_string_set(payload.get("denyToolNames")),
+            enable_use_skill=_value_or_default(payload, "enableUseSkill", True),
+            on_demand_skill_ids=_string_set(payload.get("onDemandSkillIds")),
+            force_enabled_skill_ids=_string_set(payload.get("forceEnabledSkillIds")),
+        )
 
     @model_validator(mode="after")
     def normalize_tool_and_skill_policy(self) -> "AgentToolAndSkillPolicy":
@@ -55,6 +78,22 @@ class AgentMemoryPolicy(BaseModel):
     enable_long_term_memory: bool = True
     long_term_memory_limit: Optional[int] = Field(default=10, ge=0)
     long_term_memory_score_threshold: Optional[float] = Field(default=0.6, ge=0.0, le=1.0)
+
+    @classmethod
+    def from_response(cls, payload: Mapping[str, Any] | None) -> "AgentMemoryPolicy":
+        payload = payload or {}
+        values = {
+            "enable_chat_memory": _value_or_default(payload, "enableChatMemory", True),
+            "enable_persistence_chat_memory": _value_or_default(payload, "enablePersistenceChatMemory", True),
+            "enable_chat_memory_summary": _value_or_default(payload, "enableChatMemorySummary", True),
+            "high_watermark_ratio": payload.get("highWatermarkRatio"),
+            "low_watermark_ratio": payload.get("lowWatermarkRatio"),
+            "summary_prompt": payload.get("summaryPrompt"),
+            "enable_long_term_memory": _value_or_default(payload, "enableLongTermMemory", True),
+            "long_term_memory_limit": _value_or_default(payload, "longTermMemoryLimit", 10),
+            "long_term_memory_score_threshold": _value_or_default(payload, "longTermMemoryScoreThreshold", 0.6),
+        }
+        return cls(**values)
 
     @model_validator(mode="after")
     def normalize_memory_policy(self) -> "AgentMemoryPolicy":
@@ -89,10 +128,52 @@ class AgentSpec(BaseModel):
     # 记忆策略
     memory_policy: AgentMemoryPolicy = Field(default_factory=AgentMemoryPolicy)
 
+    @classmethod
+    def from_response(cls, payload: Mapping[str, Any] | None) -> "AgentSpec":
+        payload = payload or {}
+        return cls(
+            system_prompt=str(payload.get("systemPrompt") or ""),
+            auto_generate_title=_value_or_default(payload, "autoGenerateTitle", True),
+            model_policy=AgentModelPolicy.from_response(payload.get("modelPolicy")),
+            tool_and_skill_policy=AgentToolAndSkillPolicy.from_response(payload.get("toolAndSkillPolicy")),
+            memory_policy=AgentMemoryPolicy.from_response(payload.get("memoryPolicy")),
+        )
+
 
 class Agent(BaseModel):
     agent_id: str
     name: str
     description: str = ""
+    source_type: str = ""
     version: int = 0
+    version_status: str = ""
+    assets_manifest: List[AgentAssetMeta] = Field(default_factory=list)
     spec: AgentSpec
+
+    @classmethod
+    def from_response(cls, payload: Mapping[str, Any]) -> "Agent":
+        latest_published_agent = payload.get("agentVersionBundle")
+        return cls(
+            agent_id=str(payload.get("resourceId")),
+            name=str(payload.get("name") or ""),
+            description=str(payload.get("description") or ""),
+            source_type=str(payload.get("sourceType")),
+            version=int(latest_published_agent.get("version") or 0),
+            version_status=str(latest_published_agent.get("status")),
+            assets_manifest=[
+                AgentAssetMeta.from_response(item)
+                for item in (latest_published_agent.get("assets") or [])
+            ],
+            spec=AgentSpec.from_response(latest_published_agent.get("spec")),
+        )
+
+
+def _string_set(value: Any) -> Set[str] | None:
+    if value is None:
+        return None
+    return {str(item) for item in value if item is not None}
+
+
+def _value_or_default(payload: Mapping[str, Any], key: str, default: Any) -> Any:
+    value = payload.get(key)
+    return default if value is None else value

--- a/services/wisepen-chat-service/src/chat/application/agents/resolver.py
+++ b/services/wisepen-chat-service/src/chat/application/agents/resolver.py
@@ -1,13 +1,15 @@
-﻿from typing import Protocol
-
-from common.logger import error
+from typing import TYPE_CHECKING, Protocol
 
 from chat.application.agents.default_agent import DEFAULT_AGENT_ID, build_default_agent
 from chat.application.agents.models import Agent
+from common.core.exceptions import RpcError
+
+if TYPE_CHECKING:
+    from chat.service_client import AIAssetClient
 
 
 class AgentResolver(Protocol):
-    async def resolve(self, agent_id: str | None) -> Agent | None:
+    async def resolve(self, agent_id: str | None, agent_version: int | None = None) -> Agent | None:
         ...
 
 
@@ -15,10 +17,48 @@ class DefaultAgentResolver:
     def __init__(self) -> None:
         self._default_agent = build_default_agent()
 
-    async def resolve(self, agent_id: str | None) -> Agent | None:
+    async def resolve(self, agent_id: str | None, agent_version: int | None = None) -> Agent | None:
         if agent_id is None or agent_id == DEFAULT_AGENT_ID:
             return self._default_agent
         return None
+
+
+class RemoteAgentResolver:
+    """从 Java AI Asset 服务解析自定义 Agent。"""
+
+    # Java AIResourceError values for missing resource/version.
+    _NOT_FOUND_CODES = {9111, 9211}
+
+    def __init__(self, ai_asset_client: "AIAssetClient") -> None:
+        self._client = ai_asset_client
+
+    async def resolve(self, agent_id: str | None, agent_version: int | None = None) -> Agent | None:
+        if not agent_id or agent_id == DEFAULT_AGENT_ID:
+            return None
+        if agent_version is not None and agent_version <= 0:
+            return None
+        try:
+            agent = (
+                await self._client.get_published_agent(agent_id)
+                if agent_version is None
+                else await self._client.get_agent_with_version(agent_id, agent_version)
+            )
+        except RpcError as exc:
+            if exc.code in self._NOT_FOUND_CODES:
+                return None
+            raise
+        if agent is None:
+            return None
+        if (
+            agent.agent_id != agent_id
+            or agent.version <= 0
+            or agent.version_status.upper() != "PUBLISHED"
+            or not agent.spec.system_prompt.strip()
+        ):
+            return None
+        if agent_version is not None and agent.version != agent_version:
+            return None
+        return agent
 
 
 class CompositeAgentResolver:
@@ -31,14 +71,9 @@ class CompositeAgentResolver:
         self._primary = primary
         self._fallback = fallback or DefaultAgentResolver()
 
-    async def resolve(self, agent_id: str | None) -> Agent | None:
-        if self._primary is not None and agent_id is not None:
-            try:
-                agent = await self._primary.resolve(agent_id)
-                if agent is not None:
-                    return agent
-            except Exception as e:
-                error("agent primary resolver failed.", agent_id=agent_id, exc=e)
-
-        return await self._fallback.resolve(agent_id)
-
+    async def resolve(self, agent_id: str | None, agent_version: int | None = None) -> Agent | None:
+        if agent_id is None or agent_id == DEFAULT_AGENT_ID:
+            return await self._fallback.resolve(agent_id, agent_version)
+        if self._primary is None:
+            return None
+        return await self._primary.resolve(agent_id, agent_version)

--- a/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
+++ b/services/wisepen-chat-service/src/chat/application/chat_turn_coordinator.py
@@ -23,7 +23,7 @@ from chat.application.chat_context_assembler import ChatContextAssembler, Window
 from chat.application.query_loop_runtime import QueryLoopRuntime
 from chat.application.agents import (
     AgentResolver,
-    DefaultAgentResolver, AgentSpec,
+    DefaultAgentResolver, AgentSpec, DEFAULT_AGENT_ID,
 )
 from chat.application.events import StepFinishEvent, ErrorEvent
 from chat.api.vercel_sse_mapper import to_vercel_sse
@@ -171,7 +171,15 @@ class ChatTurnCoordinator:
         chat_turn_context.user_id = user_id
         # 获取当前对话的 Agent
         session = await self._session_repo.get_session_for_user(session_id, user_id)
-        agent = await self._agent_resolver.resolve(session.agent_id)
+        if (
+            session.agent_id
+            and session.agent_id != DEFAULT_AGENT_ID
+            and (session.agent_version is None or session.agent_version <= 0)
+        ):
+            raise ServiceException(ChatErrorCode.AGENT_NOT_FOUND)
+        agent = await self._agent_resolver.resolve(session.agent_id, session.agent_version)
+        if agent is None:
+            raise ServiceException(ChatErrorCode.AGENT_NOT_FOUND)
 
         chat_turn_context.agent_spec = agent.spec
         memory_policy = chat_turn_context.agent_spec.memory_policy

--- a/services/wisepen-chat-service/src/chat/application/tools/core/registry.py
+++ b/services/wisepen-chat-service/src/chat/application/tools/core/registry.py
@@ -164,7 +164,7 @@ class ToolRegistry:
             if not _is_tool_selected: # 未被选中，跳过
                 continue
 
-            if not skill_exposure_satisfaction: # 暴露的技能不满足工具要求
+            if policy.required_allowed_builtin_skill_ids and not skill_exposure_satisfaction: # 暴露的技能不满足工具要求
                 continue
 
             # CONTEXTUAL 工具必须靠 explicitly_exposed 显式启用 或 加载了要求的 Skill

--- a/services/wisepen-chat-service/src/chat/container.py
+++ b/services/wisepen-chat-service/src/chat/container.py
@@ -17,6 +17,7 @@ from chat.core.providers import (
     OssFileLoader,
     IflytekSpeechProvider,
 )
+from chat.core.providers.agent_assets import AgentOssFileLoader
 from chat.application.llm_provider_resolver import LLMProviderResolver
 from chat.application.token_counter import TokenCounter
 from chat.core.persistence import (
@@ -36,6 +37,9 @@ from chat.application.chat_turn_coordinator import ChatTurnCoordinator
 from chat.application.chat_turn_stream_manager import ChatTurnStreamManager
 from chat.application.agents import (
     DefaultAgentResolver,
+    AgentAssetLoader,
+    CompositeAgentResolver,
+    RemoteAgentResolver,
 )
 from chat.application.tools.skill_tools.utils.skill_matcher import DefaultSkillMatcher
 from chat.application.tools.skill_tools import LoadSkillAssetTool
@@ -170,6 +174,27 @@ class Container(containers.DeclarativeContainer):
         cache_ttl_seconds=settings.OSS_CACHE_TTL_SECONDS,
         gc_interval_seconds=settings.OSS_CACHE_GC_INTERVAL_SECONDS,
     )
+    agent_oss_file_loader = providers.Singleton(
+        AgentOssFileLoader,
+        file_storage_client=file_storage_client,
+        cache_dir=settings.AGENT_OSS_CACHE_DIR,
+        cache_ttl_seconds=settings.AGENT_OSS_CACHE_TTL_SECONDS,
+        gc_interval_seconds=settings.AGENT_OSS_CACHE_GC_INTERVAL_SECONDS,
+    )
+    agent_asset_loader = providers.Singleton(
+        AgentAssetLoader,
+        file_loader=agent_oss_file_loader,
+    )
+    default_agent_resolver = providers.Singleton(DefaultAgentResolver)
+    remote_agent_resolver = providers.Singleton(
+        RemoteAgentResolver,
+        ai_asset_client=ai_asset_client,
+    )
+    agent_resolver = providers.Singleton(
+        CompositeAgentResolver,
+        primary=remote_agent_resolver,
+        fallback=default_agent_resolver,
+    )
 
     # Skill 子系统：
     # - SkillRepository 从 Java ai-asset 读取 Skill
@@ -178,7 +203,6 @@ class Container(containers.DeclarativeContainer):
         DefaultSkillMatcher,
         ai_asset_client=ai_asset_client,
     )
-    agent_resolver = providers.Singleton(DefaultAgentResolver)
     kafka_producer = providers.Singleton(
         KafkaProducerClient,
         bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS,

--- a/services/wisepen-chat-service/src/chat/container.py
+++ b/services/wisepen-chat-service/src/chat/container.py
@@ -204,6 +204,7 @@ class Container(containers.DeclarativeContainer):
         cache_ttl_seconds=settings.OSS_CACHE_TTL_SECONDS,
         gc_interval_seconds=settings.OSS_CACHE_GC_INTERVAL_SECONDS,
     )
+    # 预留：Agent 资产尚未接入 Chat，保留独立加载器与磁盘缓存注册。
     agent_oss_file_loader = providers.Singleton(
         AgentOssFileLoader,
         file_storage_client=file_storage_client,

--- a/services/wisepen-chat-service/src/chat/core/config/app_settings.py
+++ b/services/wisepen-chat-service/src/chat/core/config/app_settings.py
@@ -132,6 +132,13 @@ class AppSettings(BaseModel):
     # GC 扫描周期（秒）
     OSS_CACHE_GC_INTERVAL_SECONDS: int = 30 * 60
 
+    # Agent 资产本地磁盘缓存（与 Skill 资产隔离）
+    AGENT_OSS_CACHE_DIR: str = "/var/agent_oss_cache"
+    # 缓存文件 TTL：mtime 距今超过该秒数 → GC 清理（默认 6 小时）
+    AGENT_OSS_CACHE_TTL_SECONDS: int = 6 * 3600
+    # GC 扫描周期（秒）
+    AGENT_OSS_CACHE_GC_INTERVAL_SECONDS: int = 30 * 60
+
 
 def _run_async(coro):
     """在新线程的独立事件循环中执行协程，兼容 uvicorn 启动时已有运行中事件循环的场景。"""

--- a/services/wisepen-chat-service/src/chat/core/config/app_settings.py
+++ b/services/wisepen-chat-service/src/chat/core/config/app_settings.py
@@ -154,7 +154,7 @@ class AppSettings(BaseModel):
     # GC 扫描周期（秒）
     OSS_CACHE_GC_INTERVAL_SECONDS: int = 30 * 60
 
-    # Agent 资产本地磁盘缓存（与 Skill 资产隔离）
+    # 预留：Agent 资产本地磁盘缓存（与 Skill 资产隔离，尚未进入 Chat 使用链路）
     AGENT_OSS_CACHE_DIR: str = "/var/agent_oss_cache"
     # 缓存文件 TTL：mtime 距今超过该秒数 → GC 清理（默认 6 小时）
     AGENT_OSS_CACHE_TTL_SECONDS: int = 6 * 3600

--- a/services/wisepen-chat-service/src/chat/core/providers/agent_assets/__init__.py
+++ b/services/wisepen-chat-service/src/chat/core/providers/agent_assets/__init__.py
@@ -1,0 +1,3 @@
+from .oss_loader import AgentOssFileLoader
+
+__all__ = ["AgentOssFileLoader"]

--- a/services/wisepen-chat-service/src/chat/core/providers/agent_assets/oss_loader.py
+++ b/services/wisepen-chat-service/src/chat/core/providers/agent_assets/oss_loader.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+import httpx
+
+from chat.service_client.file_storage_service_client import FileStorageClient
+from common.logger import error, info, warn
+
+from chat.domain.interfaces.file_loader import FileLoader
+
+
+class AgentOssFileLoader(FileLoader):
+    """
+    经 wisepen-file-storage-service 颁发的预签名 URL 从 OSS 拉取 Agent Object
+    把 Object 落在 Agent 专属进程本地磁盘缓存里，一段时间未使用即被 GC 清理
+    """
+
+    def __init__(
+        self,
+        file_storage_client: FileStorageClient,
+        *,
+        cache_dir: Path,
+        download_duration_seconds: int = 900,
+        http_timeout: float = 10.0,
+        cache_ttl_seconds: int = 6 * 3600,
+        gc_interval_seconds: int = 30 * 60,
+    ) -> None:
+        self._fsc = file_storage_client
+        self._duration = int(download_duration_seconds)
+        self._cache_dir = Path(cache_dir).resolve()
+        self._cache_ttl = float(cache_ttl_seconds)
+        self._gc_interval = float(gc_interval_seconds)
+
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._http = httpx.AsyncClient(timeout=httpx.Timeout(http_timeout))
+        self._fetch_locks: Dict[str, asyncio.Lock] = {}
+        self._gc_task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        if self._gc_task is None or self._gc_task.done():
+            self._gc_task = asyncio.create_task(self._gc_loop(), name="agent-asset-cache-gc")
+            info(
+                "agent asset cache gc started.",
+                cache_dir=str(self._cache_dir),
+                ttl_seconds=int(self._cache_ttl),
+                interval_seconds=int(self._gc_interval),
+            )
+
+    async def stop(self) -> None:
+        if self._gc_task is not None:
+            self._gc_task.cancel()
+            try:
+                await self._gc_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._gc_task = None
+        await self._http.aclose()
+
+
+    async def load_by_object_key(self, object_key: str) -> bytes:
+        if not object_key:
+            raise ValueError("object_key 不能为空")
+
+        # 计算缓存文件路径 (SHA1，避免 object_key 里有 / 导致目录嵌套)
+        digest = hashlib.sha1(object_key.encode("utf-8")).hexdigest()
+        cache_path = self._cache_dir / f"{digest}.object"
+
+        # 尝试读取缓存文件
+        hit = self._read_if_fresh(cache_path)
+        if hit is not None:
+            return hit
+
+        # 加锁，并发同 key 只下载一次
+        lock = self._fetch_locks.setdefault(object_key, asyncio.Lock())
+        async with lock:
+            # 双检，防止在等待锁的时候别的协程下载好了缓存
+            hit = self._read_if_fresh(cache_path)
+            if hit is not None:
+                return hit
+            # 下载并写缓存
+            content = await self._download(object_key)
+            self._atomic_write(cache_path, content)
+            return content
+
+    # ---------- 内部实现 ----------
+
+    def _read_if_fresh(self, cache_path: Path) -> Optional[bytes]:
+        if not cache_path.is_file():
+            return None
+        try:
+            # 每次读取缓存时，更新文件的修改时间 mtime
+            os.utime(cache_path, None)
+        except OSError:
+            pass
+        try:
+            # 按字节读，资产可能是 .py/.md 文本，也可能是 .png/.pdf/.wasm 等二进制
+            return cache_path.read_bytes()
+        except OSError as e:
+            warn("agent asset cache read failed.", cache_path=str(cache_path), exc=e)
+            return None
+
+    def _atomic_write(self, cache_path: Path, content: bytes) -> None:
+        tmp = cache_path.with_name(cache_path.name + ".tmp")
+        try:
+            tmp.write_bytes(content)
+            os.replace(tmp, cache_path)
+        finally:
+            if tmp.exists():
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
+
+    async def _download(self, object_key: str) -> bytes:
+        # 先通过 FileStorageClient 申请一个预签名 URL，然后用 URL 下载
+        url = await self._fsc.get_download_url(
+            object_key=object_key,
+            duration_seconds=self._duration,
+        )
+        try:
+            resp = await self._http.get(url)
+            resp.raise_for_status()
+        except httpx.HTTPError as e:
+            error("agent asset download failed.", object_key=object_key, exc=e)
+            raise
+        content = resp.content
+        info("agent asset cached.", object_key=object_key, bytes=len(content))
+        return content
+
+    async def _gc_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._gc_interval)
+                cutoff = time.time() - self._cache_ttl
+                removed = 0
+                if not self._cache_dir.is_dir():
+                    return
+                for p in self._cache_dir.iterdir():
+                    if not p.is_file():
+                        continue
+                    try:
+                        if p.stat().st_mtime < cutoff:
+                            p.unlink(missing_ok=True)
+                            removed += 1
+                    except OSError as e:
+                        warn("agent asset cache gc failed.", path=str(p), exc=e)
+                if removed:
+                    info("agent asset cache gc finished.", removed=removed, ttl_seconds=int(self._cache_ttl))
+        except asyncio.CancelledError:
+            raise

--- a/services/wisepen-chat-service/src/chat/core/providers/agent_assets/oss_loader.py
+++ b/services/wisepen-chat-service/src/chat/core/providers/agent_assets/oss_loader.py
@@ -15,6 +15,7 @@ from common.logger import error, info, warn
 from chat.domain.interfaces.file_loader import FileLoader
 
 
+# 预留：Agent 资产尚未接入 Chat，先保留独立 OSS 下载与磁盘缓存实现。
 class AgentOssFileLoader(FileLoader):
     """
     经 wisepen-file-storage-service 颁发的预签名 URL 从 OSS 拉取 Agent Object

--- a/services/wisepen-chat-service/src/chat/domain/entities/suspended_chat.py
+++ b/services/wisepen-chat-service/src/chat/domain/entities/suspended_chat.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from chat.domain.entities import ChatMessage
     from chat.domain.repositories.model_repo import ModelRequestInfo
 
+
 @dataclass
 class SuspendedTurnContext:
     model_info: ModelRequestInfo
@@ -30,6 +31,13 @@ class SuspendedTurnContext:
     turn_suspension: TurnSuspension
 
 
+# 运行时用 Any，避免 Pydantic 解析 SuspendedTurnContext 内的 TYPE_CHECKING 前向引用。
+if TYPE_CHECKING:
+    SuspendedContextField = SuspendedTurnContext
+else:
+    SuspendedContextField = Any
+
+
 def _encode_context(value: SuspendedTurnContext) -> str:
     return base64.b64encode(
         pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
@@ -40,7 +48,7 @@ class SuspendedChat(Document):
     """未完成 Chat Turn 的临时恢复缓存"""
     session_id: str
     user_id: str
-    context: SuspendedTurnContext
+    context: SuspendedContextField
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 

--- a/services/wisepen-chat-service/src/chat/main.py
+++ b/services/wisepen-chat-service/src/chat/main.py
@@ -78,6 +78,12 @@ async def lifespan(app: FastAPI):
             await oss_file_loader.start()
         except Exception as e:
             error("file loader start failed.", exc=e)
+    agent_oss_file_loader = container.agent_oss_file_loader()
+    if getattr(agent_oss_file_loader, "start", None) is not None:
+        try:
+            await agent_oss_file_loader.start()
+        except Exception as e:
+            error("agent asset loader start failed.", exc=e)
 
     info("service ready.", service=bootstrap_settings.SERVICE_NAME, port=bootstrap_settings.SERVICE_PORT)
 
@@ -98,6 +104,12 @@ async def lifespan(app: FastAPI):
             await oss_file_loader.stop()
         except Exception as e:
             error("file loader stop failed.", exc=e)
+    agent_oss_file_loader = container.agent_oss_file_loader()
+    if getattr(agent_oss_file_loader, "stop", None) is not None:
+        try:
+            await agent_oss_file_loader.stop()
+        except Exception as e:
+            error("agent asset loader stop failed.", exc=e)
     try:
         await container.rpc_client().aclose()
     except Exception as e:

--- a/services/wisepen-chat-service/src/chat/main.py
+++ b/services/wisepen-chat-service/src/chat/main.py
@@ -79,6 +79,7 @@ async def lifespan(app: FastAPI):
             await oss_file_loader.start()
         except Exception as e:
             error("file loader start failed.", exc=e)
+    # 预留：Agent 资产尚未进入 Chat，先保留加载器生命周期。
     agent_oss_file_loader = container.agent_oss_file_loader()
     if getattr(agent_oss_file_loader, "start", None) is not None:
         try:
@@ -105,6 +106,7 @@ async def lifespan(app: FastAPI):
             await oss_file_loader.stop()
         except Exception as e:
             error("file loader stop failed.", exc=e)
+    # 预留：Agent 资产尚未进入 Chat，先保留加载器生命周期。
     agent_oss_file_loader = container.agent_oss_file_loader()
     if getattr(agent_oss_file_loader, "stop", None) is not None:
         try:

--- a/services/wisepen-chat-service/src/chat/service_client/ai_asset_service_client.py
+++ b/services/wisepen-chat-service/src/chat/service_client/ai_asset_service_client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, List, Mapping, Optional, Set
+from typing import Any, List, Mapping, Optional, Set, TYPE_CHECKING
 
 import httpx
 
@@ -9,9 +9,13 @@ from chat.domain.entities.skill import SkillInfo, SkillAssetUploadInitResult, Sk
 from common.core.exceptions import RpcError
 from common.http.rpc_client import RpcClient
 
+if TYPE_CHECKING:
+    from chat.application.agents.models import Agent
+
 
 _DEFAULT_SERVICE_NAME = "wisepen-ai-asset-service"
 _GET_SKILL_PATH = "/internal/skill/getSkillByResourceId"
+_GET_AGENT_PATH = "/internal/agent/getAgentByResourceId"
 _LIST_PUBLISHED_SKILLS_META_PATH = "/internal/skill/listPublishedSkillsMetaByResourceIds"
 _CREATE_SKILL_PATH = "/skill/createSkill"
 _CHANGE_SKILL_INFO_PATH = "/skill/changeSkillInfo"
@@ -41,6 +45,31 @@ class AIAssetClient:
 
     async def get_published_skill(self, skill_id: str) -> Optional[Skill]:
         return await self._get_skill_by_resource_id(skill_id)
+
+    async def get_agent_with_version(self, agent_id: str, agent_version: int) -> Optional["Agent"]:
+        return await self._get_agent_by_resource_id(agent_id, agent_version)
+
+    async def get_published_agent(self, agent_id: str) -> Optional["Agent"]:
+        return await self._get_agent_by_resource_id(agent_id)
+
+    async def _get_agent_by_resource_id(self, resource_id: str, agent_version: int = None) -> Optional["Agent"]:
+        from chat.application.agents.models import Agent
+
+        try:
+            data = await self._rpc.get(
+                self._service_name,
+                _GET_AGENT_PATH,
+                params={"resourceId": resource_id, "agentVersion": agent_version},
+            )
+        except RpcError as e:
+            raise e
+        if not isinstance(data, dict):
+            raise RpcError(
+                service_name=self._service_name,
+                path=_GET_AGENT_PATH,
+                msg=f"unexpected data payload: {data!r}",
+            )
+        return Agent.from_response(data)
 
     async def _get_skill_by_resource_id(self, resource_id: str, skill_version: int = None) -> Optional[Skill]:
         try:


### PR DESCRIPTION
 - 从 java 拉取 agent resources
 - 将 agent resources 中的工具/技能配置、系统提示词注入智能体会话
 - 预留 agent adsets 的拉取工具（支持拉取，但当前会话中暂未使用）
 - 集成修复：循环依赖、policy.required allowed builtin skill ids 为空导致的智能体工具清空等问题